### PR TITLE
refactor(config): Refactor authentication config to use AUTH_ prefix

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -4,7 +4,6 @@
 | Environment Variable | Default Value | Description |
 |---------------------|---------------|-------------|
 | ENVIRONMENT | `production` | The environment |
-| ENABLE_AUTH | `false` | Enable authentication |
 | ALLOWED_MODELS | `""` | Comma-separated list of models to allow. If empty, all models will be available |
 
 
@@ -48,12 +47,13 @@
 | A2A_DISABLE_HEALTHCHECK_LOGS | `true` | Disable health check log messages to reduce noise |
 
 
-### OpenID Connect
+### Authentication
 | Environment Variable | Default Value | Description |
 |---------------------|---------------|-------------|
-| OIDC_ISSUER_URL | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL |
-| OIDC_CLIENT_ID | `inference-gateway-client` | OIDC client ID |
-| OIDC_CLIENT_SECRET | `""` | OIDC client secret |
+| AUTH_ENABLE | `false` | Enable authentication |
+| AUTH_OIDC_ISSUER | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL |
+| AUTH_OIDC_CLIENT_ID | `inference-gateway-client` | OIDC client ID |
+| AUTH_OIDC_CLIENT_SECRET | `""` | OIDC client secret |
 
 
 ### Server settings

--- a/api/middlewares/auth.go
+++ b/api/middlewares/auth.go
@@ -33,25 +33,25 @@ type OIDCAuthenticatorNoop struct{}
 
 // NewOIDCAuthenticatorMiddleware creates a new OIDCAuthenticator instance
 func NewOIDCAuthenticatorMiddleware(logger logger.Logger, cfg config.Config) (OIDCAuthenticator, error) {
-	if !cfg.EnableAuth {
+	if !cfg.Auth.Enable {
 		return &OIDCAuthenticatorNoop{}, nil
 	}
 
-	provider, err := oidcV3.NewProvider(context.Background(), cfg.OIDC.IssuerUrl)
+	provider, err := oidcV3.NewProvider(context.Background(), cfg.Auth.OidcIssuer)
 	if err != nil {
 		return nil, err
 	}
 
 	oidcConfig := &oidcV3.Config{
-		ClientID: cfg.OIDC.ClientId,
+		ClientID: cfg.Auth.OidcClientId,
 	}
 
 	return &OIDCAuthenticatorImpl{
 		logger:   logger,
 		verifier: provider.Verifier(oidcConfig),
 		config: oauth2.Config{
-			ClientID:     cfg.OIDC.ClientId,
-			ClientSecret: cfg.OIDC.ClientSecret,
+			ClientID:     cfg.Auth.OidcClientId,
+			ClientSecret: cfg.Auth.OidcClientSecret,
 			Endpoint:     provider.Endpoint(),
 			Scopes:       []string{oidcV3.ScopeOpenID, "profile", "email"},
 		},

--- a/charts/inference-gateway/templates/configmap-defaults.yaml
+++ b/charts/inference-gateway/templates/configmap-defaults.yaml
@@ -7,7 +7,6 @@ metadata:
 data:
   # General settings
   ENVIRONMENT: {{ .Values.config.ENVIRONMENT | quote }}
-  ENABLE_AUTH: {{ .Values.config.ENABLE_AUTH | quote }}
   ALLOWED_MODELS: {{ .Values.config.ALLOWED_MODELS | quote }}
   # Telemetry
   TELEMETRY_ENABLE: {{ .Values.config.TELEMETRY_ENABLE | quote }}
@@ -37,8 +36,9 @@ data:
   A2A_ENABLE_RECONNECT: {{ .Values.config.A2A_ENABLE_RECONNECT | quote }}
   A2A_RECONNECT_INTERVAL: {{ .Values.config.A2A_RECONNECT_INTERVAL | quote }}
   A2A_DISABLE_HEALTHCHECK_LOGS: {{ .Values.config.A2A_DISABLE_HEALTHCHECK_LOGS | quote }}
-  # OpenID Connect
-  OIDC_ISSUER_URL: {{ .Values.config.OIDC_ISSUER_URL | quote }}
+  # Authentication
+  AUTH_ENABLE: {{ .Values.config.AUTH_ENABLE | quote }}
+  AUTH_OIDC_ISSUER: {{ .Values.config.AUTH_OIDC_ISSUER | quote }}
   # Server settings
   SERVER_HOST: {{ .Values.config.SERVER_HOST | quote }}
   SERVER_PORT: {{ .Values.config.SERVER_PORT | quote }}

--- a/charts/inference-gateway/templates/secrets-defaults.yaml
+++ b/charts/inference-gateway/templates/secrets-defaults.yaml
@@ -5,9 +5,6 @@ metadata:
   labels:
     {{- include "inference-gateway.labels" . | nindent 4 }}
 stringData:
-  # OpenID Connect
-  OIDC_CLIENT_ID: ""
-  OIDC_CLIENT_SECRET: ""
   # Providers
   ANTHROPIC_API_KEY: ""
   CLOUDFLARE_API_KEY: ""

--- a/charts/inference-gateway/values.yaml
+++ b/charts/inference-gateway/values.yaml
@@ -139,7 +139,6 @@ extraEnv: []
 config:
   # General settings
   ENVIRONMENT: "production"
-  ENABLE_AUTH: "false"
   ALLOWED_MODELS: ""
   # Telemetry
   TELEMETRY_ENABLE: "false"
@@ -169,8 +168,9 @@ config:
   A2A_ENABLE_RECONNECT: "true"
   A2A_RECONNECT_INTERVAL: "30s"
   A2A_DISABLE_HEALTHCHECK_LOGS: "true"
-  # OpenID Connect
-  OIDC_ISSUER_URL: "http://keycloak:8080/realms/inference-gateway-realm"
+  # Authentication
+  AUTH_ENABLE: "false"
+  AUTH_OIDC_ISSUER: "http://keycloak:8080/realms/inference-gateway-realm"
   # Server settings
   SERVER_HOST: "0.0.0.0"
   SERVER_PORT: "8080"

--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,6 @@ import (
 type Config struct {
 	// General settings
 	Environment   string `env:"ENVIRONMENT, default=production" description:"The environment"`
-	EnableAuth    bool   `env:"ENABLE_AUTH, default=false" description:"Enable authentication"`
 	AllowedModels string `env:"ALLOWED_MODELS" description:"Comma-separated list of models to allow. If empty, all models will be available"`
 	// Telemetry settings
 	Telemetry *TelemetryConfig `env:", prefix=TELEMETRY_" description:"Telemetry configuration"`
@@ -24,8 +23,8 @@ type Config struct {
 	MCP *MCPConfig `env:", prefix=MCP_" description:"MCP configuration"`
 	// A2A settings
 	A2A *A2AConfig `env:", prefix=A2A_" description:"A2A configuration"`
-	// OIDC settings
-	OIDC *OIDC `env:", prefix=OIDC_" description:"OIDC configuration"`
+	// Authentication settings
+	Auth *AuthConfig `env:", prefix=AUTH_" description:"Authentication configuration"`
 	// Server settings
 	Server *ServerConfig `env:", prefix=SERVER_" description:"Server configuration"`
 	// Client settings
@@ -72,11 +71,12 @@ type A2AConfig struct {
 	DisableHealthcheckLogs bool          `env:"DISABLE_HEALTHCHECK_LOGS, default=true" description:"Disable health check log messages to reduce noise"`
 }
 
-// OIDC configuration
-type OIDC struct {
-	IssuerUrl    string `env:"ISSUER_URL, default=http://keycloak:8080/realms/inference-gateway-realm" description:"OIDC issuer URL"`
-	ClientId     string `env:"CLIENT_ID, default=inference-gateway-client" type:"secret" description:"OIDC client ID"`
-	ClientSecret string `env:"CLIENT_SECRET" type:"secret" description:"OIDC client secret"`
+// Authentication configuration
+type AuthConfig struct {
+	Enable           bool   `env:"ENABLE, default=false" description:"Enable authentication"`
+	OidcIssuer       string `env:"OIDC_ISSUER, default=http://keycloak:8080/realms/inference-gateway-realm" description:"OIDC issuer URL"`
+	OidcClientId     string `env:"OIDC_CLIENT_ID, default=inference-gateway-client" type:"secret" description:"OIDC client ID"`
+	OidcClientSecret string `env:"OIDC_CLIENT_SECRET" type:"secret" description:"OIDC client secret"`
 }
 
 // Server configuration
@@ -142,16 +142,15 @@ func (cfg *Config) Load(lookuper envconfig.Lookuper) (Config, error) {
 // The string representation of Config
 func (cfg *Config) String() string {
 	return fmt.Sprintf(
-		"Config{ApplicationName:%s, Version:%s Environment:%s, Telemetry:%+v, EnableAuth:%t, "+
-			"MCP:%+v, A2A:%+v, OIDC:%+v, Server:%+v, Client:%+v, Providers:%+v}",
+		"Config{ApplicationName:%s, Version:%s Environment:%s, Telemetry:%+v, "+
+			"MCP:%+v, A2A:%+v, Auth:%+v, Server:%+v, Client:%+v, Providers:%+v}",
 		APPLICATION_NAME,
 		VERSION,
 		cfg.Environment,
 		cfg.Telemetry,
-		cfg.EnableAuth,
 		cfg.MCP,
 		cfg.A2A,
-		cfg.OIDC,
+		cfg.Auth,
 		cfg.Server,
 		cfg.Client,
 		cfg.Providers,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,6 @@ func TestLoad(t *testing.T) {
 			env:  map[string]string{},
 			expectedCfg: config.Config{
 				Environment:   "production",
-				EnableAuth:    false,
 				AllowedModels: "",
 				Telemetry: &config.TelemetryConfig{
 					Enable:      false,
@@ -54,10 +53,11 @@ func TestLoad(t *testing.T) {
 					ReconnectInterval:      30 * time.Second,
 					DisableHealthcheckLogs: true,
 				},
-				OIDC: &config.OIDC{
-					IssuerUrl:    "http://keycloak:8080/realms/inference-gateway-realm",
-					ClientId:     "inference-gateway-client",
-					ClientSecret: "",
+				Auth: &config.AuthConfig{
+					Enable:           false,
+					OidcIssuer:       "http://keycloak:8080/realms/inference-gateway-realm",
+					OidcClientId:     "inference-gateway-client",
+					OidcClientSecret: "",
 				},
 				Server: &config.ServerConfig{
 					Host:         "0.0.0.0",
@@ -169,7 +169,6 @@ func TestLoad(t *testing.T) {
 			},
 			expectedCfg: config.Config{
 				Environment:   "development",
-				EnableAuth:    false,
 				AllowedModels: "",
 				Telemetry: &config.TelemetryConfig{
 					Enable:      true,
@@ -201,10 +200,11 @@ func TestLoad(t *testing.T) {
 					ReconnectInterval:      30 * time.Second,
 					DisableHealthcheckLogs: true,
 				},
-				OIDC: &config.OIDC{
-					IssuerUrl:    "http://keycloak:8080/realms/inference-gateway-realm",
-					ClientId:     "inference-gateway-client",
-					ClientSecret: "",
+				Auth: &config.AuthConfig{
+					Enable:           false,
+					OidcIssuer:       "http://keycloak:8080/realms/inference-gateway-realm",
+					OidcClientId:     "inference-gateway-client",
+					OidcClientSecret: "",
 				},
 				Server: &config.ServerConfig{
 					Host:         "localhost",
@@ -311,7 +311,6 @@ func TestLoad(t *testing.T) {
 			},
 			expectedCfg: config.Config{
 				Environment:   "development",
-				EnableAuth:    false,
 				AllowedModels: "",
 				Telemetry: &config.TelemetryConfig{
 					Enable:      true,
@@ -343,10 +342,11 @@ func TestLoad(t *testing.T) {
 					ReconnectInterval:      30 * time.Second,
 					DisableHealthcheckLogs: true,
 				},
-				OIDC: &config.OIDC{
-					IssuerUrl:    "http://keycloak:8080/realms/inference-gateway-realm",
-					ClientId:     "inference-gateway-client",
-					ClientSecret: "",
+				Auth: &config.AuthConfig{
+					Enable:           false,
+					OidcIssuer:       "http://keycloak:8080/realms/inference-gateway-realm",
+					OidcClientId:     "inference-gateway-client",
+					OidcClientSecret: "",
 				},
 				Server: &config.ServerConfig{
 					Host:         "0.0.0.0",

--- a/examples/docker-compose/a2a/.env.example
+++ b/examples/docker-compose/a2a/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/authentication/.env.example
+++ b/examples/docker-compose/authentication/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/basic/.env.example
+++ b/examples/docker-compose/basic/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/hybrid/.env.example
+++ b/examples/docker-compose/hybrid/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/mcp/.env.example
+++ b/examples/docker-compose/mcp/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/monitoring/.env.example
+++ b/examples/docker-compose/monitoring/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/tools/.env.example
+++ b/examples/docker-compose/tools/.env.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/examples/docker-compose/ui/.env.backend.example
+++ b/examples/docker-compose/ui/.env.backend.example
@@ -1,7 +1,6 @@
 
 # General settings
 ENVIRONMENT=production
-ENABLE_AUTH=false
 ALLOWED_MODELS=
 # Telemetry
 TELEMETRY_ENABLE=false
@@ -31,10 +30,11 @@ A2A_INITIAL_BACKOFF=1s
 A2A_ENABLE_RECONNECT=true
 A2A_RECONNECT_INTERVAL=30s
 A2A_DISABLE_HEALTHCHECK_LOGS=true
-# OpenID Connect
-OIDC_ISSUER_URL=http://keycloak:8080/realms/inference-gateway-realm
-OIDC_CLIENT_ID=inference-gateway-client
-OIDC_CLIENT_SECRET=
+# Authentication
+AUTH_ENABLE=false
+AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
+AUTH_OIDC_CLIENT_ID=inference-gateway-client
+AUTH_OIDC_CLIENT_SECRET=
 # Server settings
 SERVER_HOST=0.0.0.0
 SERVER_PORT=8080

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -66,9 +66,9 @@ type Config struct {
 	{{- else if eq $name "a2a" }}
 	// A2A settings
 	A2A *A2AConfig ` + "`env:\", prefix=A2A_\" description:\"A2A configuration\"`" + `
-	{{- else if eq $name "oidc" }}
-	// OIDC settings
-	OIDC *OIDC ` + "`env:\", prefix=OIDC_\" description:\"OIDC configuration\"`" + `
+	{{- else if eq $name "auth" }}
+	// Authentication settings
+	Auth *AuthConfig ` + "`env:\", prefix=AUTH_\" description:\"Authentication configuration\"`" + `
 	{{- else if eq $name "server" }}
 	// Server settings
 	Server *ServerConfig ` + "`env:\", prefix=SERVER_\" description:\"Server configuration\"`" + `
@@ -109,12 +109,12 @@ type A2AConfig struct {
 	{{ pascalCase (trimPrefix $field.Env "A2A_") }} {{ $field.Type }} ` + "`env:\"{{ trimPrefix $field.Env \"A2A_\" }}{{if $field.Default}}, default={{$field.Default}}{{end}}\" description:\"{{$field.Description}}\"`" + `
 	{{- end }}
 }
-{{- else if eq $name "oidc" }}
+{{- else if eq $name "auth" }}
 
-// OIDC configuration
-type OIDC struct {
+// Authentication configuration
+type AuthConfig struct {
 	{{- range $field := $section.Settings }}
-	{{ pascalCase (trimPrefix $field.Env "OIDC_") }} string ` + "`env:\"{{ trimPrefix $field.Env \"OIDC_\" }}{{if $field.Default}}, default={{$field.Default}}{{end}}\"{{if $field.Secret}} type:\"secret\"{{end}} description:\"{{$field.Description}}\"`" + `
+	{{ pascalCase (trimPrefix $field.Env "AUTH_") }} {{ $field.Type }} ` + "`env:\"{{ trimPrefix $field.Env \"AUTH_\" }}{{if $field.Default}}, default={{$field.Default}}{{end}}\"{{if $field.Secret}} type:\"secret\"{{end}} description:\"{{$field.Description}}\"`" + `
 	{{- end }}
 }
 {{- else if eq $name "server" }}
@@ -177,16 +177,15 @@ func (cfg *Config) Load(lookuper envconfig.Lookuper) (Config, error) {
 // The string representation of Config
 func (cfg *Config) String() string {
     return fmt.Sprintf(
-        "Config{ApplicationName:%s, Version:%s Environment:%s, Telemetry:%+v, EnableAuth:%t, "+
-            "MCP:%+v, A2A:%+v, OIDC:%+v, Server:%+v, Client:%+v, Providers:%+v}",
+        "Config{ApplicationName:%s, Version:%s Environment:%s, Telemetry:%+v, "+
+            "MCP:%+v, A2A:%+v, Auth:%+v, Server:%+v, Client:%+v, Providers:%+v}",
         APPLICATION_NAME,
         VERSION,
         cfg.Environment,
         cfg.Telemetry,
-        cfg.EnableAuth,
         cfg.MCP,
         cfg.A2A,
-        cfg.OIDC,
+        cfg.Auth,
         cfg.Server,
         cfg.Client,
         cfg.Providers,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -496,7 +496,7 @@ components:
       bearerFormat: JWT
       description: |
         Authentication is optional by default.
-        To enable authentication, set ENABLE_AUTH to true.
+        To enable authentication, set AUTH_ENABLE to true.
         When enabled, requests must include a valid JWT token in the Authorization header.
   schemas:
     Provider:
@@ -1333,11 +1333,6 @@ components:
                   type: string
                   default: "production"
                   description: "The environment"
-                - name: enable_auth
-                  env: "ENABLE_AUTH"
-                  type: bool
-                  default: "false"
-                  description: "Enable authentication"
                 - name: allowed_models
                   env: "ALLOWED_MODELS"
                   type: string
@@ -1475,22 +1470,27 @@ components:
                   type: bool
                   default: "true"
                   description: "Disable health check log messages to reduce noise"
-          - oidc:
-              title: "OpenID Connect"
+          - auth:
+              title: "Authentication"
               settings:
-                - name: issuer_url
-                  env: "OIDC_ISSUER_URL"
+                - name: auth_enable
+                  env: "AUTH_ENABLE"
+                  type: bool
+                  default: "false"
+                  description: "Enable authentication"
+                - name: auth_oidc_issuer
+                  env: "AUTH_OIDC_ISSUER"
                   type: string
                   default: "http://keycloak:8080/realms/inference-gateway-realm"
                   description: "OIDC issuer URL"
-                - name: client_id
-                  env: "OIDC_CLIENT_ID"
+                - name: auth_oidc_client_id
+                  env: "AUTH_OIDC_CLIENT_ID"
                   type: string
                   default: "inference-gateway-client"
                   description: "OIDC client ID"
                   secret: true
-                - name: client_secret
-                  env: "OIDC_CLIENT_SECRET"
+                - name: auth_oidc_client_secret
+                  env: "AUTH_OIDC_CLIENT_SECRET"
                   type: string
                   description: "OIDC client secret"
                   secret: true


### PR DESCRIPTION
Consolidates all authentication-related environment variables under a unified AUTH_ prefix structure for improved consistency and organization.

BREAKING CHANGES:
- ENABLE_AUTH → AUTH_ENABLE
- OIDC_ISSUER_URL → AUTH_OIDC_ISSUER
- OIDC_CLIENT_ID → AUTH_OIDC_CLIENT_ID
- OIDC_CLIENT_SECRET → AUTH_OIDC_CLIENT_SECRET

Resolves #156

🤖 Generated with [Claude Code](https://claude.ai/code)