### PR TITLE
fix: Prevent gateway crash when A2A agents fail to initialize

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -179,10 +179,10 @@ func main() {
 				logger.Info("starting a2a client initialization with static agents", "timeout", cfg.A2A.ClientTimeout.String())
 				initErr := a2aClient.InitializeAll(initCtx)
 				if initErr != nil {
-					logger.Error("failed to initialize a2a client", initErr)
-					return
+					logger.Warn("a2a client initialization failed, but continuing gateway startup - background reconnection enabled", "error", initErr)
+				} else {
+					logger.Info("a2a client initialized successfully")
 				}
-				logger.Info("a2a client initialized successfully")
 			} else if cfg.A2A.ServiceDiscoveryEnable {
 				logger.Info("starting a2a client with service discovery enabled", "namespace", cfg.A2A.ServiceDiscoveryNamespace)
 			}


### PR DESCRIPTION
This PR fixes issue #178 where the Inference Gateway would crash when A2A agents failed to initialize during startup.

## Changes
- Modified `cmd/gateway/main.go` to log a warning instead of crashing when A2A initialization fails
- Gateway continues normal operation even when no A2A agents are initially available
- Preserves existing background reconnection mechanism with exponential backoff

## Testing
- All existing tests pass
- Linting passes
- Build successful

Fixes #178

Generated with [Claude Code](https://claude.ai/code)