### PR TITLE
chore(deps): Update cosign-installer to v4.0.0 in artifacts workflow

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -85,7 +85,7 @@ jobs:
       TAG: ${{ github.event.release.tag_name }}
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.0.0
         with:
           cosign-release: 'v3.0.2'
 


### PR DESCRIPTION
## Summary

Use the exact version for cosign-installer.