### PR TITLE
feat(metrics): Add comprehensive function/tool call metrics

### DIFF
--- a/a2a/agent.go
+++ b/a2a/agent.go
@@ -12,6 +12,7 @@ import (
 	"github.com/inference-gateway/a2a/adk"
 	"github.com/inference-gateway/inference-gateway/config"
 	"github.com/inference-gateway/inference-gateway/logger"
+	"github.com/inference-gateway/inference-gateway/otel"
 	"github.com/inference-gateway/inference-gateway/providers"
 )
 
@@ -44,16 +45,18 @@ type agentImpl struct {
 	provider  providers.IProvider
 	model     *string
 	a2aConfig *config.A2AConfig
+	telemetry otel.OpenTelemetry
 }
 
 // NewAgent creates a new Agent instance
-func NewAgent(logger logger.Logger, a2aClient A2AClientInterface, a2aConfig *config.A2AConfig) Agent {
+func NewAgent(logger logger.Logger, a2aClient A2AClientInterface, a2aConfig *config.A2AConfig, telemetry otel.OpenTelemetry) Agent {
 	return &agentImpl{
 		a2aClient: a2aClient,
 		logger:    logger,
 		provider:  nil,
 		model:     nil,
 		a2aConfig: a2aConfig,
+		telemetry: telemetry,
 	}
 }
 
@@ -332,6 +335,21 @@ func (a *agentImpl) processToolCall(ctx context.Context, request *providers.Crea
 	var result providers.Message
 	var err error
 
+	// Record metrics for tool call
+	providerName := "unknown"
+	modelName := "unknown"
+	if a.provider != nil {
+		providerName = a.provider.GetName()
+	}
+	if a.model != nil {
+		modelName = *a.model
+	}
+
+	startTime := time.Now()
+	if a.telemetry != nil {
+		a.telemetry.RecordToolCallCount(ctx, providerName, modelName, "a2a", toolCall.Function.Name)
+	}
+
 	switch toolCall.Function.Name {
 	case ToolQueryAgentCard:
 		result, err = a.handleAgentQueryTool(ctx, toolCall)
@@ -347,13 +365,23 @@ func (a *agentImpl) processToolCall(ctx context.Context, request *providers.Crea
 		return result
 	}
 
+	duration := float64(time.Since(startTime).Milliseconds())
+	if a.telemetry != nil {
+		a.telemetry.RecordToolCallDuration(ctx, providerName, modelName, "a2a", toolCall.Function.Name, duration)
+	}
+
 	if err != nil {
 		a.logger.Error("failed to process tool call", err, "function_name", toolCall.Function.Name)
+		if a.telemetry != nil {
+			a.telemetry.RecordToolCallFailure(ctx, providerName, modelName, "a2a", toolCall.Function.Name, "processing_error")
+		}
 		result = providers.Message{
 			Role:       providers.MessageRoleTool,
 			Content:    fmt.Sprintf("Error processing %s: %s", toolCall.Function.Name, err.Error()),
 			ToolCallId: &toolCall.ID,
 		}
+	} else if a.telemetry != nil {
+		a.telemetry.RecordToolCallSuccess(ctx, providerName, modelName, "a2a", toolCall.Function.Name)
 	}
 
 	return result

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -151,11 +151,11 @@ func main() {
 			}
 			logger.Info("mcp client initialized successfully")
 			// Create MCP agent with the initialized client
-			mcpAgent = mcp.NewAgent(logger, mcpClient)
+			mcpAgent = mcp.NewAgent(logger, mcpClient, telemetryImpl)
 			logger.Info("mcp agent created successfully")
 		} else {
 			logger.Info("mcp is enabled but no servers configured, using no-op middleware")
-			mcpAgent = mcp.NewAgent(logger, mcpClient)
+			mcpAgent = mcp.NewAgent(logger, mcpClient, telemetryImpl)
 		}
 		mcpMiddleware, err = middlewares.NewMCPMiddleware(providerRegistry, client, mcpClient, mcpAgent, logger, cfg)
 		if err != nil {
@@ -187,7 +187,7 @@ func main() {
 			logger.Info("a2a is enabled but no agents configured")
 		}
 
-		a2aAgent := a2a.NewAgent(logger, a2aClient, cfg.A2A)
+		a2aAgent := a2a.NewAgent(logger, a2aClient, cfg.A2A, telemetryImpl)
 		a2aMiddleware, err = middlewares.NewA2AMiddleware(providerRegistry, a2aClient, a2aAgent, logger, client, cfg)
 		if err != nil {
 			logger.Error("failed to initialize a2a middleware", err)

--- a/mcp/agent.go
+++ b/mcp/agent.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/inference-gateway/inference-gateway/logger"
+	"github.com/inference-gateway/inference-gateway/otel"
 	"github.com/inference-gateway/inference-gateway/providers"
 )
 
@@ -35,15 +37,17 @@ type agentImpl struct {
 	mcpClient MCPClientInterface
 	provider  providers.IProvider
 	model     *string
+	telemetry otel.OpenTelemetry
 }
 
 // NewAgent creates a new Agent instance
-func NewAgent(logger logger.Logger, mcpClient MCPClientInterface) Agent {
+func NewAgent(logger logger.Logger, mcpClient MCPClientInterface, telemetry otel.OpenTelemetry) Agent {
 	return &agentImpl{
 		mcpClient: mcpClient,
 		logger:    logger,
 		provider:  nil,
 		model:     nil,
+		telemetry: telemetry,
 	}
 }
 
@@ -307,15 +311,44 @@ func (a *agentImpl) ExecuteTools(ctx context.Context, toolCalls []providers.Chat
 		}
 
 		a.logger.Info("executing tool call", "tool_call", fmt.Sprintf("id=%s name=%s args=%v server=%s", toolCall.ID, toolCall.Function.Name, args, server))
+
+		// Record metrics for tool call
+		providerName := "unknown"
+		modelName := "unknown"
+		if a.provider != nil {
+			providerName = a.provider.GetName()
+		}
+		if a.model != nil {
+			modelName = *a.model
+		}
+
+		startTime := time.Now()
+		if a.telemetry != nil {
+			a.telemetry.RecordToolCallCount(ctx, providerName, modelName, "mcp", toolCall.Function.Name)
+		}
+
 		result, err := a.mcpClient.ExecuteTool(ctx, mcpRequest, server)
+		duration := float64(time.Since(startTime).Milliseconds())
+
+		if a.telemetry != nil {
+			a.telemetry.RecordToolCallDuration(ctx, providerName, modelName, "mcp", toolCall.Function.Name, duration)
+		}
+
 		if err != nil {
 			a.logger.Error("failed to execute tool call", err, "tool", toolCall.Function.Name, "server", server)
+			if a.telemetry != nil {
+				a.telemetry.RecordToolCallFailure(ctx, providerName, modelName, "mcp", toolCall.Function.Name, "execution_error")
+			}
 			results = append(results, providers.Message{
 				Role:       providers.MessageRoleTool,
 				Content:    fmt.Sprintf("Error: %v", err),
 				ToolCallId: &toolCall.ID,
 			})
 			continue
+		}
+
+		if a.telemetry != nil {
+			a.telemetry.RecordToolCallSuccess(ctx, providerName, modelName, "mcp", toolCall.Function.Name)
 		}
 
 		var resultStr string

--- a/tests/a2a_streaming_test.go
+++ b/tests/a2a_streaming_test.go
@@ -75,7 +75,7 @@ func TestA2AAgent_StreamingCapabilityDetection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			agent := a2a.NewAgent(mockLogger, mockA2AClient, a2aConfig)
+			agent := a2a.NewAgent(mockLogger, mockA2AClient, a2aConfig, nil)
 
 			mockA2AClient.EXPECT().GetAgentCapabilities().Return(tt.agentCapabilities).Times(1)
 
@@ -103,7 +103,7 @@ func TestA2AAgent_StreamingFallback(t *testing.T) {
 		PollingTimeout:  time.Second * 10,
 	}
 
-	agent := a2a.NewAgent(mockLogger, mockA2AClient, a2aConfig)
+	agent := a2a.NewAgent(mockLogger, mockA2AClient, a2aConfig, nil)
 
 	t.Run("SendStreamingMessage method exists and can be called", func(t *testing.T) {
 		streamingRequest := &adk.SendStreamingMessageRequest{

--- a/tests/mcp_agent_test.go
+++ b/tests/mcp_agent_test.go
@@ -50,7 +50,7 @@ func TestNewAgent(t *testing.T) {
 			mockLogger := mocks.NewMockLogger(ctrl)
 			mockMCPClient := mcpmocks.NewMockMCPClientInterface(ctrl)
 
-			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient)
+			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 
 			if tt.expectAgent {
 				assert.NotNil(t, agentInstance)
@@ -264,7 +264,7 @@ func TestAgent_Run(t *testing.T) {
 
 			tt.setupMocks(mockLogger, mockMCPClient, mockProvider)
 
-			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient)
+			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			agentInstance.SetProvider(mockProvider)
 			agentInstance.SetModel(&tt.request.Model)
 
@@ -487,7 +487,7 @@ func TestAgent_ExecuteTools(t *testing.T) {
 
 			tt.setupMocks(mockLogger, mockMCPClient, mockProvider)
 
-			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient)
+			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 
 			results, err := agentInstance.ExecuteTools(context.Background(), tt.toolCalls)
 
@@ -876,7 +876,7 @@ func TestAgent_RunWithStream(t *testing.T) {
 
 			tt.setupMocks(mockLogger, mockMCPClient, mockProvider)
 
-			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient)
+			agentInstance := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			agentInstance.SetProvider(mockProvider)
 			agentInstance.SetModel(&tt.request.Model)
 

--- a/tests/middlewares/mcp_test.go
+++ b/tests/middlewares/mcp_test.go
@@ -82,7 +82,7 @@ func TestNewMCPMiddleware(t *testing.T) {
 				mockLogger.EXPECT().Info("mcp client is nil, using no-op middleware")
 			}
 
-			mcpAgent := mcp.NewAgent(mockLogger, tt.mcpClient)
+			mcpAgent := mcp.NewAgent(mockLogger, tt.mcpClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, tt.mcpClient, mcpAgent, mockLogger, cfg)
 
 			if tt.expectError {
@@ -149,7 +149,7 @@ func TestMCPMiddleware_SkipConditions(t *testing.T) {
 				tt.setupMocks(mockRegistry, mockClient, mockMCPClient, mockLogger, mockProvider)
 			}
 
-			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 			assert.NoError(t, err)
 
@@ -267,7 +267,7 @@ func TestMCPMiddleware_AddToolsToRequest(t *testing.T) {
 
 			requestBody, _ := json.Marshal(requestData)
 
-			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 			assert.NoError(t, err)
 			router := gin.New()
@@ -446,7 +446,7 @@ func TestMCPMiddleware_NonStreamingWithToolCalls(t *testing.T) {
 
 			requestBody, _ := json.Marshal(requestData)
 
-			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 			assert.NoError(t, err)
 
@@ -558,7 +558,7 @@ data: [DONE]`,
 
 			requestBody, _ := json.Marshal(requestData)
 
-			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 			assert.NoError(t, err)
 
@@ -654,7 +654,7 @@ func TestMCPMiddleware_ErrorHandling(t *testing.T) {
 
 			tt.setupMocks(mockRegistry, mockClient, mockMCPClient, mockLogger, mockProvider)
 
-			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+			mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 			middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 			assert.NoError(t, err)
 
@@ -727,7 +727,7 @@ func TestParseStreamingToolCalls(t *testing.T) {
 	mockLogger.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
 	mockLogger.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
 
-	mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient)
+	mcpAgent := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 	middleware, err := middlewares.NewMCPMiddleware(mockRegistry, mockClient, mockMCPClient, mcpAgent, mockLogger, cfg)
 	assert.NoError(t, err)
 
@@ -807,7 +807,7 @@ func TestMCPMiddleware_StreamingWithMultipleToolCallIterations(t *testing.T) {
 			},
 		}, nil).AnyTimes()
 
-		agentImpl := mcp.NewAgent(mockLogger, mockMCPClient)
+		agentImpl := mcp.NewAgent(mockLogger, mockMCPClient, nil)
 
 		agentImpl.SetProvider(mockProvider)
 		model := "groq/meta-llama/llama-4-scout-17b-instruct"


### PR DESCRIPTION
Fixes #121

This PR adds comprehensive OpenTelemetry metrics for function/tool calls throughout the Inference Gateway.

## New Metrics

- `llm_tool_calls_total` - Counter for total function/tool calls
- `llm_tool_calls_success_total` - Counter for successful tool calls
- `llm_tool_calls_failure_total` - Counter for failed tool calls
- `llm_tool_call_duration` - Histogram for tool call execution duration

## Enhanced Tracking

- **MCP tool calls**: Tracks execution timing, success/failure rates
- **A2A tool calls**: Covers agent queries and task submissions
- **LLM responses**: Detects tool calls in both streaming and non-streaming responses

## Technical Details

- Rich labeling with provider, model, tool_type, tool_name, and error_type attributes
- Seamlessly integrated with existing OpenTelemetry/Prometheus setup
- Available on existing metrics port 9464
- No breaking changes to existing APIs

Generated with [Claude Code](https://claude.ai/code)