### PR TITLE
feat: Add dynamic config reloading with SIGHUP signals

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -7,6 +7,7 @@
 | ENABLE_TELEMETRY | `false` | Enable telemetry |
 | ENABLE_AUTH | `false` | Enable authentication |
 | ALLOWED_MODELS | `""` | Comma-separated list of models to allow. If empty, all models will be available |
+| CONFIG_FILE_PATH | `/app/.env` | Path to the configuration file |
 
 
 ### Model Context Protocol (MCP)

--- a/charts/inference-gateway/templates/configmap-defaults.yaml
+++ b/charts/inference-gateway/templates/configmap-defaults.yaml
@@ -10,6 +10,7 @@ data:
   ENABLE_TELEMETRY: {{ .Values.config.ENABLE_TELEMETRY | quote }}
   ENABLE_AUTH: {{ .Values.config.ENABLE_AUTH | quote }}
   ALLOWED_MODELS: {{ .Values.config.ALLOWED_MODELS | quote }}
+  CONFIG_FILE_PATH: {{ .Values.config.CONFIG_FILE_PATH | quote }}
   # Model Context Protocol (MCP)
   MCP_ENABLE: {{ .Values.config.MCP_ENABLE | quote }}
   MCP_EXPOSE: {{ .Values.config.MCP_EXPOSE | quote }}

--- a/charts/inference-gateway/values.yaml
+++ b/charts/inference-gateway/values.yaml
@@ -142,6 +142,7 @@ config:
   ENABLE_TELEMETRY: "false"
   ENABLE_AUTH: "false"
   ALLOWED_MODELS: ""
+  CONFIG_FILE_PATH: "/app/.env"
   # Model Context Protocol (MCP)
   MCP_ENABLE: "false"
   MCP_EXPOSE: "false"

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -293,6 +293,8 @@ func main() {
 	}
 }
 
+// reloadConfig reloads the configuration from environment variables
+// TODO - I need to allow also configurations from file, so I can mount a configmap to the container and reload it without restarting the container
 func reloadConfig(logger l.Logger) (config.Config, error) {
 	cfg, err := config.Load(envconfig.OsLookuper())
 	if err != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -268,7 +268,8 @@ func main() {
 			<-hupChan
 			logger.Info("received SIGHUP signal, reloading config...")
 
-			newCfg, err := reloadConfig(logger)
+			currentCfg := configValue.Load().(*config.Config)
+			newCfg, err := config.Reload(logger, currentCfg.ConfigFilePath)
 			if err != nil {
 				logger.Error("config reload failed", err)
 				continue
@@ -291,17 +292,4 @@ func main() {
 	} else {
 		logger.Info("server gracefully stopped")
 	}
-}
-
-// reloadConfig reloads the configuration from environment variables
-// TODO - I need to allow also configurations from file, so I can mount a configmap to the container and reload it without restarting the container
-func reloadConfig(logger l.Logger) (config.Config, error) {
-	cfg, err := config.Load(envconfig.OsLookuper())
-	if err != nil {
-		logger.Error("failed to reload config", err)
-		return config.Config{}, err
-	}
-	logger.Info("configuration reloaded via SIGHUP")
-	logger.Debug("new config", "config", cfg.String())
-	return cfg, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,7 @@ type ClientConfig struct {
 	ExpectContinueTimeout time.Duration `env:"EXPECT_CONTINUE_TIMEOUT, default=1s" description:"Expect continue timeout"`
 }
 
+// Load is a convenience way to call Config.Load with a default os lookuper.
 func Load(lookuper envconfig.Lookuper) (Config, error) {
 	var config Config
 	cfg, err := config.Load(lookuper); 

--- a/config/config.go
+++ b/config/config.go
@@ -89,6 +89,16 @@ type ClientConfig struct {
 	ExpectContinueTimeout time.Duration `env:"EXPECT_CONTINUE_TIMEOUT, default=1s" description:"Expect continue timeout"`
 }
 
+func Load(lookuper envconfig.Lookuper) (Config, error) {
+	var config Config
+	cfg, err := config.Load(lookuper); 
+	if err != nil {
+		return Config{}, fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	return cfg, nil
+}
+
 // Load configuration
 func (cfg *Config) Load(lookuper envconfig.Lookuper) (Config, error) {
 	if err := envconfig.ProcessWith(context.Background(), &envconfig.Config{

--- a/config/config.go
+++ b/config/config.go
@@ -2,12 +2,15 @@
 package config
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/inference-gateway/inference-gateway/logger"
 	"github.com/inference-gateway/inference-gateway/providers"
 	"github.com/sethvargo/go-envconfig"
 )
@@ -19,6 +22,7 @@ type Config struct {
 	EnableTelemetry bool   `env:"ENABLE_TELEMETRY, default=false" description:"Enable telemetry"`
 	EnableAuth      bool   `env:"ENABLE_AUTH, default=false" description:"Enable authentication"`
 	AllowedModels   string `env:"ALLOWED_MODELS" description:"Comma-separated list of models to allow. If empty, all models will be available"`
+	ConfigFilePath  string `env:"CONFIG_FILE_PATH, default=/app/.env" description:"Path to the configuration file"`
 	// MCP settings
 	MCP *MCPConfig `env:", prefix=MCP_" description:"MCP configuration"`
 	// A2A settings
@@ -92,7 +96,7 @@ type ClientConfig struct {
 // Load is a convenience way to call Config.Load with a default os lookuper.
 func Load(lookuper envconfig.Lookuper) (Config, error) {
 	var config Config
-	cfg, err := config.Load(lookuper); 
+	cfg, err := config.Load(lookuper)
 	if err != nil {
 		return Config{}, fmt.Errorf("failed to load configuration: %w", err)
 	}
@@ -137,6 +141,28 @@ func (cfg *Config) Load(lookuper envconfig.Lookuper) (Config, error) {
 	return *cfg, nil
 }
 
+// TODO - move the logic of validation to this function and ensure this one is called - add it to the codgen after finalized
+func (cfg *Config) Validate() error {
+	// Validate MCP configuration
+	if cfg.MCP != nil {
+		if cfg.MCP.Enable && cfg.MCP.Servers == "" {
+			return fmt.Errorf("MCP servers must be specified when MCP is enabled")
+		}
+	}
+
+	// Validate A2A configuration
+	if cfg.A2A != nil && cfg.A2A.Enable && cfg.A2A.Agents == "" {
+		return fmt.Errorf("A2A agents must be specified when A2A is enabled")
+	}
+
+	// Validate OIDC configuration
+	if cfg.OIDC != nil && (cfg.OIDC.IssuerUrl == "" || cfg.OIDC.ClientId == "") {
+		return fmt.Errorf("OIDC issuer URL and client ID must be specified")
+	}
+
+	return nil
+}
+
 // The string representation of Config
 func (cfg *Config) String() string {
 	return fmt.Sprintf(
@@ -154,4 +180,67 @@ func (cfg *Config) String() string {
 		cfg.Client,
 		cfg.Providers,
 	)
+}
+
+// Reload reloads the configuration from environment variables and a given env file path
+func Reload(logger logger.Logger, envFilePath string) (Config, error) {
+	if envFilePath == "" {
+		envFilePath = ".env"
+	}
+	fileLookuper, err := NewFileLookuperFromEnvFile(envFilePath)
+	if err != nil {
+		panic(err)
+	}
+
+	cfg, err := Load(envconfig.MultiLookuper(
+		envconfig.OsLookuper(),
+		fileLookuper,
+	))
+
+	if err != nil {
+		logger.Error("failed to reload config", err)
+		return Config{}, err
+	}
+	logger.Info("configuration reloaded via SIGHUP")
+	logger.Debug("new config", "config", cfg.String())
+	return cfg, nil
+}
+
+type FileLookuper struct {
+	data map[string]string
+}
+
+// NewFileLookuperFromEnvFile creates a new envconfig.Lookuper that reads from a file
+func NewFileLookuperFromEnvFile(path string) (envconfig.Lookuper, error) {
+	data := map[string]string{}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			val := strings.TrimSpace(parts[1])
+			data[key] = val
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return &FileLookuper{data: data}, nil
+}
+
+// Lookup retrieves the value for a given key from the file lookuper
+func (f *FileLookuper) Lookup(key string) (string, bool) {
+	v, ok := f.data[key]
+	return v, ok
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -25,6 +25,7 @@ func TestLoad(t *testing.T) {
 				Environment:     "production",
 				EnableAuth:      false,
 				AllowedModels:   "",
+				ConfigFilePath:  "/app/.env",
 				MCP: &config.MCPConfig{
 					Enable:                false,
 					Expose:                false,
@@ -149,6 +150,7 @@ func TestLoad(t *testing.T) {
 			env: map[string]string{
 				"ENABLE_TELEMETRY":     "true",
 				"ENVIRONMENT":          "development",
+				"CONFIG_FILE_PATH":     "/.env",
 				"SERVER_HOST":          "localhost",
 				"SERVER_PORT":          "9090",
 				"SERVER_READ_TIMEOUT":  "60s",
@@ -163,6 +165,7 @@ func TestLoad(t *testing.T) {
 				Environment:     "development",
 				EnableAuth:      false,
 				AllowedModels:   "",
+				ConfigFilePath:  "/.env",
 				MCP: &config.MCPConfig{
 					Enable:                false,
 					Expose:                false,
@@ -289,6 +292,7 @@ func TestLoad(t *testing.T) {
 			env: map[string]string{
 				"ENABLE_TELEMETRY": "true",
 				"ENVIRONMENT":      "development",
+				"CONFIG_FILE_PATH": "/tmp/.env",
 				"OLLAMA_API_URL":   "http://custom-ollama:8080",
 			},
 			expectedCfg: config.Config{
@@ -296,6 +300,7 @@ func TestLoad(t *testing.T) {
 				Environment:     "development",
 				EnableAuth:      false,
 				AllowedModels:   "",
+				ConfigFilePath:  "/tmp/.env",
 				MCP: &config.MCPConfig{
 					Enable:                false,
 					Expose:                false,

--- a/examples/docker-compose/a2a/.env.example
+++ b/examples/docker-compose/a2a/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/authentication/.env.example
+++ b/examples/docker-compose/authentication/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/basic/.env.example
+++ b/examples/docker-compose/basic/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/hybrid/.env.example
+++ b/examples/docker-compose/hybrid/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/mcp/.env.example
+++ b/examples/docker-compose/mcp/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/tools/.env.example
+++ b/examples/docker-compose/tools/.env.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/examples/docker-compose/ui/.env.backend.example
+++ b/examples/docker-compose/ui/.env.backend.example
@@ -4,6 +4,7 @@ ENVIRONMENT=production
 ENABLE_TELEMETRY=false
 ENABLE_AUTH=false
 ALLOWED_MODELS=
+CONFIG_FILE_PATH=/app/.env
 # Model Context Protocol (MCP)
 MCP_ENABLE=false
 MCP_EXPOSE=false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1348,6 +1348,11 @@ components:
                   type: string
                   default: ""
                   description: "Comma-separated list of models to allow. If empty, all models will be available"
+                - name: config_file_path
+                  env: "CONFIG_FILE_PATH"
+                  type: string
+                  default: "/app/.env"
+                  description: "Path to the configuration file"
           - mcp:
               title: "Model Context Protocol (MCP)"
               settings:


### PR DESCRIPTION
## Summary

This pull request aims to improve the application uptime by implementing a mechanism to reload configurations without requiring a full application restart. This is particularly useful for applications that need to adapt to changing environments or configurations dynamically.

### TODOs

- [ ] Ensure there is enough validation before reloading configurations, if the configurations is not valid it should not be reloaded.
- [ ] Attempt to make as little changes to the environment as possible, perhaps support both environment variables and configuration files, if there is a configuration file it should take precedence over environment variables. This way it's not breaking existing application that rely on environment variables. The configuration as files would be useful for the operator so it can be mounted in a container.
