### PR TITLE
feat: Add HuggingFace API support with configuration and secrets

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -54,4 +54,6 @@
 | OLLAMA_API_KEY | `""` | Ollama API Key |
 | OPENAI_API_URL | `https://api.openai.com` | OpenAI API URL |
 | OPENAI_API_KEY | `""` | OpenAI API Key |
+| HUGGINGFACE_API_URL | `https://huggingface.co` | HuggingFace API URL |
+| HUGGINGFACE_API_KEY | `""` | HuggingFace API Key |
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -101,6 +101,16 @@ func TestLoad(t *testing.T) {
 							Generate: providers.OpenAIGenerateEndpoint,
 						},
 					},
+					providers.HuggingfaceID: {
+						ID:       providers.HuggingfaceID,
+						Name:     providers.HuggingfaceDisplayName,
+						URL:      providers.HuggingfaceDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.HuggingfaceListEndpoint,
+							Generate: providers.HuggingfaceGenerateEndpoint,
+						},
+					},
 				},
 			},
 		},
@@ -200,6 +210,16 @@ func TestLoad(t *testing.T) {
 						Endpoints: providers.Endpoints{
 							List:     providers.AnthropicListEndpoint,
 							Generate: providers.AnthropicGenerateEndpoint,
+						},
+					},
+					providers.HuggingfaceID: {
+						ID:       providers.HuggingfaceID,
+						Name:     providers.HuggingfaceDisplayName,
+						URL:      providers.HuggingfaceDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.HuggingfaceListEndpoint,
+							Generate: providers.HuggingfaceGenerateEndpoint,
 						},
 					},
 				},
@@ -312,6 +332,16 @@ func TestLoad(t *testing.T) {
 						Endpoints: providers.Endpoints{
 							List:     providers.AnthropicListEndpoint,
 							Generate: providers.AnthropicGenerateEndpoint,
+						},
+					},
+					providers.HuggingfaceID: {
+						ID:       providers.HuggingfaceID,
+						Name:     providers.HuggingfaceDisplayName,
+						URL:      providers.HuggingfaceDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							List:     providers.HuggingfaceListEndpoint,
+							Generate: providers.HuggingfaceGenerateEndpoint,
 						},
 					},
 				},

--- a/examples/docker-compose/.env.example
+++ b/examples/docker-compose/.env.example
@@ -35,3 +35,5 @@ OLLAMA_API_URL=http://ollama:8080
 OLLAMA_API_KEY=
 OPENAI_API_URL=https://api.openai.com
 OPENAI_API_KEY=
+HUGGINGFACE_API_URL=https://huggingface.co
+HUGGINGFACE_API_KEY=

--- a/examples/kubernetes/agent/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/agent/inference-gateway/configmap.yaml
@@ -35,3 +35,4 @@ data:
   GROQ_API_URL: "https://api.groq.com"
   OLLAMA_API_URL: "http://ollama:8080"
   OPENAI_API_URL: "https://api.openai.com"
+  HUGGINGFACE_API_URL: "https://huggingface.co"

--- a/examples/kubernetes/agent/inference-gateway/secret.yaml
+++ b/examples/kubernetes/agent/inference-gateway/secret.yaml
@@ -17,3 +17,4 @@ stringData:
   GROQ_API_KEY: ""
   OLLAMA_API_KEY: ""
   OPENAI_API_KEY: ""
+  HUGGINGFACE_API_KEY: ""

--- a/examples/kubernetes/authentication/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/authentication/inference-gateway/configmap.yaml
@@ -35,3 +35,4 @@ data:
   GROQ_API_URL: "https://api.groq.com"
   OLLAMA_API_URL: "http://ollama:8080"
   OPENAI_API_URL: "https://api.openai.com"
+  HUGGINGFACE_API_URL: "https://huggingface.co"

--- a/examples/kubernetes/authentication/inference-gateway/secret.yaml
+++ b/examples/kubernetes/authentication/inference-gateway/secret.yaml
@@ -17,3 +17,4 @@ stringData:
   GROQ_API_KEY: ""
   OLLAMA_API_KEY: ""
   OPENAI_API_KEY: ""
+  HUGGINGFACE_API_KEY: ""

--- a/examples/kubernetes/basic/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/basic/inference-gateway/configmap.yaml
@@ -35,3 +35,4 @@ data:
   GROQ_API_URL: "https://api.groq.com"
   OLLAMA_API_URL: "http://ollama:8080"
   OPENAI_API_URL: "https://api.openai.com"
+  HUGGINGFACE_API_URL: "https://huggingface.co"

--- a/examples/kubernetes/basic/inference-gateway/secret.yaml
+++ b/examples/kubernetes/basic/inference-gateway/secret.yaml
@@ -17,3 +17,4 @@ stringData:
   GROQ_API_KEY: ""
   OLLAMA_API_KEY: ""
   OPENAI_API_KEY: ""
+  HUGGINGFACE_API_KEY: ""

--- a/examples/kubernetes/hybrid/inference-gateway/configmap.yaml
+++ b/examples/kubernetes/hybrid/inference-gateway/configmap.yaml
@@ -35,3 +35,4 @@ data:
   GROQ_API_URL: "https://api.groq.com"
   OLLAMA_API_URL: "http://ollama:8080"
   OPENAI_API_URL: "https://api.openai.com"
+  HUGGINGFACE_API_URL: "https://huggingface.co"

--- a/examples/kubernetes/hybrid/inference-gateway/secret.yaml
+++ b/examples/kubernetes/hybrid/inference-gateway/secret.yaml
@@ -17,3 +17,4 @@ stringData:
   GROQ_API_KEY: ""
   OLLAMA_API_KEY: ""
   OPENAI_API_KEY: ""
+  HUGGINGFACE_API_KEY: ""

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -287,6 +287,7 @@ components:
         - cloudflare
         - cohere
         - anthropic
+        - huggingface
     ProviderSpecificResponse:
       type: object
       description: |
@@ -582,6 +583,16 @@ components:
                   env: "OPENAI_API_KEY"
                   type: string
                   description: "OpenAI API Key"
+                  secret: true
+                - name: huggingface_api_url
+                  env: "HUGGINGFACE_API_URL"
+                  type: string
+                  default: "https://huggingface.co"
+                  description: "HuggingFace API URL"
+                - name: huggingface_api_key
+                  env: "HUGGINGFACE_API_KEY"
+                  type: string
+                  description: "HuggingFace API Key"
                   secret: true
       x-provider-configs:
         ollama:
@@ -1024,3 +1035,46 @@ components:
                                 type: string
                               content:
                                 type: string
+        huggingface:
+          id: "huggingface"
+          url: "https://api-inference.huggingface.co"
+          auth_type: "bearer"
+          endpoints:
+            list:
+              endpoint: "/models"
+              method: "GET"
+              schema:
+                response:
+                  type: object
+                  properties:
+                    models:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                          pipeline_tag:
+                            type: string
+                          likes:
+                            type: number
+            generate:
+              endpoint: "/models/{model}"
+              method: "POST"
+              schema:
+                request:
+                  type: object
+                  properties:
+                    inputs:
+                      type: string
+                    parameters:
+                      type: object
+                      additionalProperties: true
+                    options:
+                      type: object
+                      additionalProperties: true
+                response:
+                  type: object
+                  properties:
+                    generated_text:
+                      type: string

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -19,32 +19,35 @@ const (
 
 // The default base URLs of each provider
 const (
-	AnthropicDefaultBaseURL  = "https://api.anthropic.com"
-	CloudflareDefaultBaseURL = "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
-	CohereDefaultBaseURL     = "https://api.cohere.com"
-	GroqDefaultBaseURL       = "https://api.groq.com"
-	OllamaDefaultBaseURL     = "http://ollama:8080"
-	OpenaiDefaultBaseURL     = "https://api.openai.com"
+	AnthropicDefaultBaseURL   = "https://api.anthropic.com"
+	CloudflareDefaultBaseURL  = "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}"
+	CohereDefaultBaseURL      = "https://api.cohere.com"
+	GroqDefaultBaseURL        = "https://api.groq.com"
+	OllamaDefaultBaseURL      = "http://ollama:8080"
+	OpenaiDefaultBaseURL      = "https://api.openai.com"
+	HuggingfaceDefaultBaseURL = "https://api-inference.huggingface.co"
 )
 
 // The ID's of each provider
 const (
-	AnthropicID  = "anthropic"
-	CloudflareID = "cloudflare"
-	CohereID     = "cohere"
-	GroqID       = "groq"
-	OllamaID     = "ollama"
-	OpenaiID     = "openai"
+	AnthropicID   = "anthropic"
+	CloudflareID  = "cloudflare"
+	CohereID      = "cohere"
+	GroqID        = "groq"
+	OllamaID      = "ollama"
+	OpenaiID      = "openai"
+	HuggingfaceID = "huggingface"
 )
 
 // Display names for providers
 const (
-	AnthropicDisplayName  = "Anthropic"
-	CloudflareDisplayName = "Cloudflare"
-	CohereDisplayName     = "Cohere"
-	GroqDisplayName       = "Groq"
-	OllamaDisplayName     = "Ollama"
-	OpenaiDisplayName     = "Openai"
+	AnthropicDisplayName   = "Anthropic"
+	CloudflareDisplayName  = "Cloudflare"
+	CohereDisplayName      = "Cohere"
+	GroqDisplayName        = "Groq"
+	OllamaDisplayName      = "Ollama"
+	OpenaiDisplayName      = "Openai"
+	HuggingfaceDisplayName = "HuggingFace"
 )
 
 const (

--- a/providers/huggingface.go
+++ b/providers/huggingface.go
@@ -1,0 +1,74 @@
+package providers
+
+// HuggingFaceModel represents the model details returned from the HuggingFace API.
+type HuggingfaceModel struct {
+	_ID           string   `json:"_id"`
+	ID            string   `json:"id"`
+	Likes         int      `json:"likes"`
+	TrendingScore int      `json:"trending_score"`
+	Private       bool     `json:"private"`
+	Downloads     int      `json:"downloads"`
+	Tags          []string `json:"tags"`
+	PipelineTag   string   `json:"pipeline_tag"`
+	LibraryName   string   `json:"library_name"`
+	CreatedAt     string   `json:"created_at"`
+	ModelID       string   `json:"model_id"`
+}
+
+// ListModelsResponseHuggingface wraps the API response for listing models.
+type ListModelsResponseHuggingface []HuggingfaceModel
+
+// Transform converts the provider-specific response to the common ListModelsResponse.
+func (l *ListModelsResponseHuggingface) Transform() ListModelsResponse {
+	var models []Model
+	for _, m := range *l {
+		models = append(models, Model{
+			Name: m.ID,
+		})
+	}
+	return ListModelsResponse{
+		Provider: HuggingfaceID,
+		Models:   models,
+	}
+}
+
+// GenerateRequestHuggingface models the request body for generating text.
+type GenerateRequestHuggingface struct {
+	Inputs     string                 `json:"inputs"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Options    map[string]interface{} `json:"options,omitempty"`
+}
+
+// TransformHuggingface converts a generic GenerateRequest to a HuggingFace-specific request.
+// Here we use the first message's content as input.
+func (r *GenerateRequest) TransformHuggingface() GenerateRequestHuggingface {
+	input := ""
+	if len(r.Messages) > 0 {
+		input = r.Messages[0].Content
+	}
+	return GenerateRequestHuggingface{
+		Inputs:     input,
+		Parameters: map[string]interface{}{},
+		Options:    map[string]interface{}{},
+	}
+}
+
+// GenerateResponseHuggingface models the response body from the HuggingFace generate endpoint.
+type GenerateResponseHuggingface struct {
+	GeneratedText string `json:"generated_text"`
+}
+
+// Transform converts the HuggingFace-specific response to the common GenerateResponse.
+func (r *GenerateResponseHuggingface) Transform() GenerateResponse {
+	response := ResponseTokens{
+		Content: r.GeneratedText,
+		Model:   "", // Set model name if needed
+		Role:    MessageRoleAssistant,
+	}
+
+	return GenerateResponse{
+		Provider:  HuggingfaceDisplayName,
+		Response:  response,
+		EventType: EventContentDelta,
+	}
+}

--- a/providers/huggingface.go
+++ b/providers/huggingface.go
@@ -2,7 +2,7 @@ package providers
 
 // HuggingFaceModel represents the model details returned from the HuggingFace API.
 type HuggingfaceModel struct {
-	_ID           string   `json:"_id"`
+	// _ID           string   `json:"_id"`
 	ID            string   `json:"id"`
 	Likes         int      `json:"likes"`
 	TrendingScore int      `json:"trending_score"`

--- a/providers/management.go
+++ b/providers/management.go
@@ -178,7 +178,7 @@ func (p *ProviderImpl) GenerateTokens(ctx context.Context, model string, message
 	}
 
 	url := "/proxy/" + p.GetID() + baseURL.Path + p.EndpointGenerate()
-	if p.GetID() == CloudflareID {
+	if p.GetID() == CloudflareID || p.GetID() == HuggingfaceID {
 		url = strings.Replace(url, "{model}", model, 1)
 	}
 
@@ -321,6 +321,28 @@ func (p *ProviderImpl) GenerateTokens(ctx context.Context, model string, message
 			return GenerateResponse{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 		return response.Transform(), nil
+	case HuggingfaceID:
+		// Request
+		payload := genRequest.TransformHuggingface()
+		payloadBytes, err := json.Marshal(payload)
+		if err != nil {
+			p.logger.Error("failed to marshal request", err)
+			return GenerateResponse{}, fmt.Errorf("failed to marshal request: %w", err)
+		}
+
+		resp, err := fetchTokens(ctx, p.client, url, payloadBytes, p.logger)
+		if err != nil {
+			p.logger.Error("failed to make request", err)
+			return GenerateResponse{}, fmt.Errorf("failed to make request: %w", err)
+		}
+
+		// Response
+		var response GenerateResponseHuggingface
+		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			p.logger.Error("failed to decode response", err, "provider", p.GetName())
+			return GenerateResponse{}, fmt.Errorf("failed to decode response: %w", err)
+		}
+		return response.Transform(), nil
 	default:
 		p.logger.Error("unsupported provider", nil)
 		return GenerateResponse{}, fmt.Errorf("unsupported provider: %s", p.GetID())
@@ -375,6 +397,9 @@ func (p *ProviderImpl) StreamTokens(ctx context.Context, model string, messages 
 		payloadBytes, err = json.Marshal(payload)
 	case AnthropicID:
 		payload := genRequest.TransformAnthropic()
+		payloadBytes, err = json.Marshal(payload)
+	case HuggingfaceID:
+		payload := genRequest.TransformHuggingface()
 		payloadBytes, err = json.Marshal(payload)
 	default:
 		p.logger.Error("unsupported provider", nil)

--- a/providers/management.go
+++ b/providers/management.go
@@ -153,6 +153,13 @@ func (p *ProviderImpl) ListModels(ctx context.Context) (ListModelsResponse, erro
 			return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)
 		}
 		return response.Transform(), nil
+	case HuggingfaceID:
+		var response ListModelsResponseHuggingface
+		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			p.logger.Error("failed to decode response", err, "provider", p.GetName())
+			return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)
+		}
+		return response.Transform(), nil
 	default:
 		p.logger.Error("provider not found", nil, "provider", p.GetName())
 		return ListModelsResponse{}, fmt.Errorf("failed to decode response: %w", err)

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -30,6 +30,10 @@ const (
 	// Anthropic endpoints
 	AnthropicListEndpoint     = "/v1/models"
 	AnthropicGenerateEndpoint = "/v1/messages"
+
+	// Huggingface endpoints
+	HuggingfaceListEndpoint     = "/api/models?limit=1000" // It's also the default value I think there is no way to increase it, might need to introduce a search
+	HuggingfaceGenerateEndpoint = "/models/{model}"
 )
 
 // Endpoints exposed by each provider
@@ -157,6 +161,16 @@ var Registry = map[string]Config{
 		Endpoints: Endpoints{
 			List:     OpenAIListEndpoint,
 			Generate: OpenAIGenerateEndpoint,
+		},
+	},
+	HuggingfaceID: {
+		ID:       HuggingfaceID,
+		Name:     HuggingfaceDisplayName,
+		URL:      HuggingfaceDefaultBaseURL,
+		AuthType: AuthTypeBearer,
+		Endpoints: Endpoints{
+			List:     HuggingfaceListEndpoint,
+			Generate: HuggingfaceGenerateEndpoint,
 		},
 	},
 }


### PR DESCRIPTION
## Summary

Enable Huggingface will allow to use more than 1000 different LLMs this registry is huge full with Open Source LLMs that are not yet published by any Closed Source companies.

Specifically I'm going to use the deepseek coder v3 which seems interesting to me, I want to check how it performs instead of having to run it locally.

### Checklist

- [x] List endpoint
- [ ] Generate endpoint