### PR TITLE
fix: When MCP is Enabled and there are no configured servers or the configured server is unavailable return an empty slice

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,6 +34,12 @@
         "dev.containers.copyGitConfig": true,
         "githubPullRequests.experimental.chat": true,
         "githubPullRequests.experimental.notificationsView": true,
+        "github.copilot.enable": {
+          "*": true
+        },
+        "github.copilot.advanced": {
+          "authProvider": "github"
+        },
         "github.copilot.chat.codeGeneration.useInstructionFiles": true,
         "github.copilot.chat.codeGeneration.instructions": [
           {


### PR DESCRIPTION
## Summary

This Pull Request simplifies the client code by returning a single data structure.

### Changes

- **fix(copilot): Enable GitHub Copilot and set authentication provider**
- **fix: Improve MCP client handling in ListToolsHandler for better error feedback**

- Closes #81 