### PR TITLE
chore(ci): Improve GoReleaser configuration for reproducibility and OCI compliance

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,11 +40,17 @@ dockers_v2:
     tags:
       - '{{ .Version }}'
       - '{{ if not (contains .Tag `rc`) }}latest{{ end }}'
+    platforms:
+      - linux/amd64
+      - linux/arm64
     labels:
-      org.opencontainers.image.created: '{{ .Date }}'
+      org.opencontainers.image.created: '{{ .CommitDate }}'
       org.opencontainers.image.title: '{{ .ProjectName }}'
       org.opencontainers.image.revision: '{{ .FullCommit }}'
       org.opencontainers.image.version: '{{ .Version }}'
+      org.opencontainers.image.source: '{{ .GitURL }}'
+      org.opencontainers.image.url: 'https://github.com/inference-gateway/inference-gateway'
+      org.opencontainers.image.licenses: 'MIT'
       org.opencontainers.image.description: 'An open-source, cloud-native, high-performance gateway unifying multiple LLM providers, from local solutions like Ollama to major cloud providers such as OpenAI, Groq, Cohere, Anthropic, Cloudflare and DeepSeek.'
 
 archives:


### PR DESCRIPTION
## Summary

This PR updates the GoReleaser configuration to align with 2025 best practices for reproducible builds and OCI compliance:

- **Fixed reproducibility issue**: Changed Docker label `org.opencontainers.image.created` to use `{{ .CommitDate }}` instead of `{{ .Date }}` for consistent, reproducible builds
- **Added explicit platform specification**: Declared `linux/amd64` and `linux/arm64` platforms for multi-architecture support
- **Enhanced OCI metadata**: Added recommended labels including `source`, `url`, and `licenses` to improve GitHub Container Registry integration

## Changes

### Docker Labels (.goreleaser.yaml:47)
- `org.opencontainers.image.created`: Now uses `{{ .CommitDate }}` for reproducibility
- Added `org.opencontainers.image.source`: Links to Git repository
- Added `org.opencontainers.image.url`: Project homepage
- Added `org.opencontainers.image.licenses`: MIT license

### Platform Support (.goreleaser.yaml:43-45)
- Explicitly defined `linux/amd64` and `linux/arm64` platforms

These changes ensure Docker images are reproducible and include comprehensive metadata for better discoverability and compliance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)