### PR TITLE
refactor: Rename internal headers to use 'Bypass' terminology

### DIFF
--- a/api/middlewares/a2a.go
+++ b/api/middlewares/a2a.go
@@ -18,7 +18,7 @@ import (
 const (
 	// TODO - Rename this to X-A2A-Skip
 	// A2AInternalHeader marks internal A2A requests to prevent middleware loops
-	A2AInternalHeader = "X-A2A-Internal"
+	A2AInternalHeader = "X-A2A-Bypass"
 )
 
 // a2aContextKey is a custom type for context keys to avoid collisions

--- a/api/middlewares/mcp.go
+++ b/api/middlewares/mcp.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// MCPInternalHeader marks internal MCP requests to prevent middleware loops
-	MCPInternalHeader = "X-MCP-Internal"
+	MCPInternalHeader = "X-MCP-Bypass"
 
 	// MaxMCPAgentIterations limits the number of agent loop iterations
 	MaxMCPAgentIterations = 10

--- a/api/routes.go
+++ b/api/routes.go
@@ -481,7 +481,7 @@ func (router *RouterImpl) ListModelsHandler(c *gin.Context) {
 func (router *RouterImpl) ChatCompletionsHandler(c *gin.Context) {
 	var req providers.CreateChatCompletionRequest
 
-	if mcpRequest, exists := c.Get("X-MCP-Internal"); exists {
+	if mcpRequest, exists := c.Get("X-MCP-Bypass"); exists {
 		if parsedRequest, ok := mcpRequest.(*providers.CreateChatCompletionRequest); ok {
 			req = *parsedRequest
 		} else {

--- a/tests/middlewares/a2a_test.go
+++ b/tests/middlewares/a2a_test.go
@@ -195,7 +195,7 @@ func TestA2AMiddleware_RequestWithA2AMiddlewareEnabled(t *testing.T) {
 			req := httptest.NewRequest("POST", tt.path, bytes.NewReader([]byte(tt.requestBody)))
 			req.Header.Set("Content-Type", "application/json")
 			if tt.hasInternalHeader {
-				req.Header.Set("X-A2A-Internal", "true")
+				req.Header.Set("X-A2A-Bypass", "true")
 			}
 			w := httptest.NewRecorder()
 

--- a/tests/middlewares/mcp_test.go
+++ b/tests/middlewares/mcp_test.go
@@ -174,7 +174,7 @@ func TestMCPMiddleware_SkipConditions(t *testing.T) {
 			req := httptest.NewRequest(method, tt.path, strings.NewReader(`{"model":"gpt-4","messages":[]}`))
 			req.Header.Set("Content-Type", "application/json")
 			if tt.internalHeader != "" {
-				req.Header.Set("X-MCP-Internal", tt.internalHeader)
+				req.Header.Set("X-MCP-Bypass", tt.internalHeader)
 			}
 
 			router.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary

Rename X-MCP-Internal and X-A2A-Internal headers to X-MCP-Bypass and X-A2A-Bypass respectively.

It makes sense to call it this way because that's what it essentially does.
