### PR TITLE
feat: Add MaxTokens to limit the amount of the generated content

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -431,7 +431,7 @@ func (router *RouterImpl) GenerateProvidersTokenHandler(c *gin.Context) {
 		return
 	}
 
-	response, err := provider.GenerateTokens(ctx, req.Model, req.Messages, req.Tools)
+	response, err := provider.GenerateTokens(ctx, req.Model, req.Messages, req.Tools, req.MaxTokens)
 	if err != nil {
 		if err == context.DeadlineExceeded || ctx.Err() == context.DeadlineExceeded {
 			router.logger.Error("request timed out", err, "provider", c.Param("provider"))

--- a/examples/rest-endpoints/README.md
+++ b/examples/rest-endpoints/README.md
@@ -42,6 +42,7 @@ curl -X POST http://localhost:8080/llms/ollama/generate -d '{
   ],
   "stream": true,
   "ssevents": true
+  "max_tokens": 40
 }' | jq .
 ```
 
@@ -74,7 +75,8 @@ curl -X POST http://localhost:8080/llms/groq/generate -d '{
         }
       }
     }
-  ]
+  ],
+  "max_tokens": 40
 }' | jq .
 ```
 

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -109,6 +109,7 @@ type GenerateResponse struct {
 	Provider  string         `json:"provider"`
 	Response  ResponseTokens `json:"response"`
 	EventType EventType      `json:"event_type,omitempty"`
+	Usage     *Usage         `json:"usage,omitempty"`
 }
 
 type ListModelsResponse struct {
@@ -133,6 +134,16 @@ type ResponseTokens struct {
 	Model     string     `json:"model,omitempty"`
 	Role      string     `json:"role,omitempty"`
 	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
+}
+
+type Usage struct {
+	QueueTime        float64 `json:"queue_time"`
+	PromptTokens     int     `json:"prompt_tokens"`
+	PromptTime       float64 `json:"prompt_time"`
+	CompletionTokens int     `json:"completion_tokens"`
+	CompletionTime   float64 `json:"completion_time"`
+	TotalTokens      int     `json:"total_tokens"`
+	TotalTime        float64 `json:"total_time"`
 }
 
 func Float64Ptr(v float64) *float64 {

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -88,7 +88,7 @@ type GenerateRequest struct {
 	Stream    bool      `json:"stream"`
 	SSEvents  bool      `json:"ssevents"`
 	Tools     []Tool    `json:"tools"`
-	MaxTokens *int      `json:"max_tokens,omitempty"`
+	MaxTokens int       `json:"max_tokens,omitempty"`
 }
 
 // ToolCall represents a tool invocation by the LLM

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -83,11 +83,12 @@ type Tool struct {
 
 // Common response and request types
 type GenerateRequest struct {
-	Messages []Message `json:"messages"`
-	Model    string    `json:"model"`
-	Stream   bool      `json:"stream"`
-	SSEvents bool      `json:"ssevents"`
-	Tools    []Tool    `json:"tools"`
+	Messages  []Message `json:"messages"`
+	Model     string    `json:"model"`
+	Stream    bool      `json:"stream"`
+	SSEvents  bool      `json:"ssevents"`
+	Tools     []Tool    `json:"tools"`
+	MaxTokens *int      `json:"max_tokens,omitempty"`
 }
 
 // ToolCall represents a tool invocation by the LLM

--- a/providers/groq.go
+++ b/providers/groq.go
@@ -60,6 +60,7 @@ func (r *GenerateRequest) TransformGroq() GenerateRequestGroq {
 		Stream:      &r.Stream,
 		Temperature: Float64Ptr(1.0),
 		Tools:       r.Tools,
+		MaxTokens:   r.MaxTokens,
 	}
 }
 

--- a/providers/groq.go
+++ b/providers/groq.go
@@ -38,7 +38,7 @@ type GenerateRequestGroq struct {
 	Messages            []Message `json:"messages"`
 	Model               string    `json:"model"`
 	Temperature         *float64  `json:"temperature,omitempty"`
-	MaxCompletionTokens *int      `json:"max_completion_tokens,omitempty"`
+	MaxCompletionTokens int       `json:"max_completion_tokens,omitempty"`
 	TopP                *float64  `json:"top_p,omitempty"`
 	FrequencyPenalty    *float64  `json:"frequency_penalty,omitempty"`
 	PresencePenalty     *float64  `json:"presence_penalty,omitempty"`

--- a/providers/groq.go
+++ b/providers/groq.go
@@ -35,17 +35,17 @@ func (l *ListModelsResponseGroq) Transform() ListModelsResponse {
 }
 
 type GenerateRequestGroq struct {
-	Messages         []Message `json:"messages"`
-	Model            string    `json:"model"`
-	Temperature      *float64  `json:"temperature,omitempty"`
-	MaxTokens        *int      `json:"max_tokens,omitempty"`
-	TopP             *float64  `json:"top_p,omitempty"`
-	FrequencyPenalty *float64  `json:"frequency_penalty,omitempty"`
-	PresencePenalty  *float64  `json:"presence_penalty,omitempty"`
-	Stream           *bool     `json:"stream,omitempty"`
-	Stop             []string  `json:"stop,omitempty"`
-	User             *string   `json:"user,omitempty"`
-	ResponseFormat   *struct {
+	Messages            []Message `json:"messages"`
+	Model               string    `json:"model"`
+	Temperature         *float64  `json:"temperature,omitempty"`
+	MaxCompletionTokens *int      `json:"max_completion_tokens,omitempty"`
+	TopP                *float64  `json:"top_p,omitempty"`
+	FrequencyPenalty    *float64  `json:"frequency_penalty,omitempty"`
+	PresencePenalty     *float64  `json:"presence_penalty,omitempty"`
+	Stream              *bool     `json:"stream,omitempty"`
+	Stop                []string  `json:"stop,omitempty"`
+	User                *string   `json:"user,omitempty"`
+	ResponseFormat      *struct {
 		Type string `json:"type"`
 	} `json:"response_format,omitempty"`
 	Seed        *int    `json:"seed,omitempty"`
@@ -55,12 +55,12 @@ type GenerateRequestGroq struct {
 
 func (r *GenerateRequest) TransformGroq() GenerateRequestGroq {
 	return GenerateRequestGroq{
-		Messages:    r.Messages,
-		Model:       r.Model,
-		Stream:      &r.Stream,
-		Temperature: Float64Ptr(1.0),
-		Tools:       r.Tools,
-		MaxTokens:   r.MaxTokens,
+		Messages:            r.Messages,
+		Model:               r.Model,
+		Stream:              &r.Stream,
+		Temperature:         Float64Ptr(1.0),
+		Tools:               r.Tools,
+		MaxCompletionTokens: r.MaxTokens,
 	}
 }
 

--- a/providers/groq_test.go
+++ b/providers/groq_test.go
@@ -103,7 +103,6 @@ func TestGenerateResponseGroqTransform(t *testing.T) {
 					Model:   "llama2",
 					Role:    "assistant",
 				},
-				EventType: providers.EventContentDelta,
 			},
 		},
 		{

--- a/providers/management.go
+++ b/providers/management.go
@@ -27,7 +27,7 @@ type Provider interface {
 
 	// Fetchers
 	ListModels(ctx context.Context) (ListModelsResponse, error)
-	GenerateTokens(ctx context.Context, model string, messages []Message, tools []Tool) (GenerateResponse, error)
+	GenerateTokens(ctx context.Context, model string, messages []Message, tools []Tool, maxTokens int) (GenerateResponse, error)
 	StreamTokens(ctx context.Context, model string, messages []Message) (<-chan GenerateResponse, error)
 }
 
@@ -159,7 +159,7 @@ func (p *ProviderImpl) ListModels(ctx context.Context) (ListModelsResponse, erro
 	}
 }
 
-func (p *ProviderImpl) GenerateTokens(ctx context.Context, model string, messages []Message, tools []Tool) (GenerateResponse, error) {
+func (p *ProviderImpl) GenerateTokens(ctx context.Context, model string, messages []Message, tools []Tool, maxTokens int) (GenerateResponse, error) {
 	if p == nil {
 		return GenerateResponse{}, errors.New("provider cannot be nil")
 	}
@@ -176,9 +176,10 @@ func (p *ProviderImpl) GenerateTokens(ctx context.Context, model string, message
 	}
 
 	genRequest := GenerateRequest{
-		Model:    model,
-		Messages: messages,
-		Tools:    tools,
+		Model:     model,
+		Messages:  messages,
+		Tools:     tools,
+		MaxTokens: maxTokens,
 	}
 
 	switch p.GetID() {

--- a/providers/management_test.go
+++ b/providers/management_test.go
@@ -420,7 +420,7 @@ func BenchmarkGenerateTokens(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				resp, err := provider.GenerateTokens(context.Background(), "test-model", messages, []providers.Tool{})
+				resp, err := provider.GenerateTokens(context.Background(), "test-model", messages, []providers.Tool{}, 200)
 				if err != nil {
 					b.Fatalf("provider %s failed: %v\nResponse body: %s", providerID, err, responses[providerID].body)
 				}

--- a/tests/mocks/provider.go
+++ b/tests/mocks/provider.go
@@ -42,18 +42,18 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // GenerateTokens mocks base method.
-func (m *MockProvider) GenerateTokens(ctx context.Context, model string, messages []providers.Message, tools []providers.Tool) (providers.GenerateResponse, error) {
+func (m *MockProvider) GenerateTokens(ctx context.Context, model string, messages []providers.Message, tools []providers.Tool, maxTokens int) (providers.GenerateResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateTokens", ctx, model, messages, tools)
+	ret := m.ctrl.Call(m, "GenerateTokens", ctx, model, messages, tools, maxTokens)
 	ret0, _ := ret[0].(providers.GenerateResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GenerateTokens indicates an expected call of GenerateTokens.
-func (mr *MockProviderMockRecorder) GenerateTokens(ctx, model, messages, tools any) *gomock.Call {
+func (mr *MockProviderMockRecorder) GenerateTokens(ctx, model, messages, tools, maxTokens any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTokens", reflect.TypeOf((*MockProvider)(nil).GenerateTokens), ctx, model, messages, tools)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTokens", reflect.TypeOf((*MockProvider)(nil).GenerateTokens), ctx, model, messages, tools, maxTokens)
 }
 
 // GetAuthType mocks base method.

--- a/tests/routes_test.go
+++ b/tests/routes_test.go
@@ -106,7 +106,7 @@ func TestRouterHandlers(t *testing.T) {
 					Return(mockProvider, nil)
 
 				mockProvider.EXPECT().
-					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any()).
+					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(providers.GenerateResponse{
 						Provider: "test-provider",
 						Response: providers.ResponseTokens{
@@ -220,7 +220,7 @@ func TestGenerateProvidersTokenHandler(t *testing.T) {
 					BuildProvider("test-provider", mc).
 					Return(mockProvider, nil)
 				mockProvider.EXPECT().
-					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any()).
+					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(providers.GenerateResponse{
 						Provider: "test-provider",
 						Response: providers.ResponseTokens{
@@ -253,7 +253,7 @@ func TestGenerateProvidersTokenHandler(t *testing.T) {
 					BuildProvider("test-provider", mc).
 					Return(mockProvider, nil)
 				mockProvider.EXPECT().
-					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any()).
+					GenerateTokens(gomock.Any(), "test-model", gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(providers.GenerateResponse{}, context.DeadlineExceeded)
 				ml.EXPECT().
 					Error("request timed out", gomock.Any(), "provider", "test-provider")


### PR DESCRIPTION
## Summary

Allow to limit the amount of tokens generated by the LLM for Groq provider.