### PR TITLE
refactor: Prefix model IDs with provider name for consistency across providers

### DIFF
--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -31,7 +31,7 @@ func (l *ListModelsResponseAnthropic) Transform() ListModelsResponse {
 		}
 
 		models = append(models, &Model{
-			ID:       model.ID,
+			ID:       string(provider) + "/" + model.ID,
 			Object:   "model",
 			Created:  created,
 			OwnedBy:  string(provider),

--- a/providers/cloudflare.go
+++ b/providers/cloudflare.go
@@ -29,7 +29,7 @@ func (l *ListModelsResponseCloudflare) Transform() ListModelsResponse {
 			}
 		}
 		models[i] = &Model{
-			ID:       model.Name,
+			ID:       string(provider) + "/" + model.Name,
 			Object:   "model",
 			Created:  created,
 			OwnedBy:  string(provider),

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -23,7 +23,7 @@ func (l *ListModelsResponseCohere) Transform() ListModelsResponse {
 	created := time.Now().Unix()
 	for i, model := range l.Models {
 		models[i] = &Model{
-			ID:       model.Name,
+			ID:       string(provider) + "/" + model.Name,
 			Object:   "model",
 			Created:  created, // Cohere does not provide creation time
 			OwnedBy:  string(provider),

--- a/providers/deepseek.go
+++ b/providers/deepseek.go
@@ -10,6 +10,7 @@ func (l *ListModelsResponseDeepseek) Transform() ListModelsResponse {
 	models := make([]*Model, len(l.Data))
 	for i, model := range l.Data {
 		model.ServedBy = &provider
+		model.ID = string(provider) + "/" + model.ID
 		models[i] = model
 	}
 

--- a/providers/groq.go
+++ b/providers/groq.go
@@ -10,6 +10,7 @@ func (l *ListModelsResponseGroq) Transform() ListModelsResponse {
 	models := make([]*Model, len(l.Data))
 	for i, model := range l.Data {
 		model.ServedBy = &provider
+		model.ID = string(provider) + "/" + model.ID
 		models[i] = model
 	}
 

--- a/providers/ollama.go
+++ b/providers/ollama.go
@@ -10,6 +10,7 @@ func (l *ListModelsResponseOllama) Transform() ListModelsResponse {
 	models := make([]*Model, len(l.Data))
 	for i, model := range l.Data {
 		model.ServedBy = &provider
+		model.ID = string(provider) + "/" + model.ID
 		models[i] = model
 	}
 

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -10,6 +10,7 @@ func (l *ListModelsResponseOpenai) Transform() ListModelsResponse {
 	models := make([]*Model, len(l.Data))
 	for i, model := range l.Data {
 		model.ServedBy = &provider
+		model.ID = string(provider) + "/" + model.ID
 		models[i] = model
 	}
 

--- a/tests/providers_test.go
+++ b/tests/providers_test.go
@@ -210,8 +210,8 @@ func TestProviderListModels(t *testing.T) {
 	resp, err := provider.ListModels(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(resp.Data))
-	assert.Equal(t, "gpt-3.5-turbo", resp.Data[0].ID)
-	assert.Equal(t, "gpt-4", resp.Data[1].ID)
+	assert.Equal(t, "openai/gpt-3.5-turbo", resp.Data[0].ID)
+	assert.Equal(t, "openai/gpt-4", resp.Data[1].ID)
 }
 
 // TestDifferentAuthTypes tests that different auth types are properly handled


### PR DESCRIPTION
## Summary

Prefix model IDs with provider name for consistency across providers.

It's easier to integrate in different tools like this.
