### PR TITLE
refactor(debug): Refactor debug logging for better development experience

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -271,7 +271,7 @@ func handleProxyRequest(c *gin.Context, provider providers.IProvider, router *Ro
 		req.URL.RawQuery = fullURL.RawQuery
 
 		if router.cfg.Environment == "development" {
-			reqModifier := proxymodifier.NewDevRequestModifier(router.logger)
+			reqModifier := proxymodifier.NewDevRequestModifier(router.logger, &router.cfg)
 			if err := reqModifier.Modify(req); err != nil {
 				router.logger.Error("failed to modify request", err)
 				return

--- a/config/config.go
+++ b/config/config.go
@@ -15,8 +15,10 @@ import (
 // Config holds the configuration for the Inference Gateway
 type Config struct {
 	// General settings
-	Environment   string `env:"ENVIRONMENT, default=production" description:"The environment"`
-	AllowedModels string `env:"ALLOWED_MODELS" description:"Comma-separated list of models to allow. If empty, all models will be available"`
+	Environment               string `env:"ENVIRONMENT, default=production" description:"The environment"`
+	AllowedModels             string `env:"ALLOWED_MODELS" description:"Comma-separated list of models to allow. If empty, all models will be available"`
+	DebugContentTruncateWords int    `env:"DEBUG_CONTENT_TRUNCATE_WORDS, default=10" description:"Number of words to truncate per content section in debug logs (development mode only)"`
+	DebugMaxMessages          int    `env:"DEBUG_MAX_MESSAGES, default=100" description:"Maximum number of messages to show in debug logs (development mode only)"`
 	// Telemetry settings
 	Telemetry *TelemetryConfig `env:", prefix=TELEMETRY_" description:"Telemetry configuration"`
 	// MCP settings

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,8 +21,10 @@ func TestLoad(t *testing.T) {
 			name: "Success_Defaults",
 			env:  map[string]string{},
 			expectedCfg: config.Config{
-				Environment:   "production",
-				AllowedModels: "",
+				Environment:               "production",
+				AllowedModels:             "",
+				DebugContentTruncateWords: 10,
+				DebugMaxMessages:          100,
 				Telemetry: &config.TelemetryConfig{
 					Enable:      false,
 					MetricsPort: "9464",
@@ -191,8 +193,10 @@ func TestLoad(t *testing.T) {
 				"OPENAI_API_KEY":       "openai123",
 			},
 			expectedCfg: config.Config{
-				Environment:   "development",
-				AllowedModels: "",
+				Environment:               "development",
+				AllowedModels:             "",
+				DebugContentTruncateWords: 10,
+				DebugMaxMessages:          100,
 				Telemetry: &config.TelemetryConfig{
 					Enable:      true,
 					MetricsPort: "9464",
@@ -356,8 +360,10 @@ func TestLoad(t *testing.T) {
 				"OLLAMA_API_URL":   "http://custom-ollama:8080",
 			},
 			expectedCfg: config.Config{
-				Environment:   "development",
-				AllowedModels: "",
+				Environment:               "development",
+				AllowedModels:             "",
+				DebugContentTruncateWords: 10,
+				DebugMaxMessages:          100,
 				Telemetry: &config.TelemetryConfig{
 					Enable:      true,
 					MetricsPort: "9464",

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -4,10 +4,14 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
+	"github.com/inference-gateway/inference-gateway/config"
 	"github.com/inference-gateway/inference-gateway/logger"
+	"github.com/inference-gateway/inference-gateway/providers"
 )
 
 // RequestModifier defines interface for modifying proxy requests
@@ -23,6 +27,7 @@ type ResponseModifier interface {
 // DevRequestModifier implements request modification for development
 type DevRequestModifier struct {
 	logger logger.Logger
+	cfg    *config.Config
 }
 
 // DevResponseModifier implements response modification for development
@@ -31,9 +36,10 @@ type DevResponseModifier struct {
 }
 
 // NewDevRequestModifier creates a new DevRequestModifier
-func NewDevRequestModifier(l logger.Logger) RequestModifier {
+func NewDevRequestModifier(l logger.Logger, cfg *config.Config) RequestModifier {
 	return &DevRequestModifier{
 		logger: l,
+		cfg:    cfg,
 	}
 }
 
@@ -57,10 +63,8 @@ func (m *DevRequestModifier) Modify(req *http.Request) error {
 
 	bodyBuffer := bytes.NewBuffer(body)
 
-	bodyPreview := string(body)
-	if len(bodyPreview) > 1024 {
-		bodyPreview = bodyPreview[:1024] + "... (truncated)"
-	}
+	// Try to parse as JSON and apply smart truncation for chat completion requests
+	bodyPreview := m.createSmartBodyPreview(body)
 
 	m.logger.Debug("proxy request",
 		"method", req.Method,
@@ -73,6 +77,77 @@ func (m *DevRequestModifier) Modify(req *http.Request) error {
 	req.ContentLength = int64(bodyBuffer.Len())
 
 	return nil
+}
+
+// truncateWords truncates text to the specified number of words
+func (m *DevRequestModifier) truncateWords(text string, maxWords int) string {
+	if maxWords <= 0 {
+		return ""
+	}
+
+	words := strings.Fields(text)
+	if len(words) <= maxWords {
+		return text
+	}
+
+	return strings.Join(words[:maxWords], " ") + "..."
+}
+
+// createSmartBodyPreview creates an intelligent preview of the request body
+func (m *DevRequestModifier) createSmartBodyPreview(body []byte) string {
+	// Try to parse as chat completion request
+	var chatReq providers.CreateChatCompletionRequest
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		// Not a chat completion request, fall back to simple truncation
+		bodyPreview := string(body)
+		if len(bodyPreview) > 1024 {
+			bodyPreview = bodyPreview[:1024] + "... (truncated)"
+		}
+		return bodyPreview
+	}
+
+	// Apply smart truncation to chat completion request
+	return m.truncateChatCompletionRequest(chatReq)
+}
+
+// truncateChatCompletionRequest applies smart truncation to chat completion requests
+func (m *DevRequestModifier) truncateChatCompletionRequest(req providers.CreateChatCompletionRequest) string {
+	maxWords := m.cfg.DebugContentTruncateWords
+	maxMessages := m.cfg.DebugMaxMessages
+
+	// Create a copy to modify for display
+	displayReq := req
+
+	// Limit number of messages
+	if len(displayReq.Messages) > maxMessages {
+		displayReq.Messages = displayReq.Messages[:maxMessages]
+	}
+
+	// Truncate content in each message
+	for i := range displayReq.Messages {
+		if displayReq.Messages[i].Content != "" {
+			displayReq.Messages[i].Content = m.truncateWords(displayReq.Messages[i].Content, maxWords)
+		}
+	}
+
+	// Convert back to JSON for display
+	truncatedBytes, err := json.Marshal(displayReq)
+	if err != nil {
+		// Fall back to original string representation if marshaling fails
+		bodyPreview := fmt.Sprintf("%+v", req)
+		if len(bodyPreview) > 1024 {
+			bodyPreview = bodyPreview[:1024] + "... (truncated)"
+		}
+		return bodyPreview
+	}
+
+	preview := string(truncatedBytes)
+	if len(displayReq.Messages) < len(req.Messages) {
+		preview = strings.TrimSuffix(preview, "}") +
+			fmt.Sprintf(",\"_truncated\":\"showing %d of %d messages\"}", len(displayReq.Messages), len(req.Messages))
+	}
+
+	return preview
 }
 
 func (m *DevResponseModifier) Modify(resp *http.Response) error {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1352,6 +1352,16 @@ components:
                   type: string
                   default: ''
                   description: 'Comma-separated list of models to allow. If empty, all models will be available'
+                - name: debug_content_truncate_words
+                  env: 'DEBUG_CONTENT_TRUNCATE_WORDS'
+                  type: int
+                  default: '10'
+                  description: 'Number of words to truncate per content section in debug logs (development mode only)'
+                - name: debug_max_messages
+                  env: 'DEBUG_MAX_MESSAGES'
+                  type: int
+                  default: '100'
+                  description: 'Maximum number of messages to show in debug logs (development mode only)'
           - telemetry:
               title: 'Telemetry'
               settings:


### PR DESCRIPTION
Fixes #170

## Summary

Refactored debug logging to provide more useful information during development by implementing smart truncation of chat completion requests.

## Changes

- ✅ Add configurable truncation threshold for content sections (default: 10 words)
- ✅ Add configurable maximum messages limit (default: 100 messages)
- ✅ Implement smart truncation that parses JSON and truncates individual message content
- ✅ Add truncation indicators showing "showing X of Y messages"
- ✅ Maintain fallback behavior for non-chat requests
- ✅ Only affects development mode (ENVIRONMENT=development)

## Configuration

```env
DEBUG_CONTENT_TRUNCATE_WORDS=10 # Words per content section
DEBUG_MAX_MESSAGES=100 # Maximum messages to show
```

## Testing

- ✅ All tests passing
- ✅ Linting passing
- ✅ Configuration defaults validated

Generated with [Claude Code](https://claude.ai/code)