### PR TITLE
feat: Add Deepseek provider integration and configuration support

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1,22 +1,66 @@
-# Configuration Reference
-	## <no value>
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	## <no value>
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	## <no value>
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	## <no value>
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	## <no value>
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	
+## Configurations
+
+### General settings
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| APPLICATION_NAME | `inference-gateway` | The name of the application |
+| ENVIRONMENT | `production` | The environment |
+| ENABLE_TELEMETRY | `false` | Enable telemetry |
+| ENABLE_AUTH | `false` | Enable authentication |
+
+
+### OpenID Connect
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| OIDC_ISSUER_URL | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL |
+| OIDC_CLIENT_ID | `inference-gateway-client` | OIDC client ID |
+| OIDC_CLIENT_SECRET | `""` | OIDC client secret |
+
+
+### Server settings
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| SERVER_HOST | `0.0.0.0` | Server host |
+| SERVER_PORT | `8080` | Server port |
+| SERVER_READ_TIMEOUT | `30s` | Read timeout |
+| SERVER_WRITE_TIMEOUT | `30s` | Write timeout |
+| SERVER_IDLE_TIMEOUT | `120s` | Idle timeout |
+| SERVER_TLS_CERT_PATH | `""` | TLS certificate path |
+| SERVER_TLS_KEY_PATH | `""` | TLS key path |
+
+
+### Client settings
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| CLIENT_TIMEOUT | `30s` | Client timeout |
+| CLIENT_MAX_IDLE_CONNS | `20` | Maximum idle connections |
+| CLIENT_MAX_IDLE_CONNS_PER_HOST | `20` | Maximum idle connections per host |
+| CLIENT_IDLE_CONN_TIMEOUT | `30s` | Idle connection timeout |
+| CLIENT_TLS_MIN_VERSION | `TLS12` | Minimum TLS version |
+
+
+### Providers
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| DEEPSEEK_API_URL | `https://api.deepseek.com/v1` | Deepseek API URL |
+| DEEPSEEK_API_KEY | `""` | Deepseek API Key |
+| ANTHROPIC_API_URL | `https://api.anthropic.com` | Anthropic API URL |
+| ANTHROPIC_API_KEY | `""` | Anthropic API Key |
+| CLOUDFLARE_API_URL | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}` | Cloudflare API URL |
+| CLOUDFLARE_API_KEY | `""` | Cloudflare API Key |
+| COHERE_API_URL | `https://api.cohere.com` | Cohere API URL |
+| COHERE_API_KEY | `""` | Cohere API Key |
+| GOOGLE_API_URL | `https://generativelanguage.googleapis.com` | Google API URL |
+| GOOGLE_API_KEY | `""` | Google API Key |
+| GROQ_API_URL | `https://api.groq.com` | Groq API URL |
+| GROQ_API_KEY | `""` | Groq API Key |
+| OLLAMA_API_URL | `http://ollama:8080` | Ollama API URL |
+| OLLAMA_API_KEY | `""` | Ollama API Key |
+| OPENAI_API_URL | `https://api.openai.com` | OpenAI API URL |
+| OPENAI_API_KEY | `""` | OpenAI API Key |
+

--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ graph TD
     P[Proxy Gateway] --> F[Google]
     P[Proxy Gateway] --> G[Cloudflare]
     P[Proxy Gateway] --> H[Cohere]
-    P[Proxy Gateway] --> H[Anthropic]
+    P[Proxy Gateway] --> I[Anthropic]
+    P[Proxy Gateway] --> K[Deepseek]
 ```
 
 Client is sending:
@@ -110,6 +111,7 @@ Client receives:
 - [Cloudflare](https://www.cloudflare.com/)
 - [Cohere](https://docs.cohere.com/docs/the-cohere-platform)
 - [Anthropic](https://docs.anthropic.com/en/api/getting-started)
+- [Deepseek](https://api-docs.deepseek.com/)
 
 ## Configuration
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -38,6 +38,16 @@ func TestLoad(t *testing.T) {
 					IdleTimeout:  120 * time.Second,
 				},
 				Providers: map[string]*providers.Config{
+					providers.DeepseekID: {
+						ID:       providers.DeepseekID,
+						Name:     providers.DeepseekDisplayName,
+						URL:      providers.DeepseekDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.DeepseekListEndpoint,
+							Generate: providers.DeepseekGenerateEndpoint,
+						},
+					},
 					providers.AnthropicID: {
 						ID:       providers.AnthropicID,
 						Name:     providers.AnthropicDisplayName,
@@ -224,6 +234,16 @@ func TestLoad(t *testing.T) {
 							Generate: providers.AnthropicGenerateEndpoint,
 						},
 					},
+					providers.DeepseekID: {
+						ID:       providers.DeepseekID,
+						Name:     providers.DeepseekDisplayName,
+						URL:      providers.DeepseekDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.DeepseekListEndpoint,
+							Generate: providers.DeepseekGenerateEndpoint,
+						},
+					},
 				},
 			},
 		},
@@ -344,6 +364,16 @@ func TestLoad(t *testing.T) {
 						Endpoints: providers.Endpoints{
 							List:     providers.AnthropicListEndpoint,
 							Generate: providers.AnthropicGenerateEndpoint,
+						},
+					},
+					providers.DeepseekID: {
+						ID:       providers.DeepseekID,
+						Name:     providers.DeepseekDisplayName,
+						URL:      providers.DeepseekDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.DeepseekListEndpoint,
+							Generate: providers.DeepseekGenerateEndpoint,
 						},
 					},
 				},

--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -23,6 +23,8 @@ CLIENT_MAX_IDLE_CONNS_PER_HOST=20
 CLIENT_IDLE_CONN_TIMEOUT=30s
 CLIENT_TLS_MIN_VERSION=TLS12
 # Providers
+DEEPSEEK_API_URL=https://api.deepseek.com/v1
+DEEPSEEK_API_KEY=
 ANTHROPIC_API_URL=https://api.anthropic.com
 ANTHROPIC_API_KEY=
 CLOUDFLARE_API_URL=https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}

--- a/examples/kubernetes/agent/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/agent/inference-gateway/configmap.yaml
@@ -29,6 +29,7 @@ data:
   CLIENT_IDLE_CONN_TIMEOUT: "30s"
   CLIENT_TLS_MIN_VERSION: "TLS12"
   # Providers
+  DEEPSEEK_API_URL: "https://api.deepseek.com/v1"
   ANTHROPIC_API_URL: "https://api.anthropic.com"
   CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
   COHERE_API_URL: "https://api.cohere.com"

--- a/examples/kubernetes/agent/inference-gateway/secret.yaml
+++ b/examples/kubernetes/agent/inference-gateway/secret.yaml
@@ -11,6 +11,7 @@ stringData:
   OIDC_CLIENT_ID: "inference-gateway-client"
   OIDC_CLIENT_SECRET: ""
   # Providers
+  DEEPSEEK_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   CLOUDFLARE_API_KEY: ""
   COHERE_API_KEY: ""

--- a/examples/kubernetes/authentication/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/authentication/inference-gateway/configmap.yaml
@@ -29,6 +29,7 @@ data:
   CLIENT_IDLE_CONN_TIMEOUT: "30s"
   CLIENT_TLS_MIN_VERSION: "TLS12"
   # Providers
+  DEEPSEEK_API_URL: "https://api.deepseek.com/v1"
   ANTHROPIC_API_URL: "https://api.anthropic.com"
   CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
   COHERE_API_URL: "https://api.cohere.com"

--- a/examples/kubernetes/authentication/inference-gateway/secret.yaml
+++ b/examples/kubernetes/authentication/inference-gateway/secret.yaml
@@ -11,6 +11,7 @@ stringData:
   OIDC_CLIENT_ID: "inference-gateway-client"
   OIDC_CLIENT_SECRET: ""
   # Providers
+  DEEPSEEK_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   CLOUDFLARE_API_KEY: ""
   COHERE_API_KEY: ""

--- a/examples/kubernetes/basic/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/basic/inference-gateway/configmap.yaml
@@ -29,6 +29,7 @@ data:
   CLIENT_IDLE_CONN_TIMEOUT: "30s"
   CLIENT_TLS_MIN_VERSION: "TLS12"
   # Providers
+  DEEPSEEK_API_URL: "https://api.deepseek.com/v1"
   ANTHROPIC_API_URL: "https://api.anthropic.com"
   CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
   COHERE_API_URL: "https://api.cohere.com"

--- a/examples/kubernetes/basic/inference-gateway/secret.yaml
+++ b/examples/kubernetes/basic/inference-gateway/secret.yaml
@@ -11,6 +11,7 @@ stringData:
   OIDC_CLIENT_ID: "inference-gateway-client"
   OIDC_CLIENT_SECRET: ""
   # Providers
+  DEEPSEEK_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   CLOUDFLARE_API_KEY: ""
   COHERE_API_KEY: ""

--- a/examples/kubernetes/hybrid/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/hybrid/inference-gateway/configmap.yaml
@@ -29,6 +29,7 @@ data:
   CLIENT_IDLE_CONN_TIMEOUT: "30s"
   CLIENT_TLS_MIN_VERSION: "TLS12"
   # Providers
+  DEEPSEEK_API_URL: "https://api.deepseek.com/v1"
   ANTHROPIC_API_URL: "https://api.anthropic.com"
   CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
   COHERE_API_URL: "https://api.cohere.com"

--- a/examples/kubernetes/hybrid/inference-gateway/secret.yaml
+++ b/examples/kubernetes/hybrid/inference-gateway/secret.yaml
@@ -11,6 +11,7 @@ stringData:
   OIDC_CLIENT_ID: "inference-gateway-client"
   OIDC_CLIENT_SECRET: ""
   # Providers
+  DEEPSEEK_API_KEY: ""
   ANTHROPIC_API_KEY: ""
   CLOUDFLARE_API_KEY: ""
   COHERE_API_KEY: ""

--- a/internal/mdgen/mdgen.go
+++ b/internal/mdgen/mdgen.go
@@ -17,19 +17,19 @@ func GenerateConfigurationsMD(filePath string, oas string) error {
 		return fmt.Errorf("failed to read OpenAPI spec: %w", err)
 	}
 
-	const mdTemplate = `# Configuration Reference
-	
-	{{- range $section := .Sections }}
-	## {{ .Title }}
-	
-	| Environment Variable | Default Value | Description |
-	|---------------------|---------------|-------------|
-	{{- range .Settings }}
-	| {{ .Env }} | ` + "`{{ if .Default }}{{ .Default }}{{ else }}\"\"{{ end }}`" + ` | {{ .Description }} |
-	{{- end }}
-	
-	{{- end }}
-	`
+	const mdTemplate = `## Configurations
+{{- range $index, $sectionMap := .Sections }}
+{{ range $name, $section := $sectionMap }}
+### {{ $section.Title }}
+
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+{{- range $setting := $section.Settings }}
+| {{ $setting.Env }} | ` + "`{{ if $setting.Default }}{{ $setting.Default }}{{ else }}\"\"{{ end }}`" + ` | {{ $setting.Description }} |
+{{- end }}
+{{ end }}
+{{- end }}
+`
 
 	// Create template with functions
 	funcMap := template.FuncMap{

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -323,6 +323,7 @@ components:
         - cloudflare
         - cohere
         - anthropic
+        - deepseek
     ProviderSpecificResponse:
       type: object
       description: |
@@ -573,6 +574,16 @@ components:
           - providers:
               title: "Providers"
               settings:
+                - name: deepseek_api_url
+                  env: "DEEPSEEK_API_URL"
+                  type: string
+                  default: "https://api.deepseek.com/v1"
+                  description: "Deepseek API URL"
+                - name: deepseek_api_key
+                  env: "DEEPSEEK_API_KEY"
+                  type: string
+                  description: "Deepseek API Key"
+                  secret: true
                 - name: anthropic_api_url
                   env: "ANTHROPIC_API_URL"
                   type: string
@@ -1209,3 +1220,34 @@ components:
                                 type: string
                               content:
                                 type: string
+        deepseek:
+          id: "deepseek"
+          url: "http://deepseek:8080"
+          auth_type: "none"
+          endpoints:
+            list:
+              endpoint: "/api/tags"
+              method: "GET"
+              schema:
+                response:
+                  type: object
+                  properties:
+                    models:
+                      type: array
+                      items:
+                        $ref: "#/components/schemas/Model"
+            generate:
+              endpoint: "/api/generate"
+              method: "POST"
+              schema:
+                request:
+                  type: object
+                  properties:
+                    model:
+                      type: string
+                    messages:
+                      type: array
+                      items:
+                        $ref: "#/components/schemas/Message"
+                response:
+                  $ref: "#/components/schemas/GenerateResponse"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1222,11 +1222,11 @@ components:
                                 type: string
         deepseek:
           id: "deepseek"
-          url: "http://deepseek:8080"
+          url: "https://api.deepseek.com/v1"
           auth_type: "none"
           endpoints:
             list:
-              endpoint: "/api/tags"
+              endpoint: "/v1/models"
               method: "GET"
               schema:
                 response:
@@ -1237,7 +1237,7 @@ components:
                       items:
                         $ref: "#/components/schemas/Model"
             generate:
-              endpoint: "/api/generate"
+              endpoint: "/v1/chat/completions"
               method: "POST"
               schema:
                 request:

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -19,6 +19,7 @@ const (
 
 // The default base URLs of each provider
 const (
+	DeepseekDefaultBaseURL   = "https://api.deepseek.com"
 	AnthropicDefaultBaseURL  = "https://api.anthropic.com"
 	CloudflareDefaultBaseURL = "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
 	CohereDefaultBaseURL     = "https://api.cohere.com"
@@ -30,6 +31,7 @@ const (
 
 // The ID's of each provider
 const (
+	DeepseekID   = "deepseek"
 	AnthropicID  = "anthropic"
 	CloudflareID = "cloudflare"
 	CohereID     = "cohere"
@@ -41,6 +43,7 @@ const (
 
 // Display names for providers
 const (
+	DeepseekDisplayName   = "Deepseek"
 	AnthropicDisplayName  = "Anthropic"
 	CloudflareDisplayName = "Cloudflare"
 	CohereDisplayName     = "Cohere"

--- a/providers/deepseek.go
+++ b/providers/deepseek.go
@@ -1,0 +1,61 @@
+package providers
+
+import (
+	"context"
+
+	l "github.com/inference-gateway/inference-gateway/logger"
+)
+
+// DeepseekProvider implements the Provider interface for deepseek.
+type DeepseekProvider struct {
+	ProviderImpl
+}
+
+// NewDeepseekProvider creates a new instance of deepseek provider.
+func NewDeepseekProvider(cfg *Config, logger l.Logger, client Client) Provider {
+	return &DeepseekProvider{
+		ProviderImpl: ProviderImpl{
+			id:           cfg.ID,
+			name:         "Deepseek",
+			url:          cfg.URL,
+			token:        cfg.Token,
+			authType:     cfg.AuthType,
+			extraHeaders: cfg.ExtraHeaders,
+			endpoints:    cfg.Endpoints,
+			client:       client,
+			logger:       logger,
+		},
+	}
+}
+
+// GenerateTokens returns a dummy response concatenating all message contents.
+func (p *DeepseekProvider) GenerateTokens(ctx context.Context, model string, messages []Message) (GenerateResponse, error) {
+	content := ""
+	for _, m := range messages {
+		content += m.Content + " "
+	}
+	resp := GenerateResponse{
+		Provider: p.GetID(),
+		Response: ResponseTokens{
+			Content: content,
+			Model:   model,
+			Role:    "assistant",
+		},
+	}
+	return resp, nil
+}
+
+// StreamTokens starts a streaming response by sending a single dummy token.
+func (p *DeepseekProvider) StreamTokens(ctx context.Context, model string, messages []Message) (<-chan GenerateResponse, error) {
+	ch := make(chan GenerateResponse)
+	go func() {
+		defer close(ch)
+		resp, err := p.GenerateTokens(ctx, model, messages)
+		if err != nil {
+			p.logger.Error("failed to generate tokens", err)
+			return
+		}
+		ch <- resp
+	}()
+	return ch, nil
+}

--- a/providers/management.go
+++ b/providers/management.go
@@ -193,6 +193,13 @@ func (p *ProviderImpl) ListModels(ctx context.Context) (ListModelsResponse, erro
 			return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 		return response.Transform(), nil
+	case DeepseekID:
+		var response ListModelsResponseDeepseek
+		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			p.logger.Error("failed to decode response", err, "provider", p.GetName())
+			return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)
+		}
+		return response.Transform(), nil
 	default:
 		p.logger.Error("provider not found", nil, "provider", p.GetName())
 		return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)

--- a/providers/management_test.go
+++ b/providers/management_test.go
@@ -43,7 +43,7 @@ func TestParseSSEDebug(t *testing.T) {
 }
 
 func TestParseSSEWithEmbeddedMessageStart(t *testing.T) {
-	input := `data: {"json": "{\"id\":\"d8c1879d-6c59-4eb7-8209-b184f81bcf15\",\"type\":\"message-start\",\"delta\":{\"message\":{\"role\":\"assistant\",\"content\":[],\"tool_plan\":\"\",\"tool_calls\":[],\"citations\":[]}}}"}`
+	input := `data: {"json": "{\"id\":\"***\",\"type\":\"message-start\",\"delta\":{\"message\":{\"role\":\"assistant\",\"content\":[],\"tool_plan\":\"\",\"tool_calls\":[],\"citations\":[]}}}"}`
 
 	event, err := parseSSEvents([]byte(input))
 	if err != nil {

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -28,6 +28,10 @@ const (
 	// Anthropic endpoints
 	AnthropicListEndpoint     = "/v1/models"
 	AnthropicGenerateEndpoint = "/v1/messages"
+
+	// Deepseek endpoints
+	DeepseekListEndpoint     = "/v1/models"
+	DeepseekGenerateEndpoint = "/v1/chat/completions"
 )
 
 // Endpoints exposed by each provider
@@ -49,6 +53,16 @@ type Config struct {
 
 // The registry of all providers
 var Registry = map[string]Config{
+	DeepseekID: {
+		ID:       DeepseekID,
+		Name:     DeepseekDisplayName,
+		URL:      DeepseekDefaultBaseURL,
+		AuthType: AuthTypeBearer,
+		Endpoints: Endpoints{
+			List:     DeepseekListEndpoint,
+			Generate: DeepseekGenerateEndpoint,
+		},
+	},
 	AnthropicID: {
 		ID:       AnthropicID,
 		Name:     AnthropicDisplayName,


### PR DESCRIPTION
### Summary

Adding Deepseek as a provider, so we can also use it directly instead of through groq cloud.

Placing it on hold - due to the recent news about the data breach.

Safest way for now would be to either run it locally or using it via groq cloud.