### PR TITLE
chore(ci): Add Docker image description label to GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,6 +45,7 @@ dockers_v2:
       org.opencontainers.image.title: '{{ .ProjectName }}'
       org.opencontainers.image.revision: '{{ .FullCommit }}'
       org.opencontainers.image.version: '{{ .Version }}'
+      org.opencontainers.image.description: 'An open-source, cloud-native, high-performance gateway unifying multiple LLM providers, from local solutions like Ollama to major cloud providers such as OpenAI, Groq, Cohere, Anthropic, Cloudflare and DeepSeek.'
 
 archives:
   - formats:


### PR DESCRIPTION
## Summary

- Added `org.opencontainers.image.description` label to the GoReleaser Docker configuration
- This provides a comprehensive description of the inference gateway in container registries (e.g., GitHub Container Registry)
- Fixes the "No description provided" message that appears when viewing the published container image

## Changes

- Updated `.goreleaser.yaml` to include the description label with full project description

## Test plan

- [ ] Verify GoReleaser configuration is valid
- [ ] Confirm the description appears in the container registry after the next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)