### PR TITLE
docs(openapi): Update server definitions and paths for improved API structure

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16,6 +16,14 @@ info:
     url: https://github.com/inference-gateway/inference-gateway/blob/main/LICENSE
 servers:
   - url: http://localhost:8080
+    description: Default server without version prefix for healthcheck and proxy and points
+    x-server-tags: ["Health", "Proxy"]
+  - url: http://localhost:8080/v1
+    description: Default server with version prefix for listing models and chat completions
+    x-server-tags: ["Models", "Completions"]
+  - url: https://api.inference-gateway.local/v1
+    description: Local server with version prefix for listing models and chat completions
+    x-server-tags: ["Models", "Completions"]
 tags:
   - name: Models
     description: List and describe the various models available in the API.
@@ -26,7 +34,7 @@ tags:
   - name: Health
     description: Health check
 paths:
-  /v1/models:
+  /models:
     get:
       operationId: listModels
       tags:
@@ -100,7 +108,7 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalError"
-  /v1/chat/completions:
+  /chat/completions:
     post:
       operationId: createChatCompletion
       tags:


### PR DESCRIPTION
## Summary

When the v1 prefix is defined on the server the endpoints are cleaner and clearer. This PR adds the v1 prefix to the server endpoints, rather than to the paths.

Signed-off-by: Eden Reich <eden.reich@gmail.com>
