### PR TITLE
docs: Update examples to use the latest pre built OCIs

### DIFF
--- a/examples/docker-compose/mcp/docker-compose.yml
+++ b/examples/docker-compose/mcp/docker-compose.yml
@@ -1,9 +1,7 @@
 ---
 services:
   inference-gateway:
-    build:
-      context: ../../../
-      dockerfile: Dockerfile
+    image: ghcr.io/inference-gateway/inference-gateway:latest
     ports:
       - "8080:8080"
     env_file:

--- a/examples/kubernetes/agent/Taskfile.yaml
+++ b/examples/kubernetes/agent/Taskfile.yaml
@@ -48,7 +48,7 @@ tasks:
           --set config.ENVIRONMENT=development \
           --set envFrom.secretRef=inference-gateway \
           --wait \
-          --version 0.6.3 \
+          --version 0.7.1 \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🚪 Inference Gateway deployed successfully!"
 

--- a/examples/kubernetes/authentication/Taskfile.yaml
+++ b/examples/kubernetes/authentication/Taskfile.yaml
@@ -133,7 +133,7 @@ tasks:
           --set volumeMounts[0].subPath=ca.crt \
           --set volumeMounts[0].readOnly=true \
           --wait \
-          --version 0.6.3 \
+          --version 0.7.1 \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🔒 Inference Gateway with authentication enabled, deployed successfully!"
 

--- a/examples/kubernetes/basic/Taskfile.yaml
+++ b/examples/kubernetes/basic/Taskfile.yaml
@@ -25,7 +25,7 @@ tasks:
           --create-namespace \
           --namespace inference-gateway \
           --set ingress.enabled=true \
-          --version 0.6.3 \
+          --version 0.7.1 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🚪 Inference Gateway deployed successfully!"

--- a/examples/kubernetes/hybrid/Taskfile.yaml
+++ b/examples/kubernetes/hybrid/Taskfile.yaml
@@ -41,7 +41,7 @@ tasks:
           --set ingress.enabled=true \
           --set config.OLLAMA_API_URL="http://ollama.ollama:8080/v1" \
           --set envFrom.secretRef=inference-gateway \
-          --version 0.6.3 \
+          --version 0.7.1 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🚪 Inference Gateway with hybrid providers deployed successfully!"

--- a/examples/kubernetes/monitoring/Taskfile.yaml
+++ b/examples/kubernetes/monitoring/Taskfile.yaml
@@ -61,7 +61,7 @@ tasks:
           --set autoscaling.maxReplicas=10 \
           --set autoscaling.targetCPUUtilizationPercentage=80 \
           --set autoscaling.targetMemoryUtilizationPercentage=80 \
-          --version 0.6.3 \
+          --version 0.7.1 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - kubectl label namespace inference-gateway monitoring="true" --overwrite

--- a/examples/kubernetes/tls/Taskfile.yaml
+++ b/examples/kubernetes/tls/Taskfile.yaml
@@ -43,7 +43,7 @@ tasks:
           --set ingress.tls.enabled=true \
           --set ingress.tls.hosts[0]=api.inference-gateway.local \
           --set ingress.tls.secretName=api-inference-gateway-local-tls \
-          --version 0.6.3 \
+          --version 0.7.1 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🔐 Inference Gateway with TLS deployed successfully!"


### PR DESCRIPTION
## Summary

This Pull Request updates the inference-gateway service to use a pre-built image and updates the version in the Taskfiles.

### Changes

- **docs: Update inference-gateway service to use pre-built image**
- **docs: Update inference-gateway version to 0.7.1 in Taskfiles**
