### PR TITLE
feat(providers): Add Mistral AI as a provider

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -1,117 +1,119 @@
 ## Configurations
 
 ### General settings
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| ENVIRONMENT | `production` | The environment |
+| ALLOWED_MODELS | `""` | Comma-separated list of models to allow. If empty, all models will be available |
+| DEBUG_CONTENT_TRUNCATE_WORDS | `10` | Number of words to truncate per content section in debug logs (development mode only) |
+| DEBUG_MAX_MESSAGES | `100` | Maximum number of messages to show in debug logs (development mode only) |
 
-| Environment Variable         | Default Value | Description                                                                           |
-| ---------------------------- | ------------- | ------------------------------------------------------------------------------------- |
-| ENVIRONMENT                  | `production`  | The environment                                                                       |
-| ALLOWED_MODELS               | `""`          | Comma-separated list of models to allow. If empty, all models will be available       |
-| DEBUG_CONTENT_TRUNCATE_WORDS | `10`          | Number of words to truncate per content section in debug logs (development mode only) |
-| DEBUG_MAX_MESSAGES           | `100`         | Maximum number of messages to show in debug logs (development mode only)              |
 
 ### Telemetry
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| TELEMETRY_ENABLE | `false` | Enable telemetry |
+| TELEMETRY_METRICS_PORT | `9464` | Port for telemetry metrics server |
 
-| Environment Variable   | Default Value | Description                       |
-| ---------------------- | ------------- | --------------------------------- |
-| TELEMETRY_ENABLE       | `false`       | Enable telemetry                  |
-| TELEMETRY_METRICS_PORT | `9464`        | Port for telemetry metrics server |
 
 ### Model Context Protocol (MCP)
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| MCP_ENABLE | `false` | Enable MCP |
+| MCP_EXPOSE | `false` | Expose MCP tools endpoint |
+| MCP_SERVERS | `""` | List of MCP servers |
+| MCP_CLIENT_TIMEOUT | `5s` | MCP client HTTP timeout |
+| MCP_DIAL_TIMEOUT | `3s` | MCP client dial timeout |
+| MCP_TLS_HANDSHAKE_TIMEOUT | `3s` | MCP client TLS handshake timeout |
+| MCP_RESPONSE_HEADER_TIMEOUT | `3s` | MCP client response header timeout |
+| MCP_EXPECT_CONTINUE_TIMEOUT | `1s` | MCP client expect continue timeout |
+| MCP_REQUEST_TIMEOUT | `5s` | MCP client request timeout for initialize and tool calls |
+| MCP_MAX_RETRIES | `3` | Maximum number of connection retry attempts |
+| MCP_RETRY_INTERVAL | `5s` | Interval between connection retry attempts |
+| MCP_INITIAL_BACKOFF | `1s` | Initial backoff duration for exponential backoff retry |
+| MCP_ENABLE_RECONNECT | `true` | Enable automatic reconnection for failed servers |
+| MCP_RECONNECT_INTERVAL | `30s` | Interval between reconnection attempts |
+| MCP_POLLING_ENABLE | `true` | Enable health check polling |
+| MCP_POLLING_INTERVAL | `30s` | Interval between health check polling requests |
+| MCP_POLLING_TIMEOUT | `5s` | Timeout for individual health check requests |
+| MCP_DISABLE_HEALTHCHECK_LOGS | `true` | Disable health check log messages to reduce noise |
 
-| Environment Variable         | Default Value | Description                                              |
-| ---------------------------- | ------------- | -------------------------------------------------------- |
-| MCP_ENABLE                   | `false`       | Enable MCP                                               |
-| MCP_EXPOSE                   | `false`       | Expose MCP tools endpoint                                |
-| MCP_SERVERS                  | `""`          | List of MCP servers                                      |
-| MCP_CLIENT_TIMEOUT           | `5s`          | MCP client HTTP timeout                                  |
-| MCP_DIAL_TIMEOUT             | `3s`          | MCP client dial timeout                                  |
-| MCP_TLS_HANDSHAKE_TIMEOUT    | `3s`          | MCP client TLS handshake timeout                         |
-| MCP_RESPONSE_HEADER_TIMEOUT  | `3s`          | MCP client response header timeout                       |
-| MCP_EXPECT_CONTINUE_TIMEOUT  | `1s`          | MCP client expect continue timeout                       |
-| MCP_REQUEST_TIMEOUT          | `5s`          | MCP client request timeout for initialize and tool calls |
-| MCP_MAX_RETRIES              | `3`           | Maximum number of connection retry attempts              |
-| MCP_RETRY_INTERVAL           | `5s`          | Interval between connection retry attempts               |
-| MCP_INITIAL_BACKOFF          | `1s`          | Initial backoff duration for exponential backoff retry   |
-| MCP_ENABLE_RECONNECT         | `true`        | Enable automatic reconnection for failed servers         |
-| MCP_RECONNECT_INTERVAL       | `30s`         | Interval between reconnection attempts                   |
-| MCP_POLLING_ENABLE           | `true`        | Enable health check polling                              |
-| MCP_POLLING_INTERVAL         | `30s`         | Interval between health check polling requests           |
-| MCP_POLLING_TIMEOUT          | `5s`          | Timeout for individual health check requests             |
-| MCP_DISABLE_HEALTHCHECK_LOGS | `true`        | Disable health check log messages to reduce noise        |
 
 ### Agent-to-Agent (A2A) Protocol
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| A2A_ENABLE | `false` | Enable A2A protocol support |
+| A2A_EXPOSE | `false` | Expose A2A agents list cards endpoint |
+| A2A_AGENTS | `""` | Comma-separated list of A2A agent URLs |
+| A2A_CLIENT_TIMEOUT | `30s` | A2A client timeout |
+| A2A_POLLING_ENABLE | `true` | Enable task status polling |
+| A2A_POLLING_INTERVAL | `1s` | Interval between polling requests |
+| A2A_POLLING_TIMEOUT | `30s` | Maximum time to wait for task completion |
+| A2A_MAX_POLL_ATTEMPTS | `30` | Maximum number of polling attempts |
+| A2A_MAX_RETRIES | `3` | Maximum number of connection retry attempts |
+| A2A_RETRY_INTERVAL | `5s` | Interval between connection retry attempts |
+| A2A_INITIAL_BACKOFF | `1s` | Initial backoff duration for exponential backoff retry |
+| A2A_ENABLE_RECONNECT | `true` | Enable automatic reconnection for failed agents |
+| A2A_RECONNECT_INTERVAL | `30s` | Interval between reconnection attempts |
+| A2A_DISABLE_HEALTHCHECK_LOGS | `true` | Disable health check log messages to reduce noise |
+| A2A_SERVICE_DISCOVERY_ENABLE | `false` | Enable Kubernetes service discovery for A2A agents |
+| A2A_SERVICE_DISCOVERY_NAMESPACE | `""` | Kubernetes namespace to search for A2A services (empty means current namespace) |
+| A2A_SERVICE_DISCOVERY_POLLING_INTERVAL | `30s` | Interval between service discovery polling requests |
 
-| Environment Variable                   | Default Value | Description                                                                     |
-| -------------------------------------- | ------------- | ------------------------------------------------------------------------------- |
-| A2A_ENABLE                             | `false`       | Enable A2A protocol support                                                     |
-| A2A_EXPOSE                             | `false`       | Expose A2A agents list cards endpoint                                           |
-| A2A_AGENTS                             | `""`          | Comma-separated list of A2A agent URLs                                          |
-| A2A_CLIENT_TIMEOUT                     | `30s`         | A2A client timeout                                                              |
-| A2A_POLLING_ENABLE                     | `true`        | Enable task status polling                                                      |
-| A2A_POLLING_INTERVAL                   | `1s`          | Interval between polling requests                                               |
-| A2A_POLLING_TIMEOUT                    | `30s`         | Maximum time to wait for task completion                                        |
-| A2A_MAX_POLL_ATTEMPTS                  | `30`          | Maximum number of polling attempts                                              |
-| A2A_MAX_RETRIES                        | `3`           | Maximum number of connection retry attempts                                     |
-| A2A_RETRY_INTERVAL                     | `5s`          | Interval between connection retry attempts                                      |
-| A2A_INITIAL_BACKOFF                    | `1s`          | Initial backoff duration for exponential backoff retry                          |
-| A2A_ENABLE_RECONNECT                   | `true`        | Enable automatic reconnection for failed agents                                 |
-| A2A_RECONNECT_INTERVAL                 | `30s`         | Interval between reconnection attempts                                          |
-| A2A_DISABLE_HEALTHCHECK_LOGS           | `true`        | Disable health check log messages to reduce noise                               |
-| A2A_SERVICE_DISCOVERY_ENABLE           | `false`       | Enable Kubernetes service discovery for A2A agents                              |
-| A2A_SERVICE_DISCOVERY_NAMESPACE        | `""`          | Kubernetes namespace to search for A2A services (empty means current namespace) |
-| A2A_SERVICE_DISCOVERY_POLLING_INTERVAL | `30s`         | Interval between service discovery polling requests                             |
 
 ### Authentication
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| AUTH_ENABLE | `false` | Enable authentication |
+| AUTH_OIDC_ISSUER | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL |
+| AUTH_OIDC_CLIENT_ID | `inference-gateway-client` | OIDC client ID |
+| AUTH_OIDC_CLIENT_SECRET | `""` | OIDC client secret |
 
-| Environment Variable    | Default Value                                         | Description           |
-| ----------------------- | ----------------------------------------------------- | --------------------- |
-| AUTH_ENABLE             | `false`                                               | Enable authentication |
-| AUTH_OIDC_ISSUER        | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL       |
-| AUTH_OIDC_CLIENT_ID     | `inference-gateway-client`                            | OIDC client ID        |
-| AUTH_OIDC_CLIENT_SECRET | `""`                                                  | OIDC client secret    |
 
 ### Server settings
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| SERVER_HOST | `0.0.0.0` | Server host |
+| SERVER_PORT | `8080` | Server port |
+| SERVER_READ_TIMEOUT | `30s` | Read timeout |
+| SERVER_WRITE_TIMEOUT | `30s` | Write timeout |
+| SERVER_IDLE_TIMEOUT | `120s` | Idle timeout |
+| SERVER_TLS_CERT_PATH | `""` | TLS certificate path |
+| SERVER_TLS_KEY_PATH | `""` | TLS key path |
 
-| Environment Variable | Default Value | Description          |
-| -------------------- | ------------- | -------------------- |
-| SERVER_HOST          | `0.0.0.0`     | Server host          |
-| SERVER_PORT          | `8080`        | Server port          |
-| SERVER_READ_TIMEOUT  | `30s`         | Read timeout         |
-| SERVER_WRITE_TIMEOUT | `30s`         | Write timeout        |
-| SERVER_IDLE_TIMEOUT  | `120s`        | Idle timeout         |
-| SERVER_TLS_CERT_PATH | `""`          | TLS certificate path |
-| SERVER_TLS_KEY_PATH  | `""`          | TLS key path         |
 
 ### Client settings
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| CLIENT_TIMEOUT | `30s` | Client timeout |
+| CLIENT_MAX_IDLE_CONNS | `20` | Maximum idle connections |
+| CLIENT_MAX_IDLE_CONNS_PER_HOST | `20` | Maximum idle connections per host |
+| CLIENT_IDLE_CONN_TIMEOUT | `30s` | Idle connection timeout |
+| CLIENT_TLS_MIN_VERSION | `TLS12` | Minimum TLS version |
+| CLIENT_DISABLE_COMPRESSION | `true` | Disable compression for faster streaming |
+| CLIENT_RESPONSE_HEADER_TIMEOUT | `10s` | Response header timeout |
+| CLIENT_EXPECT_CONTINUE_TIMEOUT | `1s` | Expect continue timeout |
 
-| Environment Variable           | Default Value | Description                              |
-| ------------------------------ | ------------- | ---------------------------------------- |
-| CLIENT_TIMEOUT                 | `30s`         | Client timeout                           |
-| CLIENT_MAX_IDLE_CONNS          | `20`          | Maximum idle connections                 |
-| CLIENT_MAX_IDLE_CONNS_PER_HOST | `20`          | Maximum idle connections per host        |
-| CLIENT_IDLE_CONN_TIMEOUT       | `30s`         | Idle connection timeout                  |
-| CLIENT_TLS_MIN_VERSION         | `TLS12`       | Minimum TLS version                      |
-| CLIENT_DISABLE_COMPRESSION     | `true`        | Disable compression for faster streaming |
-| CLIENT_RESPONSE_HEADER_TIMEOUT | `10s`         | Response header timeout                  |
-| CLIENT_EXPECT_CONTINUE_TIMEOUT | `1s`          | Expect continue timeout                  |
 
 ### Providers
+| Environment Variable | Default Value | Description |
+|---------------------|---------------|-------------|
+| ANTHROPIC_API_URL | `https://api.anthropic.com/v1` | Anthropic API URL |
+| ANTHROPIC_API_KEY | `""` | Anthropic API Key |
+| CLOUDFLARE_API_URL | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai` | Cloudflare API URL |
+| CLOUDFLARE_API_KEY | `""` | Cloudflare API Key |
+| COHERE_API_URL | `https://api.cohere.ai` | Cohere API URL |
+| COHERE_API_KEY | `""` | Cohere API Key |
+| GROQ_API_URL | `https://api.groq.com/openai/v1` | Groq API URL |
+| GROQ_API_KEY | `""` | Groq API Key |
+| OLLAMA_API_URL | `http://ollama:8080/v1` | Ollama API URL |
+| OLLAMA_API_KEY | `""` | Ollama API Key |
+| OPENAI_API_URL | `https://api.openai.com/v1` | OpenAI API URL |
+| OPENAI_API_KEY | `""` | OpenAI API Key |
+| DEEPSEEK_API_URL | `https://api.deepseek.com` | DeepSeek API URL |
+| DEEPSEEK_API_KEY | `""` | DeepSeek API Key |
+| GOOGLE_API_URL | `https://generativelanguage.googleapis.com/v1beta/openai` | Google API URL |
+| GOOGLE_API_KEY | `""` | Google API Key |
+| MISTRAL_API_URL | `https://api.mistral.ai/v1` | Mistral API URL |
+| MISTRAL_API_KEY | `""` | Mistral API Key |
 
-| Environment Variable | Default Value                                                   | Description        |
-| -------------------- | --------------------------------------------------------------- | ------------------ |
-| ANTHROPIC_API_URL    | `https://api.anthropic.com/v1`                                  | Anthropic API URL  |
-| ANTHROPIC_API_KEY    | `""`                                                            | Anthropic API Key  |
-| CLOUDFLARE_API_URL   | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai` | Cloudflare API URL |
-| CLOUDFLARE_API_KEY   | `""`                                                            | Cloudflare API Key |
-| COHERE_API_URL       | `https://api.cohere.ai`                                         | Cohere API URL     |
-| COHERE_API_KEY       | `""`                                                            | Cohere API Key     |
-| GROQ_API_URL         | `https://api.groq.com/openai/v1`                                | Groq API URL       |
-| GROQ_API_KEY         | `""`                                                            | Groq API Key       |
-| OLLAMA_API_URL       | `http://ollama:8080/v1`                                         | Ollama API URL     |
-| OLLAMA_API_KEY       | `""`                                                            | Ollama API Key     |
-| OPENAI_API_URL       | `https://api.openai.com/v1`                                     | OpenAI API URL     |
-| OPENAI_API_KEY       | `""`                                                            | OpenAI API Key     |
-| DEEPSEEK_API_URL     | `https://api.deepseek.com`                                      | DeepSeek API URL   |
-| DEEPSEEK_API_KEY     | `""`                                                            | DeepSeek API Key   |
-| GOOGLE_API_URL       | `https://generativelanguage.googleapis.com/v1beta/openai`       | Google API URL     |
-| GOOGLE_API_KEY       | `""`                                                            | Google API Key     |

--- a/Configurations.md
+++ b/Configurations.md
@@ -1,119 +1,119 @@
 ## Configurations
 
 ### General settings
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| ENVIRONMENT | `production` | The environment |
-| ALLOWED_MODELS | `""` | Comma-separated list of models to allow. If empty, all models will be available |
-| DEBUG_CONTENT_TRUNCATE_WORDS | `10` | Number of words to truncate per content section in debug logs (development mode only) |
-| DEBUG_MAX_MESSAGES | `100` | Maximum number of messages to show in debug logs (development mode only) |
 
+| Environment Variable         | Default Value | Description                                                                           |
+| ---------------------------- | ------------- | ------------------------------------------------------------------------------------- |
+| ENVIRONMENT                  | `production`  | The environment                                                                       |
+| ALLOWED_MODELS               | `""`          | Comma-separated list of models to allow. If empty, all models will be available       |
+| DEBUG_CONTENT_TRUNCATE_WORDS | `10`          | Number of words to truncate per content section in debug logs (development mode only) |
+| DEBUG_MAX_MESSAGES           | `100`         | Maximum number of messages to show in debug logs (development mode only)              |
 
 ### Telemetry
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| TELEMETRY_ENABLE | `false` | Enable telemetry |
-| TELEMETRY_METRICS_PORT | `9464` | Port for telemetry metrics server |
 
+| Environment Variable   | Default Value | Description                       |
+| ---------------------- | ------------- | --------------------------------- |
+| TELEMETRY_ENABLE       | `false`       | Enable telemetry                  |
+| TELEMETRY_METRICS_PORT | `9464`        | Port for telemetry metrics server |
 
 ### Model Context Protocol (MCP)
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| MCP_ENABLE | `false` | Enable MCP |
-| MCP_EXPOSE | `false` | Expose MCP tools endpoint |
-| MCP_SERVERS | `""` | List of MCP servers |
-| MCP_CLIENT_TIMEOUT | `5s` | MCP client HTTP timeout |
-| MCP_DIAL_TIMEOUT | `3s` | MCP client dial timeout |
-| MCP_TLS_HANDSHAKE_TIMEOUT | `3s` | MCP client TLS handshake timeout |
-| MCP_RESPONSE_HEADER_TIMEOUT | `3s` | MCP client response header timeout |
-| MCP_EXPECT_CONTINUE_TIMEOUT | `1s` | MCP client expect continue timeout |
-| MCP_REQUEST_TIMEOUT | `5s` | MCP client request timeout for initialize and tool calls |
-| MCP_MAX_RETRIES | `3` | Maximum number of connection retry attempts |
-| MCP_RETRY_INTERVAL | `5s` | Interval between connection retry attempts |
-| MCP_INITIAL_BACKOFF | `1s` | Initial backoff duration for exponential backoff retry |
-| MCP_ENABLE_RECONNECT | `true` | Enable automatic reconnection for failed servers |
-| MCP_RECONNECT_INTERVAL | `30s` | Interval between reconnection attempts |
-| MCP_POLLING_ENABLE | `true` | Enable health check polling |
-| MCP_POLLING_INTERVAL | `30s` | Interval between health check polling requests |
-| MCP_POLLING_TIMEOUT | `5s` | Timeout for individual health check requests |
-| MCP_DISABLE_HEALTHCHECK_LOGS | `true` | Disable health check log messages to reduce noise |
 
+| Environment Variable         | Default Value | Description                                              |
+| ---------------------------- | ------------- | -------------------------------------------------------- |
+| MCP_ENABLE                   | `false`       | Enable MCP                                               |
+| MCP_EXPOSE                   | `false`       | Expose MCP tools endpoint                                |
+| MCP_SERVERS                  | `""`          | List of MCP servers                                      |
+| MCP_CLIENT_TIMEOUT           | `5s`          | MCP client HTTP timeout                                  |
+| MCP_DIAL_TIMEOUT             | `3s`          | MCP client dial timeout                                  |
+| MCP_TLS_HANDSHAKE_TIMEOUT    | `3s`          | MCP client TLS handshake timeout                         |
+| MCP_RESPONSE_HEADER_TIMEOUT  | `3s`          | MCP client response header timeout                       |
+| MCP_EXPECT_CONTINUE_TIMEOUT  | `1s`          | MCP client expect continue timeout                       |
+| MCP_REQUEST_TIMEOUT          | `5s`          | MCP client request timeout for initialize and tool calls |
+| MCP_MAX_RETRIES              | `3`           | Maximum number of connection retry attempts              |
+| MCP_RETRY_INTERVAL           | `5s`          | Interval between connection retry attempts               |
+| MCP_INITIAL_BACKOFF          | `1s`          | Initial backoff duration for exponential backoff retry   |
+| MCP_ENABLE_RECONNECT         | `true`        | Enable automatic reconnection for failed servers         |
+| MCP_RECONNECT_INTERVAL       | `30s`         | Interval between reconnection attempts                   |
+| MCP_POLLING_ENABLE           | `true`        | Enable health check polling                              |
+| MCP_POLLING_INTERVAL         | `30s`         | Interval between health check polling requests           |
+| MCP_POLLING_TIMEOUT          | `5s`          | Timeout for individual health check requests             |
+| MCP_DISABLE_HEALTHCHECK_LOGS | `true`        | Disable health check log messages to reduce noise        |
 
 ### Agent-to-Agent (A2A) Protocol
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| A2A_ENABLE | `false` | Enable A2A protocol support |
-| A2A_EXPOSE | `false` | Expose A2A agents list cards endpoint |
-| A2A_AGENTS | `""` | Comma-separated list of A2A agent URLs |
-| A2A_CLIENT_TIMEOUT | `30s` | A2A client timeout |
-| A2A_POLLING_ENABLE | `true` | Enable task status polling |
-| A2A_POLLING_INTERVAL | `1s` | Interval between polling requests |
-| A2A_POLLING_TIMEOUT | `30s` | Maximum time to wait for task completion |
-| A2A_MAX_POLL_ATTEMPTS | `30` | Maximum number of polling attempts |
-| A2A_MAX_RETRIES | `3` | Maximum number of connection retry attempts |
-| A2A_RETRY_INTERVAL | `5s` | Interval between connection retry attempts |
-| A2A_INITIAL_BACKOFF | `1s` | Initial backoff duration for exponential backoff retry |
-| A2A_ENABLE_RECONNECT | `true` | Enable automatic reconnection for failed agents |
-| A2A_RECONNECT_INTERVAL | `30s` | Interval between reconnection attempts |
-| A2A_DISABLE_HEALTHCHECK_LOGS | `true` | Disable health check log messages to reduce noise |
-| A2A_SERVICE_DISCOVERY_ENABLE | `false` | Enable Kubernetes service discovery for A2A agents |
-| A2A_SERVICE_DISCOVERY_NAMESPACE | `""` | Kubernetes namespace to search for A2A services (empty means current namespace) |
-| A2A_SERVICE_DISCOVERY_POLLING_INTERVAL | `30s` | Interval between service discovery polling requests |
 
+| Environment Variable                   | Default Value | Description                                                                     |
+| -------------------------------------- | ------------- | ------------------------------------------------------------------------------- |
+| A2A_ENABLE                             | `false`       | Enable A2A protocol support                                                     |
+| A2A_EXPOSE                             | `false`       | Expose A2A agents list cards endpoint                                           |
+| A2A_AGENTS                             | `""`          | Comma-separated list of A2A agent URLs                                          |
+| A2A_CLIENT_TIMEOUT                     | `30s`         | A2A client timeout                                                              |
+| A2A_POLLING_ENABLE                     | `true`        | Enable task status polling                                                      |
+| A2A_POLLING_INTERVAL                   | `1s`          | Interval between polling requests                                               |
+| A2A_POLLING_TIMEOUT                    | `30s`         | Maximum time to wait for task completion                                        |
+| A2A_MAX_POLL_ATTEMPTS                  | `30`          | Maximum number of polling attempts                                              |
+| A2A_MAX_RETRIES                        | `3`           | Maximum number of connection retry attempts                                     |
+| A2A_RETRY_INTERVAL                     | `5s`          | Interval between connection retry attempts                                      |
+| A2A_INITIAL_BACKOFF                    | `1s`          | Initial backoff duration for exponential backoff retry                          |
+| A2A_ENABLE_RECONNECT                   | `true`        | Enable automatic reconnection for failed agents                                 |
+| A2A_RECONNECT_INTERVAL                 | `30s`         | Interval between reconnection attempts                                          |
+| A2A_DISABLE_HEALTHCHECK_LOGS           | `true`        | Disable health check log messages to reduce noise                               |
+| A2A_SERVICE_DISCOVERY_ENABLE           | `false`       | Enable Kubernetes service discovery for A2A agents                              |
+| A2A_SERVICE_DISCOVERY_NAMESPACE        | `""`          | Kubernetes namespace to search for A2A services (empty means current namespace) |
+| A2A_SERVICE_DISCOVERY_POLLING_INTERVAL | `30s`         | Interval between service discovery polling requests                             |
 
 ### Authentication
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| AUTH_ENABLE | `false` | Enable authentication |
-| AUTH_OIDC_ISSUER | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL |
-| AUTH_OIDC_CLIENT_ID | `inference-gateway-client` | OIDC client ID |
-| AUTH_OIDC_CLIENT_SECRET | `""` | OIDC client secret |
 
+| Environment Variable    | Default Value                                         | Description           |
+| ----------------------- | ----------------------------------------------------- | --------------------- |
+| AUTH_ENABLE             | `false`                                               | Enable authentication |
+| AUTH_OIDC_ISSUER        | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL       |
+| AUTH_OIDC_CLIENT_ID     | `inference-gateway-client`                            | OIDC client ID        |
+| AUTH_OIDC_CLIENT_SECRET | `""`                                                  | OIDC client secret    |
 
 ### Server settings
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| SERVER_HOST | `0.0.0.0` | Server host |
-| SERVER_PORT | `8080` | Server port |
-| SERVER_READ_TIMEOUT | `30s` | Read timeout |
-| SERVER_WRITE_TIMEOUT | `30s` | Write timeout |
-| SERVER_IDLE_TIMEOUT | `120s` | Idle timeout |
-| SERVER_TLS_CERT_PATH | `""` | TLS certificate path |
-| SERVER_TLS_KEY_PATH | `""` | TLS key path |
 
+| Environment Variable | Default Value | Description          |
+| -------------------- | ------------- | -------------------- |
+| SERVER_HOST          | `0.0.0.0`     | Server host          |
+| SERVER_PORT          | `8080`        | Server port          |
+| SERVER_READ_TIMEOUT  | `30s`         | Read timeout         |
+| SERVER_WRITE_TIMEOUT | `30s`         | Write timeout        |
+| SERVER_IDLE_TIMEOUT  | `120s`        | Idle timeout         |
+| SERVER_TLS_CERT_PATH | `""`          | TLS certificate path |
+| SERVER_TLS_KEY_PATH  | `""`          | TLS key path         |
 
 ### Client settings
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| CLIENT_TIMEOUT | `30s` | Client timeout |
-| CLIENT_MAX_IDLE_CONNS | `20` | Maximum idle connections |
-| CLIENT_MAX_IDLE_CONNS_PER_HOST | `20` | Maximum idle connections per host |
-| CLIENT_IDLE_CONN_TIMEOUT | `30s` | Idle connection timeout |
-| CLIENT_TLS_MIN_VERSION | `TLS12` | Minimum TLS version |
-| CLIENT_DISABLE_COMPRESSION | `true` | Disable compression for faster streaming |
-| CLIENT_RESPONSE_HEADER_TIMEOUT | `10s` | Response header timeout |
-| CLIENT_EXPECT_CONTINUE_TIMEOUT | `1s` | Expect continue timeout |
 
+| Environment Variable           | Default Value | Description                              |
+| ------------------------------ | ------------- | ---------------------------------------- |
+| CLIENT_TIMEOUT                 | `30s`         | Client timeout                           |
+| CLIENT_MAX_IDLE_CONNS          | `20`          | Maximum idle connections                 |
+| CLIENT_MAX_IDLE_CONNS_PER_HOST | `20`          | Maximum idle connections per host        |
+| CLIENT_IDLE_CONN_TIMEOUT       | `30s`         | Idle connection timeout                  |
+| CLIENT_TLS_MIN_VERSION         | `TLS12`       | Minimum TLS version                      |
+| CLIENT_DISABLE_COMPRESSION     | `true`        | Disable compression for faster streaming |
+| CLIENT_RESPONSE_HEADER_TIMEOUT | `10s`         | Response header timeout                  |
+| CLIENT_EXPECT_CONTINUE_TIMEOUT | `1s`          | Expect continue timeout                  |
 
 ### Providers
-| Environment Variable | Default Value | Description |
-|---------------------|---------------|-------------|
-| ANTHROPIC_API_URL | `https://api.anthropic.com/v1` | Anthropic API URL |
-| ANTHROPIC_API_KEY | `""` | Anthropic API Key |
-| CLOUDFLARE_API_URL | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai` | Cloudflare API URL |
-| CLOUDFLARE_API_KEY | `""` | Cloudflare API Key |
-| COHERE_API_URL | `https://api.cohere.ai` | Cohere API URL |
-| COHERE_API_KEY | `""` | Cohere API Key |
-| GROQ_API_URL | `https://api.groq.com/openai/v1` | Groq API URL |
-| GROQ_API_KEY | `""` | Groq API Key |
-| OLLAMA_API_URL | `http://ollama:8080/v1` | Ollama API URL |
-| OLLAMA_API_KEY | `""` | Ollama API Key |
-| OPENAI_API_URL | `https://api.openai.com/v1` | OpenAI API URL |
-| OPENAI_API_KEY | `""` | OpenAI API Key |
-| DEEPSEEK_API_URL | `https://api.deepseek.com` | DeepSeek API URL |
-| DEEPSEEK_API_KEY | `""` | DeepSeek API Key |
-| GOOGLE_API_URL | `https://generativelanguage.googleapis.com/v1beta/openai` | Google API URL |
-| GOOGLE_API_KEY | `""` | Google API Key |
-| MISTRAL_API_URL | `https://api.mistral.ai/v1` | Mistral API URL |
-| MISTRAL_API_KEY | `""` | Mistral API Key |
 
+| Environment Variable | Default Value                                                   | Description        |
+| -------------------- | --------------------------------------------------------------- | ------------------ |
+| ANTHROPIC_API_URL    | `https://api.anthropic.com/v1`                                  | Anthropic API URL  |
+| ANTHROPIC_API_KEY    | `""`                                                            | Anthropic API Key  |
+| CLOUDFLARE_API_URL   | `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai` | Cloudflare API URL |
+| CLOUDFLARE_API_KEY   | `""`                                                            | Cloudflare API Key |
+| COHERE_API_URL       | `https://api.cohere.ai`                                         | Cohere API URL     |
+| COHERE_API_KEY       | `""`                                                            | Cohere API Key     |
+| GROQ_API_URL         | `https://api.groq.com/openai/v1`                                | Groq API URL       |
+| GROQ_API_KEY         | `""`                                                            | Groq API Key       |
+| OLLAMA_API_URL       | `http://ollama:8080/v1`                                         | Ollama API URL     |
+| OLLAMA_API_KEY       | `""`                                                            | Ollama API Key     |
+| OPENAI_API_URL       | `https://api.openai.com/v1`                                     | OpenAI API URL     |
+| OPENAI_API_KEY       | `""`                                                            | OpenAI API Key     |
+| DEEPSEEK_API_URL     | `https://api.deepseek.com`                                      | DeepSeek API URL   |
+| DEEPSEEK_API_KEY     | `""`                                                            | DeepSeek API Key   |
+| GOOGLE_API_URL       | `https://generativelanguage.googleapis.com/v1beta/openai`       | Google API URL     |
+| GOOGLE_API_KEY       | `""`                                                            | Google API Key     |
+| MISTRAL_API_URL      | `https://api.mistral.ai/v1`                                     | Mistral API URL    |
+| MISTRAL_API_KEY      | `""`                                                            | Mistral API Key    |

--- a/charts/inference-gateway/templates/configmap-defaults.yaml
+++ b/charts/inference-gateway/templates/configmap-defaults.yaml
@@ -79,3 +79,4 @@ data:
   OPENAI_API_URL: {{ .Values.config.OPENAI_API_URL | quote }}
   DEEPSEEK_API_URL: {{ .Values.config.DEEPSEEK_API_URL | quote }}
   GOOGLE_API_URL: {{ .Values.config.GOOGLE_API_URL | quote }}
+  MISTRAL_API_URL: {{ .Values.config.MISTRAL_API_URL | quote }}

--- a/charts/inference-gateway/templates/secrets-defaults.yaml
+++ b/charts/inference-gateway/templates/secrets-defaults.yaml
@@ -14,3 +14,4 @@ stringData:
   OPENAI_API_KEY: ""
   DEEPSEEK_API_KEY: ""
   GOOGLE_API_KEY: ""
+  MISTRAL_API_KEY: ""

--- a/charts/inference-gateway/values.yaml
+++ b/charts/inference-gateway/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/inference-gateway/inference-gateway
   pullPolicy: IfNotPresent
-  tag: ''
+  tag: ""
 
 monitoring:
   enabled: false
@@ -24,8 +24,8 @@ envFrom:
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.
-nameOverride: ''
-fullnameOverride: ''
+nameOverride: ""
+fullnameOverride: ""
 
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
@@ -37,7 +37,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ''
+  name: ""
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -46,10 +46,12 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -69,7 +71,7 @@ ingress:
   enabled: false
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: 'selfsigned-issuer'
+    cert-manager.io/cluster-issuer: "selfsigned-issuer"
   hosts:
     - host: api.inference-gateway.local
       paths:
@@ -136,76 +138,77 @@ extraEnv: []
 
 config:
   # General settings
-  ENVIRONMENT: 'production'
-  ALLOWED_MODELS: ''
-  DEBUG_CONTENT_TRUNCATE_WORDS: '10'
-  DEBUG_MAX_MESSAGES: '100'
+  ENVIRONMENT: "production"
+  ALLOWED_MODELS: ""
+  DEBUG_CONTENT_TRUNCATE_WORDS: "10"
+  DEBUG_MAX_MESSAGES: "100"
   # Telemetry
-  TELEMETRY_ENABLE: 'false'
-  TELEMETRY_METRICS_PORT: '9464'
+  TELEMETRY_ENABLE: "false"
+  TELEMETRY_METRICS_PORT: "9464"
   # Model Context Protocol (MCP)
-  MCP_ENABLE: 'false'
-  MCP_EXPOSE: 'false'
-  MCP_SERVERS: ''
-  MCP_CLIENT_TIMEOUT: '5s'
-  MCP_DIAL_TIMEOUT: '3s'
-  MCP_TLS_HANDSHAKE_TIMEOUT: '3s'
-  MCP_RESPONSE_HEADER_TIMEOUT: '3s'
-  MCP_EXPECT_CONTINUE_TIMEOUT: '1s'
-  MCP_REQUEST_TIMEOUT: '5s'
-  MCP_MAX_RETRIES: '3'
-  MCP_RETRY_INTERVAL: '5s'
-  MCP_INITIAL_BACKOFF: '1s'
-  MCP_ENABLE_RECONNECT: 'true'
-  MCP_RECONNECT_INTERVAL: '30s'
-  MCP_POLLING_ENABLE: 'true'
-  MCP_POLLING_INTERVAL: '30s'
-  MCP_POLLING_TIMEOUT: '5s'
-  MCP_DISABLE_HEALTHCHECK_LOGS: 'true'
+  MCP_ENABLE: "false"
+  MCP_EXPOSE: "false"
+  MCP_SERVERS: ""
+  MCP_CLIENT_TIMEOUT: "5s"
+  MCP_DIAL_TIMEOUT: "3s"
+  MCP_TLS_HANDSHAKE_TIMEOUT: "3s"
+  MCP_RESPONSE_HEADER_TIMEOUT: "3s"
+  MCP_EXPECT_CONTINUE_TIMEOUT: "1s"
+  MCP_REQUEST_TIMEOUT: "5s"
+  MCP_MAX_RETRIES: "3"
+  MCP_RETRY_INTERVAL: "5s"
+  MCP_INITIAL_BACKOFF: "1s"
+  MCP_ENABLE_RECONNECT: "true"
+  MCP_RECONNECT_INTERVAL: "30s"
+  MCP_POLLING_ENABLE: "true"
+  MCP_POLLING_INTERVAL: "30s"
+  MCP_POLLING_TIMEOUT: "5s"
+  MCP_DISABLE_HEALTHCHECK_LOGS: "true"
   # Agent-to-Agent (A2A) Protocol
-  A2A_ENABLE: 'false'
-  A2A_EXPOSE: 'false'
-  A2A_AGENTS: ''
-  A2A_CLIENT_TIMEOUT: '30s'
-  A2A_POLLING_ENABLE: 'true'
-  A2A_POLLING_INTERVAL: '1s'
-  A2A_POLLING_TIMEOUT: '30s'
-  A2A_MAX_POLL_ATTEMPTS: '30'
-  A2A_MAX_RETRIES: '3'
-  A2A_RETRY_INTERVAL: '5s'
-  A2A_INITIAL_BACKOFF: '1s'
-  A2A_ENABLE_RECONNECT: 'true'
-  A2A_RECONNECT_INTERVAL: '30s'
-  A2A_DISABLE_HEALTHCHECK_LOGS: 'true'
-  A2A_SERVICE_DISCOVERY_ENABLE: 'false'
-  A2A_SERVICE_DISCOVERY_NAMESPACE: ''
-  A2A_SERVICE_DISCOVERY_POLLING_INTERVAL: '30s'
+  A2A_ENABLE: "false"
+  A2A_EXPOSE: "false"
+  A2A_AGENTS: ""
+  A2A_CLIENT_TIMEOUT: "30s"
+  A2A_POLLING_ENABLE: "true"
+  A2A_POLLING_INTERVAL: "1s"
+  A2A_POLLING_TIMEOUT: "30s"
+  A2A_MAX_POLL_ATTEMPTS: "30"
+  A2A_MAX_RETRIES: "3"
+  A2A_RETRY_INTERVAL: "5s"
+  A2A_INITIAL_BACKOFF: "1s"
+  A2A_ENABLE_RECONNECT: "true"
+  A2A_RECONNECT_INTERVAL: "30s"
+  A2A_DISABLE_HEALTHCHECK_LOGS: "true"
+  A2A_SERVICE_DISCOVERY_ENABLE: "false"
+  A2A_SERVICE_DISCOVERY_NAMESPACE: ""
+  A2A_SERVICE_DISCOVERY_POLLING_INTERVAL: "30s"
   # Authentication
-  AUTH_ENABLE: 'false'
-  AUTH_OIDC_ISSUER: 'http://keycloak:8080/realms/inference-gateway-realm'
+  AUTH_ENABLE: "false"
+  AUTH_OIDC_ISSUER: "http://keycloak:8080/realms/inference-gateway-realm"
   # Server settings
-  SERVER_HOST: '0.0.0.0'
-  SERVER_PORT: '8080'
-  SERVER_READ_TIMEOUT: '30s'
-  SERVER_WRITE_TIMEOUT: '30s'
-  SERVER_IDLE_TIMEOUT: '120s'
-  SERVER_TLS_CERT_PATH: ''
-  SERVER_TLS_KEY_PATH: ''
+  SERVER_HOST: "0.0.0.0"
+  SERVER_PORT: "8080"
+  SERVER_READ_TIMEOUT: "30s"
+  SERVER_WRITE_TIMEOUT: "30s"
+  SERVER_IDLE_TIMEOUT: "120s"
+  SERVER_TLS_CERT_PATH: ""
+  SERVER_TLS_KEY_PATH: ""
   # Client settings
-  CLIENT_TIMEOUT: '30s'
-  CLIENT_MAX_IDLE_CONNS: '20'
-  CLIENT_MAX_IDLE_CONNS_PER_HOST: '20'
-  CLIENT_IDLE_CONN_TIMEOUT: '30s'
-  CLIENT_TLS_MIN_VERSION: 'TLS12'
-  CLIENT_DISABLE_COMPRESSION: 'true'
-  CLIENT_RESPONSE_HEADER_TIMEOUT: '10s'
-  CLIENT_EXPECT_CONTINUE_TIMEOUT: '1s'
+  CLIENT_TIMEOUT: "30s"
+  CLIENT_MAX_IDLE_CONNS: "20"
+  CLIENT_MAX_IDLE_CONNS_PER_HOST: "20"
+  CLIENT_IDLE_CONN_TIMEOUT: "30s"
+  CLIENT_TLS_MIN_VERSION: "TLS12"
+  CLIENT_DISABLE_COMPRESSION: "true"
+  CLIENT_RESPONSE_HEADER_TIMEOUT: "10s"
+  CLIENT_EXPECT_CONTINUE_TIMEOUT: "1s"
   # Providers
-  ANTHROPIC_API_URL: 'https://api.anthropic.com/v1'
-  CLOUDFLARE_API_URL: 'https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai'
-  COHERE_API_URL: 'https://api.cohere.ai'
-  GROQ_API_URL: 'https://api.groq.com/openai/v1'
-  OLLAMA_API_URL: 'http://ollama:8080/v1'
-  OPENAI_API_URL: 'https://api.openai.com/v1'
-  DEEPSEEK_API_URL: 'https://api.deepseek.com'
-  GOOGLE_API_URL: 'https://generativelanguage.googleapis.com/v1beta/openai'
+  ANTHROPIC_API_URL: "https://api.anthropic.com/v1"
+  CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai"
+  COHERE_API_URL: "https://api.cohere.ai"
+  GROQ_API_URL: "https://api.groq.com/openai/v1"
+  OLLAMA_API_URL: "http://ollama:8080/v1"
+  OPENAI_API_URL: "https://api.openai.com/v1"
+  DEEPSEEK_API_URL: "https://api.deepseek.com"
+  GOOGLE_API_URL: "https://generativelanguage.googleapis.com/v1beta/openai"
+  MISTRAL_API_URL: "https://api.mistral.ai/v1"

--- a/charts/inference-gateway/values.yaml
+++ b/charts/inference-gateway/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   repository: ghcr.io/inference-gateway/inference-gateway
   pullPolicy: IfNotPresent
-  tag: ""
+  tag: ''
 
 monitoring:
   enabled: false
@@ -24,8 +24,8 @@ envFrom:
 # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 # This is to override the chart name.
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 # This section builds out the service account more information can be found here: https://kubernetes.io/docs/concepts/security/service-accounts/
 serviceAccount:
@@ -37,7 +37,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: ""
+  name: ''
 
 # This is for setting Kubernetes Annotations to a Pod.
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
@@ -46,12 +46,10 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-podSecurityContext:
-  {}
+podSecurityContext: {}
   # fsGroup: 2000
 
-securityContext:
-  {}
+securityContext: {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -71,7 +69,7 @@ ingress:
   enabled: false
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: "selfsigned-issuer"
+    cert-manager.io/cluster-issuer: 'selfsigned-issuer'
   hosts:
     - host: api.inference-gateway.local
       paths:
@@ -138,77 +136,77 @@ extraEnv: []
 
 config:
   # General settings
-  ENVIRONMENT: "production"
-  ALLOWED_MODELS: ""
-  DEBUG_CONTENT_TRUNCATE_WORDS: "10"
-  DEBUG_MAX_MESSAGES: "100"
+  ENVIRONMENT: 'production'
+  ALLOWED_MODELS: ''
+  DEBUG_CONTENT_TRUNCATE_WORDS: '10'
+  DEBUG_MAX_MESSAGES: '100'
   # Telemetry
-  TELEMETRY_ENABLE: "false"
-  TELEMETRY_METRICS_PORT: "9464"
+  TELEMETRY_ENABLE: 'false'
+  TELEMETRY_METRICS_PORT: '9464'
   # Model Context Protocol (MCP)
-  MCP_ENABLE: "false"
-  MCP_EXPOSE: "false"
-  MCP_SERVERS: ""
-  MCP_CLIENT_TIMEOUT: "5s"
-  MCP_DIAL_TIMEOUT: "3s"
-  MCP_TLS_HANDSHAKE_TIMEOUT: "3s"
-  MCP_RESPONSE_HEADER_TIMEOUT: "3s"
-  MCP_EXPECT_CONTINUE_TIMEOUT: "1s"
-  MCP_REQUEST_TIMEOUT: "5s"
-  MCP_MAX_RETRIES: "3"
-  MCP_RETRY_INTERVAL: "5s"
-  MCP_INITIAL_BACKOFF: "1s"
-  MCP_ENABLE_RECONNECT: "true"
-  MCP_RECONNECT_INTERVAL: "30s"
-  MCP_POLLING_ENABLE: "true"
-  MCP_POLLING_INTERVAL: "30s"
-  MCP_POLLING_TIMEOUT: "5s"
-  MCP_DISABLE_HEALTHCHECK_LOGS: "true"
+  MCP_ENABLE: 'false'
+  MCP_EXPOSE: 'false'
+  MCP_SERVERS: ''
+  MCP_CLIENT_TIMEOUT: '5s'
+  MCP_DIAL_TIMEOUT: '3s'
+  MCP_TLS_HANDSHAKE_TIMEOUT: '3s'
+  MCP_RESPONSE_HEADER_TIMEOUT: '3s'
+  MCP_EXPECT_CONTINUE_TIMEOUT: '1s'
+  MCP_REQUEST_TIMEOUT: '5s'
+  MCP_MAX_RETRIES: '3'
+  MCP_RETRY_INTERVAL: '5s'
+  MCP_INITIAL_BACKOFF: '1s'
+  MCP_ENABLE_RECONNECT: 'true'
+  MCP_RECONNECT_INTERVAL: '30s'
+  MCP_POLLING_ENABLE: 'true'
+  MCP_POLLING_INTERVAL: '30s'
+  MCP_POLLING_TIMEOUT: '5s'
+  MCP_DISABLE_HEALTHCHECK_LOGS: 'true'
   # Agent-to-Agent (A2A) Protocol
-  A2A_ENABLE: "false"
-  A2A_EXPOSE: "false"
-  A2A_AGENTS: ""
-  A2A_CLIENT_TIMEOUT: "30s"
-  A2A_POLLING_ENABLE: "true"
-  A2A_POLLING_INTERVAL: "1s"
-  A2A_POLLING_TIMEOUT: "30s"
-  A2A_MAX_POLL_ATTEMPTS: "30"
-  A2A_MAX_RETRIES: "3"
-  A2A_RETRY_INTERVAL: "5s"
-  A2A_INITIAL_BACKOFF: "1s"
-  A2A_ENABLE_RECONNECT: "true"
-  A2A_RECONNECT_INTERVAL: "30s"
-  A2A_DISABLE_HEALTHCHECK_LOGS: "true"
-  A2A_SERVICE_DISCOVERY_ENABLE: "false"
-  A2A_SERVICE_DISCOVERY_NAMESPACE: ""
-  A2A_SERVICE_DISCOVERY_POLLING_INTERVAL: "30s"
+  A2A_ENABLE: 'false'
+  A2A_EXPOSE: 'false'
+  A2A_AGENTS: ''
+  A2A_CLIENT_TIMEOUT: '30s'
+  A2A_POLLING_ENABLE: 'true'
+  A2A_POLLING_INTERVAL: '1s'
+  A2A_POLLING_TIMEOUT: '30s'
+  A2A_MAX_POLL_ATTEMPTS: '30'
+  A2A_MAX_RETRIES: '3'
+  A2A_RETRY_INTERVAL: '5s'
+  A2A_INITIAL_BACKOFF: '1s'
+  A2A_ENABLE_RECONNECT: 'true'
+  A2A_RECONNECT_INTERVAL: '30s'
+  A2A_DISABLE_HEALTHCHECK_LOGS: 'true'
+  A2A_SERVICE_DISCOVERY_ENABLE: 'false'
+  A2A_SERVICE_DISCOVERY_NAMESPACE: ''
+  A2A_SERVICE_DISCOVERY_POLLING_INTERVAL: '30s'
   # Authentication
-  AUTH_ENABLE: "false"
-  AUTH_OIDC_ISSUER: "http://keycloak:8080/realms/inference-gateway-realm"
+  AUTH_ENABLE: 'false'
+  AUTH_OIDC_ISSUER: 'http://keycloak:8080/realms/inference-gateway-realm'
   # Server settings
-  SERVER_HOST: "0.0.0.0"
-  SERVER_PORT: "8080"
-  SERVER_READ_TIMEOUT: "30s"
-  SERVER_WRITE_TIMEOUT: "30s"
-  SERVER_IDLE_TIMEOUT: "120s"
-  SERVER_TLS_CERT_PATH: ""
-  SERVER_TLS_KEY_PATH: ""
+  SERVER_HOST: '0.0.0.0'
+  SERVER_PORT: '8080'
+  SERVER_READ_TIMEOUT: '30s'
+  SERVER_WRITE_TIMEOUT: '30s'
+  SERVER_IDLE_TIMEOUT: '120s'
+  SERVER_TLS_CERT_PATH: ''
+  SERVER_TLS_KEY_PATH: ''
   # Client settings
-  CLIENT_TIMEOUT: "30s"
-  CLIENT_MAX_IDLE_CONNS: "20"
-  CLIENT_MAX_IDLE_CONNS_PER_HOST: "20"
-  CLIENT_IDLE_CONN_TIMEOUT: "30s"
-  CLIENT_TLS_MIN_VERSION: "TLS12"
-  CLIENT_DISABLE_COMPRESSION: "true"
-  CLIENT_RESPONSE_HEADER_TIMEOUT: "10s"
-  CLIENT_EXPECT_CONTINUE_TIMEOUT: "1s"
+  CLIENT_TIMEOUT: '30s'
+  CLIENT_MAX_IDLE_CONNS: '20'
+  CLIENT_MAX_IDLE_CONNS_PER_HOST: '20'
+  CLIENT_IDLE_CONN_TIMEOUT: '30s'
+  CLIENT_TLS_MIN_VERSION: 'TLS12'
+  CLIENT_DISABLE_COMPRESSION: 'true'
+  CLIENT_RESPONSE_HEADER_TIMEOUT: '10s'
+  CLIENT_EXPECT_CONTINUE_TIMEOUT: '1s'
   # Providers
-  ANTHROPIC_API_URL: "https://api.anthropic.com/v1"
-  CLOUDFLARE_API_URL: "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai"
-  COHERE_API_URL: "https://api.cohere.ai"
-  GROQ_API_URL: "https://api.groq.com/openai/v1"
-  OLLAMA_API_URL: "http://ollama:8080/v1"
-  OPENAI_API_URL: "https://api.openai.com/v1"
-  DEEPSEEK_API_URL: "https://api.deepseek.com"
-  GOOGLE_API_URL: "https://generativelanguage.googleapis.com/v1beta/openai"
-  MISTRAL_API_URL: "https://api.mistral.ai/v1"
+  ANTHROPIC_API_URL: 'https://api.anthropic.com/v1'
+  CLOUDFLARE_API_URL: 'https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/ai'
+  COHERE_API_URL: 'https://api.cohere.ai'
+  GROQ_API_URL: 'https://api.groq.com/openai/v1'
+  OLLAMA_API_URL: 'http://ollama:8080/v1'
+  OPENAI_API_URL: 'https://api.openai.com/v1'
+  DEEPSEEK_API_URL: 'https://api.deepseek.com'
+  GOOGLE_API_URL: 'https://generativelanguage.googleapis.com/v1beta/openai'
+  MISTRAL_API_URL: 'https://api.mistral.ai/v1'

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -175,6 +175,16 @@ func TestLoad(t *testing.T) {
 							Chat:   providers.GoogleChatEndpoint,
 						},
 					},
+					providers.MistralID: {
+						ID:       providers.MistralID,
+						Name:     providers.MistralDisplayName,
+						URL:      providers.MistralDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							Models: providers.MistralModelsEndpoint,
+							Chat:   providers.MistralChatEndpoint,
+						},
+					},
 				},
 			},
 		},
@@ -349,6 +359,16 @@ func TestLoad(t *testing.T) {
 							Chat:   providers.GoogleChatEndpoint,
 						},
 					},
+					providers.MistralID: {
+						ID:       providers.MistralID,
+						Name:     providers.MistralDisplayName,
+						URL:      providers.MistralDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							Models: providers.MistralModelsEndpoint,
+							Chat:   providers.MistralChatEndpoint,
+						},
+					},
 				},
 			},
 		},
@@ -512,6 +532,16 @@ func TestLoad(t *testing.T) {
 						Endpoints: providers.Endpoints{
 							Models: providers.GoogleModelsEndpoint,
 							Chat:   providers.GoogleChatEndpoint,
+						},
+					},
+					providers.MistralID: {
+						ID:       providers.MistralID,
+						Name:     providers.MistralDisplayName,
+						URL:      providers.MistralDefaultBaseURL,
+						AuthType: providers.AuthTypeBearer,
+						Endpoints: providers.Endpoints{
+							Models: providers.MistralModelsEndpoint,
+							Chat:   providers.MistralChatEndpoint,
 						},
 					},
 				},

--- a/examples/docker-compose/a2a/.env.example
+++ b/examples/docker-compose/a2a/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/authentication/.env.example
+++ b/examples/docker-compose/authentication/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/basic/.env.example
+++ b/examples/docker-compose/basic/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/hybrid/.env.example
+++ b/examples/docker-compose/hybrid/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/mcp/.env.example
+++ b/examples/docker-compose/mcp/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/monitoring/.env.example
+++ b/examples/docker-compose/monitoring/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/tools/.env.example
+++ b/examples/docker-compose/tools/.env.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/docker-compose/ui/.env.backend.example
+++ b/examples/docker-compose/ui/.env.backend.example
@@ -83,3 +83,5 @@ DEEPSEEK_API_URL=https://api.deepseek.com
 DEEPSEEK_API_KEY=
 GOOGLE_API_URL=https://generativelanguage.googleapis.com/v1beta/openai
 GOOGLE_API_KEY=
+MISTRAL_API_URL=https://api.mistral.ai/v1
+MISTRAL_API_KEY=

--- a/examples/rest-endpoints/README.md
+++ b/examples/rest-endpoints/README.md
@@ -14,6 +14,7 @@ Assuming you've deployed the Inference Gateway, you can interact with the langua
 | List Cohere models     | `curl -X GET http://localhost:8080/v1/models?provider=cohere`     |
 | List Anthropic models  | `curl -X GET http://localhost:8080/v1/models?provider=anthropic`  |
 | List DeepSeek models   | `curl -X GET http://localhost:8080/v1/models?provider=deepseek`   |
+| List Mistral models    | `curl -X GET http://localhost:8080/v1/models?provider=mistral`    |
 
 ### POST Endpoints
 
@@ -26,6 +27,7 @@ Assuming you've deployed the Inference Gateway, you can interact with the langua
 | api.cohere.com     | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"cohere/command-r","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                          |
 | api.anthropic.com  | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"anthropic/claude-3-opus-20240229","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`          |
 | api.deepseek.com   | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"deepseek/deepseek-reasoner","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                |
+| api.mistral.ai     | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"mistral/pixtral-large-latest","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`              |
 
 You can set the stream as an optional flag in the request body to enable streaming of tokens. The default value is `false`.
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -96,6 +96,11 @@ paths:
                         created: 1718441600
                         owned_by: 'ollama'
                         served_by: 'ollama'
+                      - id: 'mistral/mistral-large-latest'
+                        object: 'model'
+                        created: 1698019200
+                        owned_by: 'mistral'
+                        served_by: 'mistral'
                 singleProvider:
                   summary: Models from a specific provider
                   value:
@@ -415,6 +420,14 @@ components:
                   - role: 'user'
                     content: 'Explain quantum computing'
                 temperature: 0.5
+            mistral:
+              summary: Mistral AI request
+              value:
+                model: 'mistral-large-latest'
+                messages:
+                  - role: 'user'
+                    content: 'Write a Python function to calculate fibonacci numbers'
+                temperature: 0.3
     CreateChatCompletionRequest:
       required: true
       description: |
@@ -489,6 +502,27 @@ components:
                       },
                     ],
                 }
+            mistral:
+              summary: Mistral AI response
+              value:
+                {
+                  'id': 'cmpl-123',
+                  'object': 'chat.completion',
+                  'created': 1677652288,
+                  'model': 'mistral-large-latest',
+                  'choices':
+                    [
+                      {
+                        'index': 0,
+                        'message':
+                          {
+                            'role': 'assistant',
+                            'content': 'def fibonacci(n):\n    if n <= 1:\n        return n\n    return fibonacci(n-1) + fibonacci(n-2)',
+                          },
+                        'finish_reason': 'stop',
+                      },
+                    ],
+                }
   securitySchemes:
     bearerAuth:
       type: http
@@ -510,6 +544,7 @@ components:
         - anthropic
         - deepseek
         - google
+        - mistral
       x-provider-configs:
         ollama:
           id: 'ollama'
@@ -605,6 +640,19 @@ components:
         google:
           id: 'google'
           url: 'https://generativelanguage.googleapis.com/v1beta/openai'
+          auth_type: 'bearer'
+          endpoints:
+            models:
+              name: 'list_models'
+              method: 'GET'
+              endpoint: '/models'
+            chat:
+              name: 'chat_completions'
+              method: 'POST'
+              endpoint: '/chat/completions'
+        mistral:
+          id: 'mistral'
+          url: 'https://api.mistral.ai/v1'
           auth_type: 'bearer'
           endpoints:
             models:
@@ -1738,4 +1786,14 @@ components:
                   env: 'GOOGLE_API_KEY'
                   type: string
                   description: 'Google API Key'
+                  secret: true
+                - name: mistral_api_url
+                  env: 'MISTRAL_API_URL'
+                  type: string
+                  default: 'https://api.mistral.ai/v1'
+                  description: 'Mistral API URL'
+                - name: mistral_api_key
+                  env: 'MISTRAL_API_KEY'
+                  type: string
+                  description: 'Mistral API Key'
                   secret: true

--- a/providers/common_types.go
+++ b/providers/common_types.go
@@ -17,6 +17,7 @@ const (
 	DeepseekDefaultBaseURL   = "https://api.deepseek.com"
 	GoogleDefaultBaseURL     = "https://generativelanguage.googleapis.com/v1beta/openai"
 	GroqDefaultBaseURL       = "https://api.groq.com/openai/v1"
+	MistralDefaultBaseURL    = "https://api.mistral.ai/v1"
 	OllamaDefaultBaseURL     = "http://ollama:8080/v1"
 	OpenaiDefaultBaseURL     = "https://api.openai.com/v1"
 )
@@ -35,6 +36,8 @@ const (
 	GoogleChatEndpoint       = "/chat/completions"
 	GroqModelsEndpoint       = "/models"
 	GroqChatEndpoint         = "/chat/completions"
+	MistralModelsEndpoint    = "/models"
+	MistralChatEndpoint      = "/chat/completions"
 	OllamaModelsEndpoint     = "/models"
 	OllamaChatEndpoint       = "/chat/completions"
 	OpenaiModelsEndpoint     = "/models"
@@ -51,6 +54,7 @@ const (
 	DeepseekID   Provider = "deepseek"
 	GoogleID     Provider = "google"
 	GroqID       Provider = "groq"
+	MistralID    Provider = "mistral"
 	OllamaID     Provider = "ollama"
 	OpenaiID     Provider = "openai"
 )
@@ -63,6 +67,7 @@ const (
 	DeepseekDisplayName   = "Deepseek"
 	GoogleDisplayName     = "Google"
 	GroqDisplayName       = "Groq"
+	MistralDisplayName    = "Mistral"
 	OllamaDisplayName     = "Ollama"
 	OpenaiDisplayName     = "Openai"
 )

--- a/providers/management.go
+++ b/providers/management.go
@@ -23,9 +23,9 @@ func (p *ProviderImpl) prepareStreamingRequest(clientReq CreateChatCompletionReq
 		IncludeUsage: true,
 	}
 
-	// Special case - cohere doesn't like stream_options, so we don't
+	// Special case - cohere and mistral don't like stream_options, so we don't
 	// include it - probably they haven't implemented it yet in their OpenAI "compatible" API
-	if *p.GetID() == CohereID {
+	if *p.GetID() == CohereID || *p.GetID() == MistralID {
 		clientReq.StreamOptions = nil
 	}
 

--- a/providers/management.go
+++ b/providers/management.go
@@ -199,6 +199,13 @@ func (p *ProviderImpl) ListModels(ctx context.Context) (ListModelsResponse, erro
 			return ListModelsResponse{}, err
 		}
 		transformer = &resp
+	case MistralID:
+		var resp ListModelsResponseMistral
+		if err := json.NewDecoder(response.Body).Decode(&resp); err != nil {
+			p.logger.Error("Failed to unmarshal response", err, "provider", p.GetName(), "url", url)
+			return ListModelsResponse{}, err
+		}
+		transformer = &resp
 	default:
 		var resp ListModelsResponseOpenai
 		if err := json.NewDecoder(response.Body).Decode(&resp); err != nil {

--- a/providers/mistral.go
+++ b/providers/mistral.go
@@ -1,0 +1,22 @@
+package providers
+
+type ListModelsResponseMistral struct {
+	Object string  `json:"object"`
+	Data   []Model `json:"data"`
+}
+
+func (l *ListModelsResponseMistral) Transform() ListModelsResponse {
+	provider := MistralID
+	models := make([]Model, len(l.Data))
+	for i, model := range l.Data {
+		model.ServedBy = provider
+		model.ID = string(provider) + "/" + model.ID
+		models[i] = model
+	}
+
+	return ListModelsResponse{
+		Provider: &provider,
+		Object:   l.Object,
+		Data:     models,
+	}
+}

--- a/providers/model_mapping.go
+++ b/providers/model_mapping.go
@@ -23,6 +23,7 @@ func DetermineProviderAndModelName(model string) (provider *Provider, modelName 
 		"cohere/":     CohereID,
 		"deepseek/":   DeepseekID,
 		"google/":     GoogleID,
+		"mistral/":    MistralID,
 	}
 
 	for prefix, providerID := range providerPrefixMapping {

--- a/providers/registry.go
+++ b/providers/registry.go
@@ -128,6 +128,16 @@ var Registry = map[Provider]*Config{
 			Chat:   GroqChatEndpoint,
 		},
 	},
+	MistralID: {
+		ID:       MistralID,
+		Name:     MistralDisplayName,
+		URL:      MistralDefaultBaseURL,
+		AuthType: AuthTypeBearer,
+		Endpoints: Endpoints{
+			Models: MistralModelsEndpoint,
+			Chat:   MistralChatEndpoint,
+		},
+	},
 	OllamaID: {
 		ID:       OllamaID,
 		Name:     OllamaDisplayName,

--- a/tests/providers_test.go
+++ b/tests/providers_test.go
@@ -36,6 +36,17 @@ func TestProviderRegistry(t *testing.T) {
 				Chat:   providers.OpenaiChatEndpoint,
 			},
 		},
+		providers.MistralID: {
+			ID:       providers.MistralID,
+			Name:     providers.MistralDisplayName,
+			URL:      providers.MistralDefaultBaseURL,
+			Token:    "test-token",
+			AuthType: providers.AuthTypeBearer,
+			Endpoints: providers.Endpoints{
+				Models: providers.MistralModelsEndpoint,
+				Chat:   providers.MistralChatEndpoint,
+			},
+		},
 		providers.OllamaID: {
 			ID:       providers.OllamaID,
 			Name:     providers.OllamaDisplayName,
@@ -53,6 +64,7 @@ func TestProviderRegistry(t *testing.T) {
 	providerConfigs := registry.GetProviders()
 	assert.Equal(t, len(cfg), len(providerConfigs))
 	assert.Equal(t, cfg[providers.OpenaiID], providerConfigs[providers.OpenaiID])
+	assert.Equal(t, cfg[providers.MistralID], providerConfigs[providers.MistralID])
 	assert.Equal(t, cfg[providers.OllamaID], providerConfigs[providers.OllamaID])
 
 	ctrl := gomock.NewController(t)
@@ -251,6 +263,12 @@ func TestDifferentAuthTypes(t *testing.T) {
 			},
 		},
 		{
+			name:       "Mistral Bearer Auth",
+			providerId: providers.MistralID,
+			authType:   providers.AuthTypeBearer,
+			token:      "mistral-api-key",
+		},
+		{
 			name:       "No Auth",
 			providerId: providers.OllamaID,
 			authType:   providers.AuthTypeNone,
@@ -433,6 +451,14 @@ func BenchmarkProviderTransformations(b *testing.B) {
 		},
 	}
 
+	mistralData := &providers.ListModelsResponseMistral{
+		Object: "list",
+		Data: []providers.Model{
+			{ID: "mistral-large-latest"},
+			{ID: "mistral-small-latest"},
+		},
+	}
+
 	b.Run("OllamaTransform", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_ = ollamaData.Transform()
@@ -442,6 +468,12 @@ func BenchmarkProviderTransformations(b *testing.B) {
 	b.Run("OpenAITransform", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			_ = openaiData.Transform()
+		}
+	})
+
+	b.Run("MistralTransform", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = mistralData.Transform()
 		}
 	})
 }


### PR DESCRIPTION
Implements Mistral AI as a provider for the inference-gateway

Closes #172

## Summary
Adds Mistral AI support with OpenAI-compatible API integration:
- Provider ID: `mistral`
- Base URL: `https://api.mistral.ai/v1`
- Authentication: Bearer token (`MISTRAL_API_KEY`)
- Endpoints: `/models` and `/chat/completions`

## Changes
- Add Mistral to OpenAPI configurations
- Generate Golang types for Mistral provider
- Update provider registry and documentation
- Add comprehensive tests and examples
- Support `MISTRAL_API_KEY` and `MISTRAL_API_URL` environment variables

Generated with [Claude Code](https://claude.ai/code)