### PR TITLE
fix: Enhance error handling in ChatCompletions and ListModels methods

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -530,7 +530,7 @@ func (router *RouterImpl) ChatCompletionsHandler(c *gin.Context) {
 			return
 		}
 		router.logger.Error("failed to generate tokens", err, "provider", providerID)
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Failed to generate tokens"})
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: fmt.Sprintf("Failed to generate tokens: %s", err)})
 		return
 	}
 


### PR DESCRIPTION
## Summary

Enhance error handling in ChatCompletions and ListModels methods.

There was an issue that the error from the provider was not returned to the client for further debugging.

Also remove fix a special case for groq API, remove it, keep the API as is - maybe I'll implement something in the SDK client to ensure it's default to "parsed".
