### PR TITLE
refactor: Run mcp:schema:download to fetch the latest schema changes …

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,12 +12,14 @@ tasks:
     cmds:
       - curl -o mcp/mcp-schema.json https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/mcp/mcp-schema.json
       - curl -o mcp/mcp-schema.yaml https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/mcp/mcp-schema.yaml
+      - task: format
 
   a2a:schema:download:
     desc: 'Download the latest A2A schema'
     cmds:
       - curl -o a2a/a2a-schema.json https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/a2a/a2a-schema.json
       - curl -o a2a/a2a-schema.yaml https://raw.githubusercontent.com/inference-gateway/schemas/refs/heads/main/a2a/a2a-schema.yaml
+      - task: format
 
   install:generator:
     desc: 'Install the generator tool'

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -316,7 +316,7 @@ func (mc *MCPClient) ExecuteTool(ctx context.Context, request Request, serverURL
 	}
 
 	response := CallToolResult{
-		Content: make([]interface{}, len(result.Content)),
+		Content: make([]ContentBlock, len(result.Content)),
 	}
 
 	for i, content := range result.Content {

--- a/mcp/mcp-schema.json
+++ b/mcp/mcp-schema.json
@@ -11,6 +11,10 @@
           },
           "type": "array"
         },
+        "lastModified": {
+          "description": "The moment the resource was last modified, as an ISO 8601 formatted string.\n\nShould be an ISO 8601 formatted string (e.g., \"2025-01-12T15:00:58Z\").\n\nExamples: last activity timestamp in an open file, timestamp when the resource\nwas attached, etc.",
+          "type": "string"
+        },
         "priority": {
           "description": "Describes how important this data is for operating the server.\n\nA value of 1 means \"most important,\" and indicates that the data is\neffectively required, while 0 means \"least important,\" and indicates that\nthe data is entirely optional.",
           "maximum": 1,
@@ -23,6 +27,11 @@
     "AudioContent": {
       "description": "Audio provided to or from an LLM.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -44,8 +53,28 @@
       "required": ["data", "mimeType", "type"],
       "type": "object"
     },
+    "BaseMetadata": {
+      "description": "Base interface for metadata with name (identifier) and title (display name) properties.",
+      "properties": {
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "type": "object"
+    },
     "BlobResourceContents": {
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "blob": {
           "description": "A base64-encoded string representing the binary data of the item.",
           "format": "byte",
@@ -112,26 +141,13 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "content": {
           "description": "A list of content objects that represent the unstructured result of the tool call.",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/TextContent"
-              },
-              {
-                "$ref": "#/definitions/ImageContent"
-              },
-              {
-                "$ref": "#/definitions/AudioContent"
-              },
-              {
-                "$ref": "#/definitions/EmbeddedResource"
-              }
-            ]
+            "$ref": "#/definitions/ContentBlock"
           },
           "type": "array"
         },
@@ -309,13 +325,26 @@
               "required": ["name", "value"],
               "type": "object"
             },
+            "context": {
+              "description": "Additional, optional context for completions",
+              "properties": {
+                "arguments": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Previously-resolved variables in a URI template or prompt.",
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
             "ref": {
               "anyOf": [
                 {
                   "$ref": "#/definitions/PromptReference"
                 },
                 {
-                  "$ref": "#/definitions/ResourceReference"
+                  "$ref": "#/definitions/ResourceTemplateReference"
                 }
               ]
             }
@@ -332,7 +361,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "completion": {
@@ -359,6 +388,25 @@
       },
       "required": ["completion"],
       "type": "object"
+    },
+    "ContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TextContent"
+        },
+        {
+          "$ref": "#/definitions/ImageContent"
+        },
+        {
+          "$ref": "#/definitions/AudioContent"
+        },
+        {
+          "$ref": "#/definitions/ResourceLink"
+        },
+        {
+          "$ref": "#/definitions/EmbeddedResource"
+        }
+      ]
     },
     "CreateMessageRequest": {
       "description": "A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.",
@@ -420,7 +468,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "content": {
@@ -504,16 +552,18 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "action": {
-          "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly declined the action\n- \"cancel\": User dismissed without making an explicit choice",
+          "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
           "enum": ["accept", "cancel", "decline"],
           "type": "string"
         },
         "content": {
-          "additionalProperties": {},
+          "additionalProperties": {
+            "type": ["string", "integer", "boolean"]
+          },
           "description": "The submitted form data, only present when action is \"accept\".\nContains values matching the requested schema.",
           "type": "object"
         }
@@ -524,6 +574,11 @@
     "EmbeddedResource": {
       "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -610,7 +665,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "description": {
@@ -630,6 +685,11 @@
     "ImageContent": {
       "description": "An image provided to or from an LLM.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -652,9 +712,14 @@
       "type": "object"
     },
     "Implementation": {
-      "description": "Describes the name and version of an MCP implementation.",
+      "description": "Describes the name and version of an MCP implementation, with an optional title for UI representation.",
       "properties": {
         "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "version": {
@@ -696,7 +761,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "capabilities": {
@@ -729,7 +794,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -738,34 +803,6 @@
       },
       "required": ["method"],
       "type": "object"
-    },
-    "JSONRPCBatchRequest": {
-      "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/JSONRPCRequest"
-          },
-          {
-            "$ref": "#/definitions/JSONRPCNotification"
-          }
-        ]
-      },
-      "type": "array"
-    },
-    "JSONRPCBatchResponse": {
-      "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
-      "items": {
-        "anyOf": [
-          {
-            "$ref": "#/definitions/JSONRPCResponse"
-          },
-          {
-            "$ref": "#/definitions/JSONRPCError"
-          }
-        ]
-      },
-      "type": "array"
     },
     "JSONRPCError": {
       "description": "A response to a request that indicates an error occurred.",
@@ -807,38 +844,10 @@
           "$ref": "#/definitions/JSONRPCNotification"
         },
         {
-          "description": "A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/JSONRPCRequest"
-              },
-              {
-                "$ref": "#/definitions/JSONRPCNotification"
-              }
-            ]
-          },
-          "type": "array"
-        },
-        {
           "$ref": "#/definitions/JSONRPCResponse"
         },
         {
           "$ref": "#/definitions/JSONRPCError"
-        },
-        {
-          "description": "A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/JSONRPCResponse"
-              },
-              {
-                "$ref": "#/definitions/JSONRPCError"
-              }
-            ]
-          },
-          "type": "array"
         }
       ],
       "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
@@ -858,7 +867,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -885,6 +894,8 @@
           "additionalProperties": {},
           "properties": {
             "_meta": {
+              "additionalProperties": {},
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "properties": {
                 "progressToken": {
                   "$ref": "#/definitions/ProgressToken",
@@ -942,7 +953,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "nextCursor": {
@@ -984,7 +995,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "nextCursor": {
@@ -1026,7 +1037,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "nextCursor": {
@@ -1054,6 +1065,8 @@
           "additionalProperties": {},
           "properties": {
             "_meta": {
+              "additionalProperties": {},
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "properties": {
                 "progressToken": {
                   "$ref": "#/definitions/ProgressToken",
@@ -1074,7 +1087,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "roots": {
@@ -1112,7 +1125,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "nextCursor": {
@@ -1222,7 +1235,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -1276,7 +1289,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "nextCursor": {
@@ -1297,6 +1310,8 @@
           "additionalProperties": {},
           "properties": {
             "_meta": {
+              "additionalProperties": {},
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "properties": {
                 "progressToken": {
                   "$ref": "#/definitions/ProgressToken",
@@ -1369,6 +1384,11 @@
     "Prompt": {
       "description": "A prompt or prompt template that the server offers.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "arguments": {
           "description": "A list of arguments to use for templating the prompt.",
           "items": {
@@ -1381,7 +1401,11 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the prompt or prompt template.",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         }
       },
@@ -1396,12 +1420,16 @@
           "type": "string"
         },
         "name": {
-          "description": "The name of the argument.",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
           "type": "string"
         },
         "required": {
           "description": "Whether this argument must be provided.",
           "type": "boolean"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
         }
       },
       "required": ["name"],
@@ -1419,7 +1447,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -1433,20 +1461,7 @@
       "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
       "properties": {
         "content": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextContent"
-            },
-            {
-              "$ref": "#/definitions/ImageContent"
-            },
-            {
-              "$ref": "#/definitions/AudioContent"
-            },
-            {
-              "$ref": "#/definitions/EmbeddedResource"
-            }
-          ]
+          "$ref": "#/definitions/ContentBlock"
         },
         "role": {
           "$ref": "#/definitions/Role"
@@ -1459,7 +1474,11 @@
       "description": "Identifies a prompt.",
       "properties": {
         "name": {
-          "description": "The name of the prompt or prompt template",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "type": {
@@ -1497,7 +1516,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         },
         "contents": {
@@ -1526,6 +1545,8 @@
           "additionalProperties": {},
           "properties": {
             "_meta": {
+              "additionalProperties": {},
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "properties": {
                 "progressToken": {
                   "$ref": "#/definitions/ProgressToken",
@@ -1548,6 +1569,11 @@
     "Resource": {
       "description": "A known resource that the server is capable of reading.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -1561,12 +1587,16 @@
           "type": "string"
         },
         "name": {
-          "description": "A human-readable name for this resource.\n\nThis can be used by clients to populate UI elements.",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
           "type": "string"
         },
         "size": {
           "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
           "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
         },
         "uri": {
           "description": "The URI of this resource.",
@@ -1580,6 +1610,11 @@
     "ResourceContents": {
       "description": "The contents of a specific resource or sub-resource.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
           "type": "string"
@@ -1591,6 +1626,51 @@
         }
       },
       "required": ["uri"],
+      "type": "object"
+    },
+    "ResourceLink": {
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+      "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
+        "annotations": {
+          "$ref": "#/definitions/Annotations",
+          "description": "Optional annotations for the client."
+        },
+        "description": {
+          "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
+          "type": "string"
+        },
+        "mimeType": {
+          "description": "The MIME type of this resource, if known.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "size": {
+          "description": "The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.\n\nThis can be used by Hosts to display file sizes and estimate context window usage.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
+        },
+        "type": {
+          "const": "resource_link",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of this resource.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": ["name", "type", "uri"],
       "type": "object"
     },
     "ResourceListChangedNotification": {
@@ -1605,7 +1685,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -1615,25 +1695,14 @@
       "required": ["method"],
       "type": "object"
     },
-    "ResourceReference": {
-      "description": "A reference to a resource or resource template definition.",
-      "properties": {
-        "type": {
-          "const": "ref/resource",
-          "type": "string"
-        },
-        "uri": {
-          "description": "The URI or URI template of the resource.",
-          "format": "uri-template",
-          "type": "string"
-        }
-      },
-      "required": ["type", "uri"],
-      "type": "object"
-    },
     "ResourceTemplate": {
       "description": "A template description for resources available on the server.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -1647,7 +1716,11 @@
           "type": "string"
         },
         "name": {
-          "description": "A human-readable name for the type of resource this template refers to.\n\nThis can be used by clients to populate UI elements.",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
+          "type": "string"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "uriTemplate": {
@@ -1657,6 +1730,22 @@
         }
       },
       "required": ["name", "uriTemplate"],
+      "type": "object"
+    },
+    "ResourceTemplateReference": {
+      "description": "A reference to a resource or resource template definition.",
+      "properties": {
+        "type": {
+          "const": "ref/resource",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI or URI template of the resource.",
+          "format": "uri-template",
+          "type": "string"
+        }
+      },
+      "required": ["type", "uri"],
       "type": "object"
     },
     "ResourceUpdatedNotification": {
@@ -1686,7 +1775,7 @@
       "properties": {
         "_meta": {
           "additionalProperties": {},
-          "description": "This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.",
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
           "type": "object"
         }
       },
@@ -1700,6 +1789,11 @@
     "Root": {
       "description": "Represents a root directory or file that the server can operate on.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "name": {
           "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
           "type": "string"
@@ -1725,7 +1819,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },
@@ -1966,6 +2060,11 @@
     "TextContent": {
       "description": "Text provided to or from an LLM.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/Annotations",
           "description": "Optional annotations for the client."
@@ -1984,6 +2083,11 @@
     },
     "TextResourceContents": {
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
           "type": "string"
@@ -2004,9 +2108,14 @@
     "Tool": {
       "description": "Definition for a tool the client can call.",
       "properties": {
+        "_meta": {
+          "additionalProperties": {},
+          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
+          "type": "object"
+        },
         "annotations": {
           "$ref": "#/definitions/ToolAnnotations",
-          "description": "Optional additional tool information."
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
         },
         "description": {
           "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
@@ -2038,11 +2147,11 @@
           "type": "object"
         },
         "name": {
-          "description": "The name of the tool.",
+          "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
           "type": "string"
         },
         "outputSchema": {
-          "description": "An optional JSON Schema object defining the structure of the tool's output returned in \nthe structuredContent field of a CallToolResult.",
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.",
           "properties": {
             "properties": {
               "additionalProperties": {
@@ -2065,6 +2174,10 @@
           },
           "required": ["type"],
           "type": "object"
+        },
+        "title": {
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "type": "string"
         }
       },
       "required": ["inputSchema", "name"],
@@ -2108,7 +2221,7 @@
           "properties": {
             "_meta": {
               "additionalProperties": {},
-              "description": "This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.",
+              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
               "type": "object"
             }
           },

--- a/mcp/mcp-schema.yaml
+++ b/mcp/mcp-schema.yaml
@@ -11,6 +11,15 @@ definitions:
         items:
           $ref: '#/definitions/Role'
         type: array
+      lastModified:
+        description: |-
+          The moment the resource was last modified, as an ISO 8601 formatted string.
+
+          Should be an ISO 8601 formatted string (e.g., "2025-01-12T15:00:58Z").
+
+          Examples: last activity timestamp in an open file, timestamp when the resource
+          was attached, etc.
+        type: string
       priority:
         description: |-
           Describes how important this data is for operating the server.
@@ -25,6 +34,10 @@ definitions:
   AudioContent:
     description: Audio provided to or from an LLM.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -43,8 +56,30 @@ definitions:
       - mimeType
       - type
     type: object
+  BaseMetadata:
+    description: Base interface for metadata with name (identifier) and title (display name) properties.
+    properties:
+      name:
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
+        type: string
+    required:
+      - name
+    type: object
   BlobResourceContents:
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       blob:
         description: A base64-encoded string representing the binary data of the item.
         format: byte
@@ -99,16 +134,12 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       content:
         description: A list of content objects that represent the unstructured result of the tool call.
         items:
-          anyOf:
-            - $ref: '#/definitions/TextContent'
-            - $ref: '#/definitions/ImageContent'
-            - $ref: '#/definitions/AudioContent'
-            - $ref: '#/definitions/EmbeddedResource'
+          $ref: '#/definitions/ContentBlock'
         type: array
       isError:
         description: |-
@@ -239,10 +270,19 @@ definitions:
               - name
               - value
             type: object
+          context:
+            description: Additional, optional context for completions
+            properties:
+              arguments:
+                additionalProperties:
+                  type: string
+                description: Previously-resolved variables in a URI template or prompt.
+                type: object
+            type: object
           ref:
             anyOf:
               - $ref: '#/definitions/PromptReference'
-              - $ref: '#/definitions/ResourceReference'
+              - $ref: '#/definitions/ResourceTemplateReference'
         required:
           - argument
           - ref
@@ -256,7 +296,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       completion:
         properties:
@@ -277,6 +317,13 @@ definitions:
     required:
       - completion
     type: object
+  ContentBlock:
+    anyOf:
+      - $ref: '#/definitions/TextContent'
+      - $ref: '#/definitions/ImageContent'
+      - $ref: '#/definitions/AudioContent'
+      - $ref: '#/definitions/ResourceLink'
+      - $ref: '#/definitions/EmbeddedResource'
   CreateMessageRequest:
     description: A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
     properties:
@@ -329,7 +376,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       content:
         anyOf:
@@ -396,13 +443,13 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       action:
         description: |-
           The user action in response to the elicitation.
           - "accept": User submitted the form/confirmed the action
-          - "decline": User explicitly declined the action
+          - "decline": User explicitly decline the action
           - "cancel": User dismissed without making an explicit choice
         enum:
           - accept
@@ -410,7 +457,11 @@ definitions:
           - decline
         type: string
       content:
-        additionalProperties: {}
+        additionalProperties:
+          type:
+            - string
+            - integer
+            - boolean
         description: |-
           The submitted form data, only present when action is "accept".
           Contains values matching the requested schema.
@@ -425,6 +476,10 @@ definitions:
       It is up to the client how best to render embedded resources for the benefit
       of the LLM and/or the user.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -490,7 +545,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       description:
         description: An optional description for the prompt.
@@ -505,6 +560,10 @@ definitions:
   ImageContent:
     description: An image provided to or from an LLM.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -524,9 +583,19 @@ definitions:
       - type
     type: object
   Implementation:
-    description: Describes the name and version of an MCP implementation.
+    description: Describes the name and version of an MCP implementation, with an optional title for UI representation.
     properties:
       name:
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
         type: string
       version:
         type: string
@@ -563,7 +632,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       capabilities:
         $ref: '#/definitions/ServerCapabilities'
@@ -594,26 +663,12 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
       - method
     type: object
-  JSONRPCBatchRequest:
-    description: A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.
-    items:
-      anyOf:
-        - $ref: '#/definitions/JSONRPCRequest'
-        - $ref: '#/definitions/JSONRPCNotification'
-    type: array
-  JSONRPCBatchResponse:
-    description: A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.
-    items:
-      anyOf:
-        - $ref: '#/definitions/JSONRPCResponse'
-        - $ref: '#/definitions/JSONRPCError'
-    type: array
   JSONRPCError:
     description: A response to a request that indicates an error occurred.
     properties:
@@ -645,20 +700,8 @@ definitions:
     anyOf:
       - $ref: '#/definitions/JSONRPCRequest'
       - $ref: '#/definitions/JSONRPCNotification'
-      - description: A JSON-RPC batch request, as described in https://www.jsonrpc.org/specification#batch.
-        items:
-          anyOf:
-            - $ref: '#/definitions/JSONRPCRequest'
-            - $ref: '#/definitions/JSONRPCNotification'
-        type: array
       - $ref: '#/definitions/JSONRPCResponse'
       - $ref: '#/definitions/JSONRPCError'
-      - description: A JSON-RPC batch response, as described in https://www.jsonrpc.org/specification#batch.
-        items:
-          anyOf:
-            - $ref: '#/definitions/JSONRPCResponse'
-            - $ref: '#/definitions/JSONRPCError'
-        type: array
     description: Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
   JSONRPCNotification:
     description: A notification which does not expect a response.
@@ -673,7 +716,7 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
@@ -694,6 +737,8 @@ definitions:
         additionalProperties: {}
         properties:
           _meta:
+            additionalProperties: {}
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             properties:
               progressToken:
                 $ref: '#/definitions/ProgressToken'
@@ -742,7 +787,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       nextCursor:
         description: |-
@@ -778,7 +823,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       nextCursor:
         description: |-
@@ -814,7 +859,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       nextCursor:
         description: |-
@@ -845,6 +890,8 @@ definitions:
         additionalProperties: {}
         properties:
           _meta:
+            additionalProperties: {}
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             properties:
               progressToken:
                 $ref: '#/definitions/ProgressToken'
@@ -862,7 +909,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       roots:
         items:
@@ -893,7 +940,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       nextCursor:
         description: |-
@@ -1027,7 +1074,7 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
@@ -1070,7 +1117,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       nextCursor:
         description: |-
@@ -1088,6 +1135,8 @@ definitions:
         additionalProperties: {}
         properties:
           _meta:
+            additionalProperties: {}
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             properties:
               progressToken:
                 $ref: '#/definitions/ProgressToken'
@@ -1142,6 +1191,10 @@ definitions:
   Prompt:
     description: A prompt or prompt template that the server offers.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       arguments:
         description: A list of arguments to use for templating the prompt.
         items:
@@ -1151,7 +1204,16 @@ definitions:
         description: An optional description of what this prompt provides
         type: string
       name:
-        description: The name of the prompt or prompt template.
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
         type: string
     required:
       - name
@@ -1163,11 +1225,20 @@ definitions:
         description: A human-readable description of the argument.
         type: string
       name:
-        description: The name of the argument.
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
       required:
         description: Whether this argument must be provided.
         type: boolean
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
+        type: string
     required:
       - name
     type: object
@@ -1182,7 +1253,7 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
@@ -1196,11 +1267,7 @@ definitions:
       resources from the MCP server.
     properties:
       content:
-        anyOf:
-          - $ref: '#/definitions/TextContent'
-          - $ref: '#/definitions/ImageContent'
-          - $ref: '#/definitions/AudioContent'
-          - $ref: '#/definitions/EmbeddedResource'
+        $ref: '#/definitions/ContentBlock'
       role:
         $ref: '#/definitions/Role'
     required:
@@ -1211,7 +1278,16 @@ definitions:
     description: Identifies a prompt.
     properties:
       name:
-        description: The name of the prompt or prompt template
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
         type: string
       type:
         const: ref/prompt
@@ -1244,7 +1320,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
       contents:
         items:
@@ -1263,6 +1339,8 @@ definitions:
         additionalProperties: {}
         properties:
           _meta:
+            additionalProperties: {}
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             properties:
               progressToken:
                 $ref: '#/definitions/ProgressToken'
@@ -1280,6 +1358,10 @@ definitions:
   Resource:
     description: A known resource that the server is capable of reading.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -1293,10 +1375,7 @@ definitions:
         description: The MIME type of this resource, if known.
         type: string
       name:
-        description: |-
-          A human-readable name for this resource.
-
-          This can be used by clients to populate UI elements.
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
       size:
         description: |-
@@ -1304,6 +1383,15 @@ definitions:
 
           This can be used by Hosts to display file sizes and estimate context window usage.
         type: integer
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
+        type: string
       uri:
         description: The URI of this resource.
         format: uri
@@ -1315,6 +1403,10 @@ definitions:
   ResourceContents:
     description: The contents of a specific resource or sub-resource.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1323,6 +1415,58 @@ definitions:
         format: uri
         type: string
     required:
+      - uri
+    type: object
+  ResourceLink:
+    description: |-
+      A resource that the server is capable of reading, included in a prompt or tool call result.
+
+      Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
+    properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
+      annotations:
+        $ref: '#/definitions/Annotations'
+        description: Optional annotations for the client.
+      description:
+        description: |-
+          A description of what this resource represents.
+
+          This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
+        type: string
+      mimeType:
+        description: The MIME type of this resource, if known.
+        type: string
+      name:
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      size:
+        description: |-
+          The size of the raw resource content, in bytes (i.e., before base64 encoding or any tokenization), if known.
+
+          This can be used by Hosts to display file sizes and estimate context window usage.
+        type: integer
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
+        type: string
+      type:
+        const: resource_link
+        type: string
+      uri:
+        description: The URI of this resource.
+        format: uri
+        type: string
+    required:
+      - name
+      - type
       - uri
     type: object
   ResourceListChangedNotification:
@@ -1336,29 +1480,19 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
       - method
     type: object
-  ResourceReference:
-    description: A reference to a resource or resource template definition.
-    properties:
-      type:
-        const: ref/resource
-        type: string
-      uri:
-        description: The URI or URI template of the resource.
-        format: uri-template
-        type: string
-    required:
-      - type
-      - uri
-    type: object
   ResourceTemplate:
     description: A template description for resources available on the server.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -1372,10 +1506,16 @@ definitions:
         description: The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.
         type: string
       name:
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
+        type: string
+      title:
         description: |-
-          A human-readable name for the type of resource this template refers to.
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
 
-          This can be used by clients to populate UI elements.
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
         type: string
       uriTemplate:
         description: A URI template (according to RFC 6570) that can be used to construct resource URIs.
@@ -1384,6 +1524,20 @@ definitions:
     required:
       - name
       - uriTemplate
+    type: object
+  ResourceTemplateReference:
+    description: A reference to a resource or resource template definition.
+    properties:
+      type:
+        const: ref/resource
+        type: string
+      uri:
+        description: The URI or URI template of the resource.
+        format: uri-template
+        type: string
+    required:
+      - type
+      - uri
     type: object
   ResourceUpdatedNotification:
     description: A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.
@@ -1409,7 +1563,7 @@ definitions:
     properties:
       _meta:
         additionalProperties: {}
-        description: This result property is reserved by the protocol to allow clients and servers to attach additional metadata to their responses.
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
         type: object
     type: object
   Role:
@@ -1421,6 +1575,10 @@ definitions:
   Root:
     description: Represents a root directory or file that the server can operate on.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       name:
         description: |-
           An optional name for the root. This can be used to provide a human-readable
@@ -1451,7 +1609,7 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:
@@ -1606,6 +1764,10 @@ definitions:
   TextContent:
     description: Text provided to or from an LLM.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/Annotations'
         description: Optional annotations for the client.
@@ -1621,6 +1783,10 @@ definitions:
     type: object
   TextResourceContents:
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1638,9 +1804,16 @@ definitions:
   Tool:
     description: Definition for a tool the client can call.
     properties:
+      _meta:
+        additionalProperties: {}
+        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        type: object
       annotations:
         $ref: '#/definitions/ToolAnnotations'
-        description: Optional additional tool information.
+        description: |-
+          Optional additional tool information.
+
+          Display name precedence order is: title, annotations.title, then name.
       description:
         description: |-
           A human-readable description of the tool.
@@ -1667,11 +1840,11 @@ definitions:
           - type
         type: object
       name:
-        description: The name of the tool.
+        description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
       outputSchema:
         description: |-
-          An optional JSON Schema object defining the structure of the tool's output returned in 
+          An optional JSON Schema object defining the structure of the tool's output returned in
           the structuredContent field of a CallToolResult.
         properties:
           properties:
@@ -1690,6 +1863,15 @@ definitions:
         required:
           - type
         type: object
+      title:
+        description: |-
+          Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
+          even by those unfamiliar with domain-specific terminology.
+
+          If not provided, the name should be used for display (except for Tool,
+          where `annotations.title` should be given precedence over using `name`,
+          if present).
+        type: string
     required:
       - inputSchema
       - name
@@ -1753,7 +1935,7 @@ definitions:
         properties:
           _meta:
             additionalProperties: {}
-            description: This parameter name is reserved by MCP to allow clients and servers to attach additional metadata to their notifications.
+            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
             type: object
         type: object
     required:

--- a/tests/mcp_agent_test.go
+++ b/tests/mcp_agent_test.go
@@ -124,10 +124,10 @@ func TestAgent_Run(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Tool executed successfully",
 						},
 					},
 				}, nil).Times(1)
@@ -192,8 +192,8 @@ func TestAgent_Run(t *testing.T) {
 
 				mockMCPClient.EXPECT().GetServerForTool(gomock.Any()).Return("http://test-server:8080/mcp", nil).Times(10)
 				mockMCPClient.EXPECT().ExecuteTool(gomock.Any(), gomock.Any(), gomock.Any()).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{"type": "text", "text": "Tool result"},
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{Type: "text", Text: "Tool result"},
 					},
 				}, nil).Times(10)
 
@@ -310,10 +310,10 @@ func TestAgent_ExecuteTools(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Tool executed successfully",
 						},
 					},
 				}, nil).Times(1)
@@ -350,10 +350,10 @@ func TestAgent_ExecuteTools(t *testing.T) {
 					},
 					"http://custom-server:8080",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Server tool executed",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Server tool executed",
 						},
 					},
 				}, nil).Times(1)
@@ -433,10 +433,10 @@ func TestAgent_ExecuteTools(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "First tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "First tool executed successfully",
 						},
 					},
 				}, nil).Times(1)
@@ -452,10 +452,10 @@ func TestAgent_ExecuteTools(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Second tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Second tool executed successfully",
 						},
 					},
 				}, nil).Times(1)
@@ -790,10 +790,10 @@ func TestAgent_RunWithStream(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "First tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "First tool executed successfully",
 						},
 					},
 				}, nil).Times(1)
@@ -809,10 +809,10 @@ func TestAgent_RunWithStream(t *testing.T) {
 					},
 					"http://test-server:8080/mcp",
 				).Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Second tool executed successfully",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Second tool executed successfully",
 						},
 					},
 				}, nil).Times(1)

--- a/tests/middlewares/mcp_test.go
+++ b/tests/middlewares/mcp_test.go
@@ -328,10 +328,10 @@ func TestMCPMiddleware_NonStreamingWithToolCalls(t *testing.T) {
 				},
 			},
 			toolResponse: &mcp.CallToolResult{
-				Content: []interface{}{
-					map[string]interface{}{
-						"type": "text",
-						"text": "Tool executed successfully",
+				Content: []mcp.ContentBlock{
+					mcp.TextContent{
+						Type: "text",
+						Text: "Tool executed successfully",
 					},
 				},
 			},
@@ -530,10 +530,10 @@ data: [DONE]`,
 
 			if tt.expectToolCalls {
 				mockMCPClient.EXPECT().ExecuteTool(gomock.Any(), gomock.Any(), "").Return(&mcp.CallToolResult{
-					Content: []interface{}{
-						map[string]interface{}{
-							"type": "text",
-							"text": "Tool result",
+					Content: []mcp.ContentBlock{
+						mcp.TextContent{
+							Type: "text",
+							Text: "Tool result",
 						},
 					},
 				}, nil).AnyTimes()
@@ -800,10 +800,10 @@ func TestMCPMiddleware_StreamingWithMultipleToolCallIterations(t *testing.T) {
 		mockMCPClient.EXPECT().GetServerForTool("get-pizza-info").Return("http://mcp-pizza-server:8084/mcp", nil).AnyTimes()
 
 		mockMCPClient.EXPECT().ExecuteTool(gomock.Any(), gomock.Any(), "http://mcp-pizza-server:8084/mcp").Return(&mcp.CallToolResult{
-			Content: []interface{}{
-				map[string]interface{}{
-					"type": "text",
-					"text": "Top pizzas: Margherita, Pepperoni, Hawaiian",
+			Content: []mcp.ContentBlock{
+				mcp.TextContent{
+					Type: "text",
+					Text: "Top pizzas: Margherita, Pepperoni, Hawaiian",
 				},
 			},
 		}, nil).AnyTimes()


### PR DESCRIPTION
## Summary

This pull request pulls the latest changes of the official MCP schema and updates the code to be compatible.

### Changelog

- Added `lastModified` property to track resource modification timestamps.
- Introduced `BaseMetadata` definition for consistent metadata structure.
- Updated existing definitions to include `_meta` for additional metadata.
- Consolidated content types under `ContentBlock` for better organization.
- Enhanced descriptions for clarity and consistency across definitions.
- Removed deprecated `JSONRPCBatchRequest` and `JSONRPCBatchResponse` definitions.
- Added `ResourceLink` definition to represent resources in prompts and tool calls.
- Updated `ResourceTemplate` and `ResourceTemplateReference` for improved resource management.