### PR TITLE
chore(docs): Update Kubernetes examples to use k3s v1.34.1 and ingress-nginx v4.14.0

### DIFF
--- a/examples/kubernetes/agent/Cluster.yaml
+++ b/examples/kubernetes/agent/Cluster.yaml
@@ -1,18 +1,12 @@
 ---
 apiVersion: ctlptl.dev/v1alpha1
-kind: Registry
-name: local-registry
-port: 5000
-image: registry:2
----
-apiVersion: ctlptl.dev/v1alpha1
 kind: Cluster
 product: k3d
 registry: local-registry
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     options:
       k3s:
         extraArgs:

--- a/examples/kubernetes/agent/Taskfile.yaml
+++ b/examples/kubernetes/agent/Taskfile.yaml
@@ -7,12 +7,12 @@ tasks:
     cmds:
       - ctlptl apply -f Cluster.yaml
       - helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+      - helm repo update
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
-          --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - echo "🚀 Infrastructure with registry deployed successfully!"
@@ -48,7 +48,7 @@ tasks:
           --set config.ENVIRONMENT=development \
           --set envFrom.secretRef=inference-gateway \
           --wait \
-          --version 0.14.0 \
+          --version 0.19.5 \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🚪 Inference Gateway deployed successfully!"
 

--- a/examples/kubernetes/authentication/Cluster.yaml
+++ b/examples/kubernetes/authentication/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/authentication/Taskfile.yaml
+++ b/examples/kubernetes/authentication/Taskfile.yaml
@@ -9,13 +9,14 @@ tasks:
       - helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
       - helm repo add jetstack https://charts.jetstack.io
       - helm repo add bitnami https://charts.bitnami.com/bitnami
+      - helm repo update
       - echo "🚀 Starting authentication infrastructure deployment..."
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - |
@@ -133,7 +134,7 @@ tasks:
           --set volumeMounts[0].subPath=ca.crt \
           --set volumeMounts[0].readOnly=true \
           --wait \
-          --version 0.14.0 \
+          --version 0.19.5 \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🔒 Inference Gateway with authentication enabled, deployed successfully!"
 

--- a/examples/kubernetes/basic/Cluster.yaml
+++ b/examples/kubernetes/basic/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/hybrid/Cluster.yaml
+++ b/examples/kubernetes/hybrid/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 3
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/hybrid/Taskfile.yaml
+++ b/examples/kubernetes/hybrid/Taskfile.yaml
@@ -7,12 +7,13 @@ tasks:
     cmds:
       - ctlptl apply -f Cluster.yaml
       - helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+      - helm repo update
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - echo "🚀 Hybrid infrastructure deployed successfully!"
@@ -41,7 +42,7 @@ tasks:
           --set ingress.enabled=true \
           --set config.OLLAMA_API_URL="http://ollama.ollama:8080/v1" \
           --set envFrom.secretRef=inference-gateway \
-          --version 0.14.0 \
+          --version 0.19.5 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🚪 Inference Gateway with hybrid providers deployed successfully!"

--- a/examples/kubernetes/mcp/Cluster.yaml
+++ b/examples/kubernetes/mcp/Cluster.yaml
@@ -6,7 +6,7 @@ name: k3d-mcp-cluster
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/mcp/Taskfile.yaml
+++ b/examples/kubernetes/mcp/Taskfile.yaml
@@ -107,7 +107,7 @@ tasks:
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           --timeout=10m \
           ingress-nginx ingress-nginx/ingress-nginx

--- a/examples/kubernetes/monitoring/Cluster.yaml
+++ b/examples/kubernetes/monitoring/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 3
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/monitoring/Taskfile.yaml
+++ b/examples/kubernetes/monitoring/Taskfile.yaml
@@ -9,13 +9,14 @@ tasks:
       - helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
       - helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
       - helm repo add grafana https://grafana.github.io/helm-charts
+      - helm repo update
       - echo "🚀 Starting monitoring infrastructure deployment..."
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - |
@@ -61,7 +62,7 @@ tasks:
           --set autoscaling.maxReplicas=10 \
           --set autoscaling.targetCPUUtilizationPercentage=80 \
           --set autoscaling.targetMemoryUtilizationPercentage=80 \
-          --version 0.14.0 \
+          --version 0.19.5 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - kubectl label namespace inference-gateway monitoring="true" --overwrite

--- a/examples/kubernetes/tls/Cluster.yaml
+++ b/examples/kubernetes/tls/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 443:443
         nodeFilters:

--- a/examples/kubernetes/tls/Taskfile.yaml
+++ b/examples/kubernetes/tls/Taskfile.yaml
@@ -8,13 +8,14 @@ tasks:
       - ctlptl apply -f Cluster.yaml
       - helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
       - helm repo add jetstack https://charts.jetstack.io
+      - helm repo update
       - echo "🚀 Starting TLS infrastructure deployment..."
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - |
@@ -43,7 +44,7 @@ tasks:
           --set ingress.tls.enabled=true \
           --set ingress.tls.hosts[0]=api.inference-gateway.local \
           --set ingress.tls.secretName=api-inference-gateway-local-tls \
-          --version 0.14.0 \
+          --version 0.19.5 \
           --wait \
           inference-gateway oci://ghcr.io/inference-gateway/charts/inference-gateway
       - echo "🔐 Inference Gateway with TLS deployed successfully!"

--- a/examples/kubernetes/ui/Cluster.yaml
+++ b/examples/kubernetes/ui/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 1
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/examples/kubernetes/ui/README.md
+++ b/examples/kubernetes/ui/README.md
@@ -79,7 +79,7 @@ helm upgrade --install \
   --create-namespace \
   --namespace kube-system \
   --set controller.progressDeadlineSeconds=500 \
-  --version 4.12.2 \
+  --version 4.14.0 \
   --wait \
   ingress-nginx ingress-nginx/ingress-nginx
 ```

--- a/examples/kubernetes/ui/Taskfile.yaml
+++ b/examples/kubernetes/ui/Taskfile.yaml
@@ -13,7 +13,7 @@ tasks:
           --create-namespace \
           --namespace kube-system \
           --set controller.progressDeadlineSeconds=500 \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --wait \
           ingress-nginx ingress-nginx/ingress-nginx
       - |

--- a/hack/Cluster.yaml
+++ b/hack/Cluster.yaml
@@ -5,7 +5,7 @@ product: k3d
 k3d:
   v1alpha5Simple:
     agents: 3
-    image: docker.io/rancher/k3s:v1.32.0-k3s1
+    image: docker.io/rancher/k3s:v1.34.1-k3s1
     ports:
       - port: 80:80
         nodeFilters:

--- a/hack/Taskfile.yml
+++ b/hack/Taskfile.yml
@@ -47,11 +47,12 @@ tasks:
       - helm repo add codecentric https://codecentric.github.io/helm-charts
       - helm repo add jetstack https://charts.jetstack.io
       - helm repo add bitnami https://charts.bitnami.com/bitnami
+      - helm repo update
       - |
         helm upgrade --install \
           --create-namespace \
           --namespace kube-system \
-          --version 4.12.2 \
+          --version 4.14.0 \
           --set controller.progressDeadlineSeconds=600 \
           ingress-nginx ingress-nginx/ingress-nginx
       - |


### PR DESCRIPTION
## Summary

Update the examples, bump the version of nginx ingress and k3s to the latest and ensure examples are working.