### PR TITLE
feat: Add ALLOWED_MODELS configuration for model filtering

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -6,6 +6,7 @@
 | ENVIRONMENT | `production` | The environment |
 | ENABLE_TELEMETRY | `false` | Enable telemetry |
 | ENABLE_AUTH | `false` | Enable authentication |
+| ALLOWED_MODELS | `""` | Comma-separated list of models to allow. If empty, all models will be available |
 
 
 ### Model Context Protocol (MCP)

--- a/charts/inference-gateway/templates/configmap-defaults.yaml
+++ b/charts/inference-gateway/templates/configmap-defaults.yaml
@@ -9,6 +9,7 @@ data:
   ENVIRONMENT: {{ .Values.config.ENVIRONMENT | quote }}
   ENABLE_TELEMETRY: {{ .Values.config.ENABLE_TELEMETRY | quote }}
   ENABLE_AUTH: {{ .Values.config.ENABLE_AUTH | quote }}
+  ALLOWED_MODELS: {{ .Values.config.ALLOWED_MODELS | quote }}
   # Model Context Protocol (MCP)
   MCP_ENABLE: {{ .Values.config.MCP_ENABLE | quote }}
   MCP_EXPOSE: {{ .Values.config.MCP_EXPOSE | quote }}

--- a/charts/inference-gateway/values.yaml
+++ b/charts/inference-gateway/values.yaml
@@ -141,6 +141,7 @@ config:
   ENVIRONMENT: "production"
   ENABLE_TELEMETRY: "false"
   ENABLE_AUTH: "false"
+  ALLOWED_MODELS: ""
   # Model Context Protocol (MCP)
   MCP_ENABLE: "false"
   MCP_EXPOSE: "false"

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Environment     string `env:"ENVIRONMENT, default=production" description:"The environment"`
 	EnableTelemetry bool   `env:"ENABLE_TELEMETRY, default=false" description:"Enable telemetry"`
 	EnableAuth      bool   `env:"ENABLE_AUTH, default=false" description:"Enable authentication"`
+	AllowedModels   string `env:"ALLOWED_MODELS" description:"Comma-separated list of models to allow. If empty, all models will be available"`
 	// MCP settings
 	MCP *MCPConfig `env:", prefix=MCP_" description:"MCP configuration"`
 	// OIDC settings

--- a/examples/docker-compose/authentication/.env.example
+++ b/examples/docker-compose/authentication/.env.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/basic/.env.example
+++ b/examples/docker-compose/basic/.env.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/hybrid/.env.example
+++ b/examples/docker-compose/hybrid/.env.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/mcp/.env.example
+++ b/examples/docker-compose/mcp/.env.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/tools/.env.example
+++ b/examples/docker-compose/tools/.env.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/ui/.env.backend.example
+++ b/examples/docker-compose/ui/.env.backend.example
@@ -3,6 +3,7 @@
 ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
+ALLOWED_MODELS=
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1177,6 +1177,11 @@ components:
                   type: bool
                   default: "false"
                   description: "Enable authentication"
+                - name: allowed_models
+                  env: "ALLOWED_MODELS"
+                  type: string
+                  default: ""
+                  description: "Comma-separated list of models to allow. If empty, all models will be available"
           - mcp:
               title: "Model Context Protocol (MCP)"
               settings:

--- a/tests/api_routes_test.go
+++ b/tests/api_routes_test.go
@@ -1,0 +1,462 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/inference-gateway/inference-gateway/api"
+	"github.com/inference-gateway/inference-gateway/config"
+	"github.com/inference-gateway/inference-gateway/logger"
+	"github.com/inference-gateway/inference-gateway/providers"
+	"github.com/inference-gateway/inference-gateway/tests/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestListModelsHandler_AllowedModelsFiltering(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedModels  string
+		mockModels     []providers.Model
+		expectedModels []string
+		description    string
+	}{
+		{
+			name:          "Empty ALLOWED_MODELS returns all models",
+			allowedModels: "",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4", "openai/gpt-3.5-turbo", "anthropic/claude-3"},
+			description:    "When MODELS_LIST is empty, all models should be returned",
+		},
+		{
+			name:          "Filter by exact model ID",
+			allowedModels: "openai/gpt-4",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4"},
+			description:    "Should return only the exact model ID match",
+		},
+		{
+			name:          "Filter by model name without provider prefix",
+			allowedModels: "gpt-4,claude-3",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4", "anthropic/claude-3"},
+			description:    "Should match models by name without provider prefix",
+		},
+		{
+			name:          "Case insensitive matching",
+			allowedModels: "GPT-4,CLAUDE-3",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4", "anthropic/claude-3"},
+			description:    "Should match models in a case-insensitive manner",
+		},
+		{
+			name:          "Trim whitespace in ALLOWED_MODELS",
+			allowedModels: " gpt-4 , claude-3 ",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4", "anthropic/claude-3"},
+			description:    "Should handle whitespace correctly in the models list",
+		},
+		{
+			name:          "No matches returns empty list",
+			allowedModels: "nonexistent-model",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+			},
+			expectedModels: []string{},
+			description:    "Should return empty list when no models match the filter",
+		},
+		{
+			name:          "Mixed exact ID and name matching",
+			allowedModels: "openai/gpt-4,claude-3",
+			mockModels: []providers.Model{
+				{ID: "openai/gpt-4", Object: "model", Created: 1677649963, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "openai/gpt-3.5-turbo", Object: "model", Created: 1677610602, OwnedBy: "openai", ServedBy: providers.OpenaiID},
+				{ID: "anthropic/claude-3", Object: "model", Created: 1677649963, OwnedBy: "anthropic", ServedBy: providers.AnthropicID},
+			},
+			expectedModels: []string{"openai/gpt-4", "anthropic/claude-3"},
+			description:    "Should handle mix of exact ID and name-only matching",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				response := providers.ListModelsResponse{
+					Object: "list",
+					Data:   tt.mockModels,
+				}
+
+				jsonResponse, err := json.Marshal(response)
+				require.NoError(t, err)
+				_, err = w.Write(jsonResponse)
+				require.NoError(t, err)
+			}))
+			defer server.Close()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockClient := mocks.NewMockClient(ctrl)
+
+			mockClient.EXPECT().
+				Do(gomock.Any()).
+				DoAndReturn(func(req *http.Request) (*http.Response, error) {
+					return http.DefaultClient.Get(server.URL + "/models")
+				}).
+				AnyTimes()
+
+			log, err := logger.NewLogger("test")
+			require.NoError(t, err)
+
+			providerCfg := map[providers.Provider]*providers.Config{
+				providers.OpenaiID: {
+					ID:       providers.OpenaiID,
+					Name:     providers.OpenaiDisplayName,
+					URL:      server.URL,
+					Token:    "test-token",
+					AuthType: providers.AuthTypeBearer,
+					Endpoints: providers.Endpoints{
+						Models: providers.OpenaiModelsEndpoint,
+					},
+				},
+			}
+
+			registry := providers.NewProviderRegistry(providerCfg, log)
+
+			cfg := config.Config{
+				AllowedModels: tt.allowedModels,
+				Server: &config.ServerConfig{
+					ReadTimeout: time.Duration(5000) * time.Millisecond,
+				},
+				Providers: providerCfg,
+			}
+
+			router := api.NewRouter(cfg, log, registry, mockClient, nil)
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.GET("/v1/models", router.ListModelsHandler)
+
+			t.Run("SingleProvider", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := http.NewRequest("GET", "/v1/models?provider=openai", nil)
+				require.NoError(t, err)
+
+				r.ServeHTTP(w, req)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+
+				var response providers.ListModelsResponse
+				err = json.Unmarshal(w.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, "list", response.Object)
+				assert.Equal(t, len(tt.expectedModels), len(response.Data))
+
+				actualModelIDs := make([]string, len(response.Data))
+				for i, model := range response.Data {
+					actualModelIDs[i] = model.ID
+				}
+
+				for _, expectedID := range tt.expectedModels {
+					assert.Contains(t, actualModelIDs, expectedID, "Expected model %s not found in response", expectedID)
+				}
+			})
+
+			t.Run("AllProviders", func(t *testing.T) {
+				w := httptest.NewRecorder()
+				req, err := http.NewRequest("GET", "/v1/models", nil)
+				require.NoError(t, err)
+
+				r.ServeHTTP(w, req)
+
+				assert.Equal(t, http.StatusOK, w.Code)
+
+				var response providers.ListModelsResponse
+				err = json.Unmarshal(w.Body.Bytes(), &response)
+				require.NoError(t, err)
+
+				assert.Equal(t, "list", response.Object)
+				assert.Equal(t, len(tt.expectedModels), len(response.Data))
+
+				actualModelIDs := make([]string, len(response.Data))
+				for i, model := range response.Data {
+					actualModelIDs[i] = model.ID
+				}
+
+				for _, expectedID := range tt.expectedModels {
+					assert.Contains(t, actualModelIDs, expectedID, "Expected model %s not found in response", expectedID)
+				}
+			})
+		})
+	}
+}
+
+func TestListModelsHandler_ErrorCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		providerParam  string
+		mockSetup      func(*mocks.MockClient)
+		expectedStatus int
+		expectedError  string
+		description    string
+	}{
+		{
+			name:           "Unknown provider",
+			providerParam:  "unknown",
+			mockSetup:      func(mockClient *mocks.MockClient) {},
+			expectedStatus: http.StatusBadRequest,
+			expectedError:  "Provider not found",
+			description:    "Should return error for unknown provider",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockClient := mocks.NewMockClient(ctrl)
+			tt.mockSetup(mockClient)
+
+			log, err := logger.NewLogger("test")
+			require.NoError(t, err)
+
+			registry := providers.NewProviderRegistry(map[providers.Provider]*providers.Config{}, log)
+
+			cfg := config.Config{
+				Server: &config.ServerConfig{
+					ReadTimeout: time.Duration(5000) * time.Millisecond,
+				},
+			}
+
+			router := api.NewRouter(cfg, log, registry, mockClient, nil)
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.GET("/v1/models", router.ListModelsHandler)
+
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest("GET", "/v1/models?provider="+tt.providerParam, nil)
+			require.NoError(t, err)
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			var response map[string]interface{}
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			errorMsg, exists := response["error"]
+			assert.True(t, exists, "Response should contain error field")
+			assert.Contains(t, errorMsg.(string), tt.expectedError, "Error message should contain expected text")
+		})
+	}
+}
+
+func TestChatCompletionsHandler_ModelValidation(t *testing.T) {
+	tests := []struct {
+		name           string
+		allowedModels  string
+		requestModel   string
+		expectedStatus int
+		expectedError  string
+		description    string
+	}{
+		{
+			name:           "Allowed model passes validation",
+			allowedModels:  "gpt-4,claude-3",
+			requestModel:   "openai/gpt-4",
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+			description:    "Should allow requests with models in the allowed list",
+		},
+		{
+			name:           "Disallowed model fails validation",
+			allowedModels:  "gpt-4,claude-3",
+			requestModel:   "openai/gpt-3.5-turbo",
+			expectedStatus: http.StatusForbidden,
+			expectedError:  "Model not allowed. Please check the list of allowed models.",
+			description:    "Should reject requests with models not in the allowed list",
+		},
+		{
+			name:           "Empty allowed models allows all",
+			allowedModels:  "",
+			requestModel:   "openai/gpt-3.5-turbo",
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+			description:    "Should allow all models when ALLOWED_MODELS is empty",
+		},
+		{
+			name:           "Case insensitive model validation",
+			allowedModels:  "GPT-4,CLAUDE-3",
+			requestModel:   "openai/gpt-4",
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+			description:    "Should validate models in a case-insensitive manner",
+		},
+		{
+			name:           "Exact model ID matching",
+			allowedModels:  "openai/gpt-4",
+			requestModel:   "openai/gpt-4",
+			expectedStatus: http.StatusOK,
+			expectedError:  "",
+			description:    "Should allow exact model ID matches",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+
+				response := map[string]interface{}{
+					"id":      "chatcmpl-test",
+					"object":  "chat.completion",
+					"created": 1677649963,
+					"model":   tt.requestModel,
+					"choices": []map[string]interface{}{
+						{
+							"index": 0,
+							"message": map[string]interface{}{
+								"role":    "assistant",
+								"content": "Test response",
+							},
+							"finish_reason": "stop",
+						},
+					},
+				}
+
+				jsonResponse, _ := json.Marshal(response)
+				_, _ = w.Write(jsonResponse)
+			}))
+			defer server.Close()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockClient := mocks.NewMockClient(ctrl)
+
+			mockClient.EXPECT().
+				Do(gomock.Any()).
+				DoAndReturn(func(req *http.Request) (*http.Response, error) {
+					if tt.expectedStatus == http.StatusOK {
+						testReq, err := http.NewRequest(req.Method, server.URL+"/chat/completions", req.Body)
+						if err != nil {
+							return nil, err
+						}
+
+						for key, values := range req.Header {
+							for _, value := range values {
+								testReq.Header.Add(key, value)
+							}
+						}
+						return http.DefaultClient.Do(testReq)
+					}
+					return nil, nil
+				}).
+				AnyTimes()
+
+			log, err := logger.NewLogger("test")
+			require.NoError(t, err)
+
+			providerCfg := map[providers.Provider]*providers.Config{
+				providers.OpenaiID: {
+					ID:       providers.OpenaiID,
+					Name:     providers.OpenaiDisplayName,
+					URL:      server.URL,
+					Token:    "test-token",
+					AuthType: providers.AuthTypeBearer,
+					Endpoints: providers.Endpoints{
+						Chat: providers.OpenaiChatEndpoint,
+					},
+				},
+			}
+
+			registry := providers.NewProviderRegistry(providerCfg, log)
+
+			cfg := config.Config{
+				AllowedModels: tt.allowedModels,
+				Server: &config.ServerConfig{
+					ReadTimeout: time.Duration(5000) * time.Millisecond,
+				},
+				Providers: providerCfg,
+			}
+
+			router := api.NewRouter(cfg, log, registry, mockClient, nil)
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			r.POST("/v1/chat/completions", router.ChatCompletionsHandler)
+
+			// Create request body with the test model
+			requestBody := map[string]interface{}{
+				"model": tt.requestModel,
+				"messages": []map[string]string{
+					{
+						"role":    "user",
+						"content": "Hello, world!",
+					},
+				},
+			}
+
+			jsonBody, err := json.Marshal(requestBody)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			req, err := http.NewRequest("POST", "/v1/chat/completions", strings.NewReader(string(jsonBody)))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+
+			var response map[string]interface{}
+			err = json.Unmarshal(w.Body.Bytes(), &response)
+			require.NoError(t, err)
+
+			if tt.expectedError != "" {
+				errorMsg, exists := response["error"]
+				assert.True(t, exists, "Response should contain error field")
+				assert.Contains(t, errorMsg.(string), tt.expectedError, "Error message should contain expected text")
+			} else {
+				assert.Equal(t, "chat.completion", response["object"])
+				assert.NotEmpty(t, response["model"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This could be useful for few reasons:

- In the UI for example when listing all models - there are a lot, but some are actually not even support tool-use.
- In production in case things goes wrong, you might want to quickly remove a model from the usage.
