### PR TITLE
feat: Add reasoning_content field to chunk message in OpenAPI specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -904,6 +904,9 @@ components:
         content:
           type: string
           description: The contents of the chunk message.
+        reasoning_content:
+          type: string
+          description: The reasoning content of the chunk message.
         tool_calls:
           type: array
           items:

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -139,10 +139,11 @@ type ChatCompletionStreamOptions struct {
 
 // ChatCompletionStreamResponseDelta represents a ChatCompletionStreamResponseDelta in the API
 type ChatCompletionStreamResponseDelta struct {
-	Content   string                                `json:"content,omitempty"`
-	Refusal   string                                `json:"refusal,omitempty"`
-	Role      *MessageRole                          `json:"role,omitempty"`
-	ToolCalls []*ChatCompletionMessageToolCallChunk `json:"tool_calls,omitempty"`
+	Content          string                                `json:"content,omitempty"`
+	ReasoningContent string                                `json:"reasoning_content,omitempty"`
+	Refusal          string                                `json:"refusal,omitempty"`
+	Role             *MessageRole                          `json:"role,omitempty"`
+	ToolCalls        []*ChatCompletionMessageToolCallChunk `json:"tool_calls,omitempty"`
 }
 
 // ChatCompletionTool represents a ChatCompletionTool in the API


### PR DESCRIPTION
## Summary

Add reasoning_content field to chunk message in OpenAPI specification.

DeepSeek R1 sends it.
