### PR TITLE
feat: Add GetAgentHandler endpoint to retrieve specific A2A agent details by ID

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,6 +33,7 @@ type Router interface {
 	ChatCompletionsHandler(c *gin.Context)
 	ListToolsHandler(c *gin.Context)
 	ListAgentsHandler(c *gin.Context)
+	GetAgentHandler(c *gin.Context)
 	ProxyHandler(c *gin.Context)
 	HealthcheckHandler(c *gin.Context)
 	NotFoundHandler(c *gin.Context)
@@ -671,11 +674,13 @@ func (router *RouterImpl) ListToolsHandler(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
-// ListAgentsHandler implements an endpoint that returns available A2A agents
+// ListAgentsHandler implements an endpoint that returns complete A2A agent cards with all detailed information
 // when A2A_EXPOSE environment variable is enabled.
 //
 // This handler supports the Agent-to-Agent (A2A) protocol by exposing a list of
-// connected agents along with their metadata such as name, description, and URL.
+// connected agents along with their complete agent cards containing comprehensive
+// metadata such as name, description, URL, capabilities, skills, security schemes,
+// and supported input/output modes.
 //
 // The endpoint follows the OpenAI-compatible API format pattern used throughout
 // the gateway for consistency.
@@ -692,16 +697,31 @@ func (router *RouterImpl) ListToolsHandler(c *gin.Context) {
 //	  "object": "list",
 //	  "data": [
 //	    {
-//	      "id": "https://agent1.example.com",
 //	      "name": "Calculator Agent",
 //	      "description": "An agent that can perform mathematical calculations",
-//	      "url": "https://agent1.example.com"
-//	    },
-//	    {
-//	      "id": "https://agent2.example.com",
-//	      "name": "Weather Agent",
-//	      "description": "An agent that provides weather information",
-//	      "url": "https://agent2.example.com"
+//	      "url": "https://agent1.example.com",
+//	      "version": "1.0.0",
+//	      "capabilities": {
+//	        "supportsStreaming": true,
+//	        "supportsTaskCancellation": false
+//	      },
+//	      "skills": [
+//	        {
+//	          "id": "calculate",
+//	          "name": "Mathematical Calculation",
+//	          "description": "Perform basic and advanced mathematical operations",
+//	          "tags": ["math", "calculation"],
+//	          "examples": ["2 + 2", "sqrt(16)", "sin(pi/2)"]
+//	        }
+//	      ],
+//	      "defaultInputModes": ["text/plain"],
+//	      "defaultOutputModes": ["text/plain", "application/json"],
+//	      "provider": {
+//	        "organization": "Example Corp",
+//	        "url": "https://example.com"
+//	      },
+//	      "security": [],
+//	      "securitySchemes": {}
 //	    }
 //	  ]
 //	}
@@ -735,6 +755,10 @@ func (router *RouterImpl) ListToolsHandler(c *gin.Context) {
 //   - Requires authentication via Bearer token
 //   - Only exposes agents when explicitly configured via A2A_EXPOSE=true
 //   - Does not expose internal errors to clients
+//
+// Note: This endpoint now returns complete AgentCard objects instead of simplified
+// A2AItem objects, providing clients with full agent metadata including capabilities,
+// skills, security requirements, and supported modalities.
 func (router *RouterImpl) ListAgentsHandler(c *gin.Context) {
 	if !router.cfg.A2A.Expose {
 		router.logger.Error("a2a agents endpoint access attempted but not exposed", nil)
@@ -742,15 +766,15 @@ func (router *RouterImpl) ListAgentsHandler(c *gin.Context) {
 		return
 	}
 
-	var allAgents []providers.A2AItem
+	var allAgents []providers.A2AAgentCard
 
 	switch {
 	case router.a2aClient == nil:
 		router.logger.Debug("a2a client is nil, returning empty agents list")
-		allAgents = make([]providers.A2AItem, 0)
+		allAgents = make([]providers.A2AAgentCard, 0)
 	case !router.a2aClient.IsInitialized():
 		router.logger.Info("a2a client not initialized, no agents available")
-		allAgents = make([]providers.A2AItem, 0)
+		allAgents = make([]providers.A2AAgentCard, 0)
 	default:
 		agentURLs := router.a2aClient.GetAgents()
 
@@ -761,17 +785,13 @@ func (router *RouterImpl) ListAgentsHandler(c *gin.Context) {
 				continue
 			}
 
-			a2aAgent := providers.A2AItem{
-				ID:          agentURL,
-				Name:        agentCard.Name,
-				Description: &agentCard.Description,
-				Url:         &agentURL,
-			}
-			allAgents = append(allAgents, a2aAgent)
+			// TODO: refactor providers package to be able to use a2a.AgentCard directly, instead of copying fields
+			convertedCard := convertA2AAgentCard(*agentCard, agentURL)
+			allAgents = append(allAgents, convertedCard)
 		}
 
 		if allAgents == nil {
-			allAgents = make([]providers.A2AItem, 0)
+			allAgents = make([]providers.A2AAgentCard, 0)
 		}
 	}
 
@@ -781,6 +801,174 @@ func (router *RouterImpl) ListAgentsHandler(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
+}
+
+// GetAgentHandler implements an endpoint that returns a specific A2A agent by ID
+//
+// This endpoint provides detailed information about a single A2A agent identified by its unique ID.
+// The ID is generated as a base64-encoded SHA256 hash of the agent's URL to ensure uniqueness
+// and deterministic identification across restarts.
+//
+// Request:
+//   - Method: GET
+//   - Path: /a2a/agents/{id}
+//   - Parameters:
+//   - id (path): The unique identifier of the agent (base64-encoded SHA256 hash of the agent URL)
+//
+// Response (200 OK):
+//   - Content-Type: application/json
+//   - Body: A2AAgentCard object containing complete agent information
+//
+// Response (404 Not Found):
+//   - When the specified agent ID does not exist
+//
+// Response (403 Forbidden):
+//   - When A2A_EXPOSE is not enabled
+//
+// Security:
+//   - Requires authentication via Bearer token
+//   - Only accessible when explicitly configured via A2A_EXPOSE=true
+//   - Does not expose internal errors to clients
+func (router *RouterImpl) GetAgentHandler(c *gin.Context) {
+	if !router.cfg.A2A.Expose {
+		router.logger.Error("a2a agent endpoint access attempted but not exposed", nil)
+		c.JSON(http.StatusForbidden, ErrorResponse{Error: "A2A agents endpoint is not exposed. Set A2A_EXPOSE=true to enable."})
+		return
+	}
+
+	agentID := c.Param("id")
+	if agentID == "" {
+		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "Agent ID is required"})
+		return
+	}
+
+	switch {
+	case router.a2aClient == nil:
+		router.logger.Debug("a2a client is nil")
+		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Agent not found"})
+		return
+	case !router.a2aClient.IsInitialized():
+		router.logger.Info("a2a client not initialized, no agents available")
+		c.JSON(http.StatusNotFound, ErrorResponse{Error: "Agent not found"})
+		return
+	}
+
+	agentURLs := router.a2aClient.GetAgents()
+
+	for _, agentURL := range agentURLs {
+		if generateAgentID(agentURL) == agentID {
+			agentCard, err := router.a2aClient.GetAgentCard(c.Request.Context(), agentURL)
+			if err != nil {
+				router.logger.Error("failed to get agent card from a2a agent", err, "agent", agentURL)
+				c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "Failed to retrieve agent information"})
+				return
+			}
+
+			convertedCard := convertA2AAgentCard(*agentCard, agentURL)
+			c.JSON(http.StatusOK, convertedCard)
+			return
+		}
+	}
+
+	c.JSON(http.StatusNotFound, ErrorResponse{Error: "Agent not found"})
+}
+
+// convertA2AAgentCard converts an a2a.AgentCard to providers.A2AAgentCard
+func convertA2AAgentCard(agentCard a2a.AgentCard, agentURL string) providers.A2AAgentCard {
+	capabilities := make(map[string]interface{})
+
+	if agentCard.Capabilities.Extensions != nil {
+		capabilities["extensions"] = agentCard.Capabilities.Extensions
+	} else {
+		capabilities["extensions"] = []a2a.AgentExtension{}
+	}
+
+	capabilities["pushNotifications"] = agentCard.Capabilities.PushNotifications
+	capabilities["stateTransitionHistory"] = agentCard.Capabilities.StateTransitionHistory
+	capabilities["streaming"] = agentCard.Capabilities.Streaming
+
+	var provider *map[string]interface{}
+	if agentCard.Provider != nil {
+		providerMap := make(map[string]interface{})
+		providerMap["organization"] = agentCard.Provider.Organization
+		providerMap["url"] = agentCard.Provider.URL
+		provider = &providerMap
+	}
+
+	var security *[]map[string]interface{}
+	if agentCard.Security != nil {
+		securitySlice := make([]map[string]interface{}, len(agentCard.Security))
+		for i, sec := range agentCard.Security {
+			securityMap := make(map[string]interface{})
+			for k, v := range sec {
+				securityMap[k] = v
+			}
+			securitySlice[i] = securityMap
+		}
+		security = &securitySlice
+	}
+
+	var securitySchemes *map[string]interface{}
+	if agentCard.SecuritySchemes != nil {
+		schemes := make(map[string]interface{})
+		for k, v := range agentCard.SecuritySchemes {
+			schemes[k] = v
+		}
+		securitySchemes = &schemes
+	}
+
+	skills := make([]map[string]interface{}, len(agentCard.Skills))
+	for i, skill := range agentCard.Skills {
+		skillMap := make(map[string]interface{})
+		skillMap["description"] = skill.Description
+
+		if skill.Examples != nil {
+			skillMap["examples"] = skill.Examples
+		} else {
+			skillMap["examples"] = []string{}
+		}
+
+		skillMap["id"] = skill.ID
+
+		if skill.InputModes != nil {
+			skillMap["inputModes"] = skill.InputModes
+		} else {
+			skillMap["inputModes"] = []string{}
+		}
+
+		skillMap["name"] = skill.Name
+		if skill.OutputModes != nil {
+			skillMap["outputModes"] = skill.OutputModes
+		} else {
+			skillMap["outputModes"] = []string{}
+		}
+
+		if skill.Tags != nil {
+			skillMap["tags"] = skill.Tags
+		} else {
+			skillMap["tags"] = []string{}
+		}
+
+		skills[i] = skillMap
+	}
+
+	return providers.A2AAgentCard{
+		Capabilities:                      capabilities,
+		Defaultinputmodes:                 agentCard.DefaultInputModes,
+		Defaultoutputmodes:                agentCard.DefaultOutputModes,
+		Description:                       agentCard.Description,
+		Documentationurl:                  agentCard.DocumentationURL,
+		Iconurl:                           agentCard.IconURL,
+		ID:                                generateAgentID(agentURL),
+		Name:                              agentCard.Name,
+		Provider:                          provider,
+		Security:                          security,
+		Securityschemes:                   securitySchemes,
+		Skills:                            skills,
+		Supportsauthenticatedextendedcard: agentCard.SupportsAuthenticatedExtendedCard,
+		Url:                               agentCard.URL,
+		Version:                           agentCard.Version,
+	}
 }
 
 // filterModelsByAllowList filters models based on the comma-separated ALLOWED_MODELS configuration.
@@ -855,4 +1043,11 @@ func (router *RouterImpl) isModelAllowed(modelID string, allowedModels string) b
 	}
 
 	return false
+}
+
+// generateAgentID creates a unique identifier for an agent based on its URL
+// Uses SHA256 hash of the URL encoded as base64 for deterministic, unique IDs
+func generateAgentID(agentURL string) string {
+	hash := sha256.Sum256([]byte(agentURL))
+	return base64.StdEncoding.EncodeToString(hash[:])
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -224,6 +224,7 @@ func main() {
 	{
 		v1.GET("/models", api.ListModelsHandler)
 		v1.GET("/a2a/agents", api.ListAgentsHandler)
+		v1.GET("/a2a/agents/:id", api.GetAgentHandler)
 		v1.GET("/mcp/tools", api.ListToolsHandler)
 		v1.POST("/chat/completions", api.ChatCompletionsHandler)
 	}

--- a/internal/openapi/openapi.go
+++ b/internal/openapi/openapi.go
@@ -104,8 +104,8 @@ type OpenAPISchema struct {
 			MCPTool                               SchemaProperty `yaml:"MCPTool"`
 			MCPNotExposed                         SchemaProperty `yaml:"MCPNotExposed"`
 			ListAgentsResponse                    SchemaProperty `yaml:"ListAgentsResponse"`
-			A2AItem                               SchemaProperty `yaml:"A2AItem"`
 			A2ANotExposed                         SchemaProperty `yaml:"A2ANotExposed"`
+			A2AAgentCard                          SchemaProperty `yaml:"A2AAgentCard"`
 		}
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -202,6 +202,42 @@ paths:
           $ref: "#/components/responses/A2ANotExposed"
         "500":
           $ref: "#/components/responses/InternalError"
+  /a2a/agents/{id}:
+    get:
+      operationId: getAgent
+      tags:
+        - A2A
+      description: |
+        Gets a specific A2A agent by its unique identifier. Only accessible when EXPOSE_A2A is enabled.
+      summary: Gets a specific A2A agent by ID
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The unique identifier of the agent
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/A2AAgentCard"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/A2ANotExposed"
+        "404":
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        "500":
+          $ref: "#/components/responses/InternalError"
   /proxy/{provider}/{path}:
     parameters:
       - name: provider
@@ -740,12 +776,92 @@ components:
         data:
           type: array
           items:
-            $ref: "#/components/schemas/A2AItem"
+            $ref: "#/components/schemas/A2AAgentCard"
           default: []
           description: Array of available A2A agents
       required:
         - object
         - data
+    A2AAgentCard:
+      description: |-
+        An AgentCard conveys key information:
+        - Overall details (version, name, description, uses)
+        - Skills: A set of capabilities the agent can perform
+        - Default modalities/content types supported by the agent.
+        - Authentication requirements
+      properties:
+        capabilities:
+          additionalProperties: true
+          description: Optional capabilities supported by the agent.
+        defaultInputModes:
+          description: |-
+            The set of interaction modes that the agent supports across all skills. This can be overridden per-skill.
+            Supported media types for input.
+          items:
+            type: string
+          type: array
+        defaultOutputModes:
+          description: Supported media types for output.
+          items:
+            type: string
+          type: array
+        description:
+          description: |-
+            A human-readable description of the agent. Used to assist users and
+            other agents in understanding what the agent can do.
+          type: string
+        documentationUrl:
+          description: A URL to documentation for the agent.
+          type: string
+        iconUrl:
+          description: A URL to an icon for the agent.
+          type: string
+        id:
+          description: Unique identifier for the agent (base64-encoded SHA256 hash of the agent URL).
+          type: string
+        name:
+          description: Human readable name of the agent.
+          type: string
+        provider:
+          additionalProperties: true
+          description: The service provider of the agent
+        security:
+          description: Security requirements for contacting the agent.
+          items:
+            additionalProperties: true
+            type: object
+          type: array
+        securitySchemes:
+          additionalProperties: true
+          description: Security scheme details used for authenticating with this agent.
+          type: object
+        skills:
+          description: Skills are a unit of capability that an agent can perform.
+          items:
+            additionalProperties: true
+          type: array
+        supportsAuthenticatedExtendedCard:
+          description: |-
+            true if the agent supports providing an extended agent card when the user is authenticated.
+            Defaults to false if not specified.
+          type: boolean
+        url:
+          description: A URL to the address the agent is hosted at.
+          type: string
+        version:
+          description: The version of the agent - format is up to the provider.
+          type: string
+      required:
+        - capabilities
+        - defaultInputModes
+        - defaultOutputModes
+        - description
+        - id
+        - name
+        - skills
+        - url
+        - version
+      type: object
     MCPTool:
       type: object
       description: An MCP tool definition
@@ -777,26 +893,6 @@ components:
         - name
         - description
         - server
-    A2AItem:
-      type: object
-      description: An item in the A2A list
-      properties:
-        id:
-          type: string
-          description: The ID of the item
-        name:
-          type: string
-          description: The name of the item
-        description:
-          type: string
-          description: A description of the item
-        url:
-          type: string
-          format: uri
-          description: The URL of the item
-      required:
-        - id
-        - name
     FunctionObject:
       type: object
       properties:

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -97,12 +97,23 @@ type ListModelsTransformer interface {
 	Transform() ListModelsResponse
 }
 
-// A2AItem represents a A2AItem in the API
-type A2AItem struct {
-	Description *string `json:"description,omitempty"`
-	ID          string  `json:"id"`
-	Name        string  `json:"name"`
-	Url         *string `json:"url,omitempty"`
+// A2AAgentCard represents a A2AAgentCard in the API
+type A2AAgentCard struct {
+	Capabilities                      map[string]interface{}    `json:"capabilities"`
+	Defaultinputmodes                 []string                  `json:"defaultInputModes"`
+	Defaultoutputmodes                []string                  `json:"defaultOutputModes"`
+	Description                       string                    `json:"description"`
+	Documentationurl                  *string                   `json:"documentationUrl,omitempty"`
+	Iconurl                           *string                   `json:"iconUrl,omitempty"`
+	ID                                string                    `json:"id"`
+	Name                              string                    `json:"name"`
+	Provider                          *map[string]interface{}   `json:"provider,omitempty"`
+	Security                          *[]map[string]interface{} `json:"security,omitempty"`
+	Securityschemes                   *map[string]interface{}   `json:"securitySchemes,omitempty"`
+	Skills                            []map[string]interface{}  `json:"skills"`
+	Supportsauthenticatedextendedcard *bool                     `json:"supportsAuthenticatedExtendedCard,omitempty"`
+	Url                               string                    `json:"url"`
+	Version                           string                    `json:"version"`
 }
 
 // ChatCompletionChoice represents a ChatCompletionChoice in the API
@@ -226,8 +237,8 @@ type FunctionParameters map[string]interface{}
 
 // ListAgentsResponse represents a ListAgentsResponse in the API
 type ListAgentsResponse struct {
-	Data   []A2AItem `json:"data"`
-	Object string    `json:"object"`
+	Data   []A2AAgentCard `json:"data"`
+	Object string         `json:"object"`
 }
 
 // ListModelsResponse represents a ListModelsResponse in the API

--- a/tests/api_routes_test.go
+++ b/tests/api_routes_test.go
@@ -8,17 +8,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/inference-gateway/inference-gateway/a2a"
-	"github.com/inference-gateway/inference-gateway/api"
-	"github.com/inference-gateway/inference-gateway/config"
-	"github.com/inference-gateway/inference-gateway/logger"
-	"github.com/inference-gateway/inference-gateway/providers"
+	gin "github.com/gin-gonic/gin"
+	a2a "github.com/inference-gateway/inference-gateway/a2a"
+	api "github.com/inference-gateway/inference-gateway/api"
+	config "github.com/inference-gateway/inference-gateway/config"
+	logger "github.com/inference-gateway/inference-gateway/logger"
+	providers "github.com/inference-gateway/inference-gateway/providers"
 	a2amocks "github.com/inference-gateway/inference-gateway/tests/mocks/a2a"
 	providersmocks "github.com/inference-gateway/inference-gateway/tests/mocks/providers"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
 )
 
 func init() {
@@ -469,7 +469,7 @@ func TestListAgentsHandler(t *testing.T) {
 		a2aClientNil         bool
 		a2aClientInitialized bool
 		agentURLs            []string
-		agentCards           map[string]*providers.A2AItem
+		agentCards           map[string]*a2a.AgentCard
 		agentCardErrors      map[string]error
 		expectedStatus       int
 		expectedError        string
@@ -513,12 +513,11 @@ func TestListAgentsHandler(t *testing.T) {
 			a2aExpose:            true,
 			a2aClientInitialized: true,
 			agentURLs:            []string{"https://agent1.example.com"},
-			agentCards: map[string]*providers.A2AItem{
+			agentCards: map[string]*a2a.AgentCard{
 				"https://agent1.example.com": {
-					ID:          "https://agent1.example.com",
 					Name:        "Calculator Agent",
-					Description: stringPtr("An agent that can perform mathematical calculations"),
-					Url:         stringPtr("https://agent1.example.com"),
+					Description: "An agent that can perform mathematical calculations",
+					URL:         "https://agent1.example.com",
 				},
 			},
 			expectedStatus:     http.StatusOK,
@@ -530,18 +529,16 @@ func TestListAgentsHandler(t *testing.T) {
 			a2aExpose:            true,
 			a2aClientInitialized: true,
 			agentURLs:            []string{"https://agent1.example.com", "https://agent2.example.com"},
-			agentCards: map[string]*providers.A2AItem{
+			agentCards: map[string]*a2a.AgentCard{
 				"https://agent1.example.com": {
-					ID:          "https://agent1.example.com",
 					Name:        "Calculator Agent",
-					Description: stringPtr("An agent that can perform mathematical calculations"),
-					Url:         stringPtr("https://agent1.example.com"),
+					Description: "An agent that can perform mathematical calculations",
+					URL:         "https://agent1.example.com",
 				},
 				"https://agent2.example.com": {
-					ID:          "https://agent2.example.com",
 					Name:        "Weather Agent",
-					Description: stringPtr("An agent that provides weather information"),
-					Url:         stringPtr("https://agent2.example.com"),
+					Description: "An agent that provides weather information",
+					URL:         "https://agent2.example.com",
 				},
 			},
 			expectedStatus:     http.StatusOK,
@@ -553,12 +550,11 @@ func TestListAgentsHandler(t *testing.T) {
 			a2aExpose:            true,
 			a2aClientInitialized: true,
 			agentURLs:            []string{"https://agent1.example.com", "https://agent2.example.com"},
-			agentCards: map[string]*providers.A2AItem{
+			agentCards: map[string]*a2a.AgentCard{
 				"https://agent1.example.com": {
-					ID:          "https://agent1.example.com",
 					Name:        "Calculator Agent",
-					Description: stringPtr("An agent that can perform mathematical calculations"),
-					Url:         stringPtr("https://agent1.example.com"),
+					Description: "An agent that can perform mathematical calculations",
+					URL:         "https://agent1.example.com",
 				},
 			},
 			agentCardErrors: map[string]error{
@@ -613,7 +609,7 @@ func TestListAgentsHandler(t *testing.T) {
 						if agentCard, exists := tt.agentCards[agentURL]; exists {
 							mockAgentCard := &a2a.AgentCard{
 								Name:        agentCard.Name,
-								Description: *agentCard.Description,
+								Description: agentCard.Description,
 							}
 							mockA2AClient.EXPECT().
 								GetAgentCard(gomock.Any(), agentURL).

--- a/tests/mocks/routes.go
+++ b/tests/mocks/routes.go
@@ -52,6 +52,18 @@ func (mr *MockRouterMockRecorder) ChatCompletionsHandler(c any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChatCompletionsHandler", reflect.TypeOf((*MockRouter)(nil).ChatCompletionsHandler), c)
 }
 
+// GetAgentHandler mocks base method.
+func (m *MockRouter) GetAgentHandler(c *gin.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "GetAgentHandler", c)
+}
+
+// GetAgentHandler indicates an expected call of GetAgentHandler.
+func (mr *MockRouterMockRecorder) GetAgentHandler(c any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAgentHandler", reflect.TypeOf((*MockRouter)(nil).GetAgentHandler), c)
+}
+
 // HealthcheckHandler mocks base method.
 func (m *MockRouter) HealthcheckHandler(c *gin.Context) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Summary

This pull request provides a way to fetch all a2a agents cards, stored in the cache (retrieved only once, on server startup) and retrieve a single agent card by its ID. It also includes a basic test for the new functionality.

Will refactor it later, for now I'll just copy the data structure from the a2a schema with only the relevant fields, the rest will keep unstructured data.
