### PR TITLE
refactor(A2A): Refactor tool names to use consistent a2a_ prefix

### DIFF
--- a/a2a/agent.go
+++ b/a2a/agent.go
@@ -20,8 +20,8 @@ const MaxAgentIterations = 10
 
 // Supported A2A tool function names
 const (
-	ToolQueryAgentCard    = "query_a2a_agent_card"
-	ToolSubmitTaskToAgent = "submit_task_to_agent"
+	ToolQueryAgentCard    = "a2a_query_agent_card"
+	ToolSubmitTaskToAgent = "a2a_submit_task_to_agent"
 )
 
 // Agent defines the interface for running agent operations

--- a/api/middlewares/a2a.go
+++ b/api/middlewares/a2a.go
@@ -318,7 +318,7 @@ func (m *A2AMiddlewareImpl) createAgentQueryTool() providers.ChatCompletionTool 
 	return providers.ChatCompletionTool{
 		Type: providers.ChatCompletionToolTypeFunction,
 		Function: providers.FunctionObject{
-			Name:        "query_a2a_agent_card",
+			Name:        "a2a_query_agent_card",
 			Description: &description,
 			Parameters: &providers.FunctionParameters{
 				"type": "object",
@@ -349,7 +349,7 @@ func (m *A2AMiddlewareImpl) createTaskSubmissionTool() providers.ChatCompletionT
 	return providers.ChatCompletionTool{
 		Type: providers.ChatCompletionToolTypeFunction,
 		Function: providers.FunctionObject{
-			Name:        "submit_task_to_agent",
+			Name:        "a2a_submit_task_to_agent",
 			Description: &description,
 			Parameters: &providers.FunctionParameters{
 				"type": "object",

--- a/api/middlewares/a2a.go
+++ b/api/middlewares/a2a.go
@@ -318,7 +318,7 @@ func (m *A2AMiddlewareImpl) createAgentQueryTool() providers.ChatCompletionTool 
 	return providers.ChatCompletionTool{
 		Type: providers.ChatCompletionToolTypeFunction,
 		Function: providers.FunctionObject{
-			Name:        "a2a_query_agent_card",
+			Name:        a2a.ToolQueryAgentCard,
 			Description: &description,
 			Parameters: &providers.FunctionParameters{
 				"type": "object",
@@ -349,7 +349,7 @@ func (m *A2AMiddlewareImpl) createTaskSubmissionTool() providers.ChatCompletionT
 	return providers.ChatCompletionTool{
 		Type: providers.ChatCompletionToolTypeFunction,
 		Function: providers.FunctionObject{
-			Name:        "a2a_submit_task_to_agent",
+			Name:        a2a.ToolSubmitTaskToAgent,
 			Description: &description,
 			Parameters: &providers.FunctionParameters{
 				"type": "object",

--- a/examples/kubernetes/a2a/README.md
+++ b/examples/kubernetes/a2a/README.md
@@ -78,8 +78,8 @@ curl -X POST http://api.inference-gateway.local/chat/completions \
 }'
 ```
 
-7. If you view the logs of the gateway, you should see that the Gateway (as an A2A-client agent) queried the relevant agent for their card using `query_a2a_agent_card` tool call.
-8. Then it delegated the task to the correct agent using `submit_task_to_agent` tool call.
+7. If you view the logs of the gateway, you should see that the Gateway (as an A2A-client agent) queried the relevant agent for their card using `a2a_query_agent_card` tool call.
+8. Then it delegated the task to the correct agent using `a2a_submit_task_to_agent` tool call.
 9. The agent processed the request (with possible few iterations and internal tool calls) and returned the response to the Gateway, which then returned it to the user.
 
 ** If you send it as a streaming request with the headers `Accept: text/event-stream` and `Content-Type: application/json`, you will see the response in a streaming fashion. **

--- a/tests/middlewares/a2a_test.go
+++ b/tests/middlewares/a2a_test.go
@@ -345,10 +345,10 @@ func TestA2AMiddleware_AgentsAreInjectedAsTools(t *testing.T) {
 				foundAgentQueryTool := false
 				foundTaskSubmissionTool := false
 				for _, tool := range *capturedRequest.Tools {
-					if tool.Function.Name == "query_a2a_agent_card" {
+					if tool.Function.Name == "a2a_query_agent_card" {
 						foundAgentQueryTool = true
 					}
-					if tool.Function.Name == "submit_task_to_agent" {
+					if tool.Function.Name == "a2a_submit_task_to_agent" {
 						foundTaskSubmissionTool = true
 					}
 				}
@@ -382,7 +382,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_1",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "query_a2a_agent_card",
+						Name:      "a2a_query_agent_card",
 						Arguments: `{"agent_url": "http://agent1.example.com"}`,
 					},
 				},
@@ -414,12 +414,12 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 			expectedStatus:        http.StatusOK,
 		},
 		{
-			name: "LLM calls submit_task_to_agent tool - successful execution",
+			name: "LLM calls a2a_submit_task_to_agent tool - successful execution",
 			toolCalls: []providers.ChatCompletionMessageToolCall{
 				{
 					ID: "call_2",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "submit_task_to_agent",
+						Name:      "a2a_submit_task_to_agent",
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},
@@ -465,7 +465,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_3",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "submit_task_to_agent",
+						Name:      "a2a_submit_task_to_agent",
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},
@@ -488,7 +488,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_4",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "submit_task_to_agent",
+						Name:      "a2a_submit_task_to_agent",
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},

--- a/tests/middlewares/a2a_test.go
+++ b/tests/middlewares/a2a_test.go
@@ -345,10 +345,10 @@ func TestA2AMiddleware_AgentsAreInjectedAsTools(t *testing.T) {
 				foundAgentQueryTool := false
 				foundTaskSubmissionTool := false
 				for _, tool := range *capturedRequest.Tools {
-					if tool.Function.Name == "a2a_query_agent_card" {
+					if tool.Function.Name == a2a.ToolQueryAgentCard {
 						foundAgentQueryTool = true
 					}
-					if tool.Function.Name == "a2a_submit_task_to_agent" {
+					if tool.Function.Name == a2a.ToolSubmitTaskToAgent {
 						foundTaskSubmissionTool = true
 					}
 				}
@@ -382,7 +382,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_1",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "a2a_query_agent_card",
+						Name:      a2a.ToolQueryAgentCard,
 						Arguments: `{"agent_url": "http://agent1.example.com"}`,
 					},
 				},
@@ -419,7 +419,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_2",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "a2a_submit_task_to_agent",
+						Name:      a2a.ToolSubmitTaskToAgent,
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},
@@ -465,7 +465,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_3",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "a2a_submit_task_to_agent",
+						Name:      a2a.ToolSubmitTaskToAgent,
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},
@@ -488,7 +488,7 @@ func TestA2AMiddleware_LLMDecisionToSubmitTask(t *testing.T) {
 				{
 					ID: "call_4",
 					Function: providers.ChatCompletionMessageToolCallFunction{
-						Name:      "a2a_submit_task_to_agent",
+						Name:      a2a.ToolSubmitTaskToAgent,
 						Arguments: `{"agent_url": "http://agent1.example.com", "task_description": "Calculate 5+3"}`,
 					},
 				},


### PR DESCRIPTION
This PR refactors A2A tool names to use a consistent `a2a_` prefix for better parsing and context understanding in UI applications.

## Changes
- Rename `query_a2a_agent_card` to `a2a_query_agent_card`
- Rename `submit_task_to_agent` to `a2a_submit_task_to_agent`
- Updated constants, middleware, tests, and documentation

## Testing
- ✅ All tests pass
- ✅ Linting passes

Fixes #147

Generated with [Claude Code](https://claude.ai/code)