### PR TITLE
chore(ci): Migrate GoReleaser to dockers_v2 format

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,49 +32,19 @@ builds:
     ldflags:
       - -s -w -X main.version={{ .Version }} -X main.commit={{ .Commit }} -X main.date={{ .CommitDate }} -X main.builtBy=goreleaser -X main.treeState={{ .IsGitDirty }}
 
-dockers:
-  - id: inference-gateway-amd64
-    goos: linux
-    goarch: amd64
-    goamd64: 'v1'
-    use: buildx
+dockers_v2:
+  - id: inference-gateway
     dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - 'ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-amd64'
-    build_flag_templates:
-      - '--platform=linux/amd64'
-      - '--pull'
-      - '--label=org.opencontainers.image.created={{ .Date }}'
-      - '--label=org.opencontainers.image.title={{ .ProjectName }}'
-      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
-      - '--label=org.opencontainers.image.version={{ .Version }}'
-
-  - id: inference-gateway-arm64
-    goos: linux
-    goarch: arm64
-    goarm: '7'
-    use: buildx
-    dockerfile: Dockerfile.goreleaser
-    image_templates:
-      - 'ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-arm64'
-    build_flag_templates:
-      - '--platform=linux/arm64'
-      - '--pull'
-      - '--label=org.opencontainers.image.created={{ .Date }}'
-      - '--label=org.opencontainers.image.title={{ .ProjectName }}'
-      - '--label=org.opencontainers.image.revision={{ .FullCommit }}'
-      - '--label=org.opencontainers.image.version={{ .Version }}'
-
-docker_manifests:
-  - name_template: ghcr.io/inference-gateway/inference-gateway:{{ .Version }}
-    image_templates:
-      - ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-amd64
-      - ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-arm64
-
-  - name_template: '{{ if not (contains .Tag `rc`) }}ghcr.io/inference-gateway/inference-gateway:latest{{ end }}'
-    image_templates:
-      - '{{ if not (contains .Tag `rc`) }}ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-amd64{{ end }}'
-      - '{{ if not (contains .Tag `rc`) }}ghcr.io/inference-gateway/inference-gateway:{{ .Version }}-arm64{{ end }}'
+    images:
+      - 'ghcr.io/inference-gateway/inference-gateway'
+    tags:
+      - '{{ .Version }}'
+      - '{{ if not (contains .Tag `rc`) }}latest{{ end }}'
+    labels:
+      org.opencontainers.image.created: '{{ .Date }}'
+      org.opencontainers.image.title: '{{ .ProjectName }}'
+      org.opencontainers.image.revision: '{{ .FullCommit }}'
+      org.opencontainers.image.version: '{{ .Version }}'
 
 archives:
   - formats:

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,5 +1,6 @@
 FROM gcr.io/distroless/static-debian12
+ARG TARGETPLATFORM
 WORKDIR /app
-COPY inference-gateway /app/inference-gateway
+COPY $TARGETPLATFORM/inference-gateway /app/inference-gateway
 EXPOSE 8080
 CMD ["./inference-gateway"]


### PR DESCRIPTION
## Summary

- Migrated from deprecated `dockers` and `docker_manifests` to the new `dockers_v2` format in `.goreleaser.yaml`
- Updated `Dockerfile.goreleaser` to support multi-platform builds using the `TARGETPLATFORM` ARG
- Simplified Docker configuration by consolidating platform-specific builds into a single entry
- Eliminates deprecation warnings during GoReleaser execution

## Changes

**`.goreleaser.yaml`:**
- Replaced 40+ lines of deprecated `dockers` and `docker_manifests` configuration with 13 lines of modern `dockers_v2` config
- Tags and labels are now defined more cleanly without conditional logic in image templates
- Maintains same functionality: multi-platform builds (amd64/arm64) with version and latest tags

**`Dockerfile.goreleaser`:**
- Added `ARG TARGETPLATFORM` to support GoReleaser's multi-platform artifact organization
- Updated COPY path to use `$TARGETPLATFORM/inference-gateway`

## Test Plan

- [x] Validated configuration with `goreleaser check`
- [x] Tested snapshot build with `goreleaser build --snapshot --clean --single-target`
- [x] Verified no deprecation warnings appear
- [ ] Test full release workflow in CI

Fixes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)