### PR TITLE
chore: Add missing annotations for multi-arch builds in GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,15 @@ dockers_v2:
       org.opencontainers.image.url: 'https://github.com/inference-gateway/inference-gateway'
       org.opencontainers.image.licenses: 'MIT'
       org.opencontainers.image.description: 'An open-source, cloud-native, high-performance gateway unifying multiple LLM providers, from local solutions like Ollama to major cloud providers such as OpenAI, Groq, Cohere, Anthropic, Cloudflare and DeepSeek.'
+    annotations:
+      org.opencontainers.image.created: '{{ .CommitDate }}'
+      org.opencontainers.image.title: '{{ .ProjectName }}'
+      org.opencontainers.image.revision: '{{ .FullCommit }}'
+      org.opencontainers.image.version: '{{ .Version }}'
+      org.opencontainers.image.source: '{{ .GitURL }}'
+      org.opencontainers.image.url: 'https://github.com/inference-gateway/inference-gateway'
+      org.opencontainers.image.licenses: 'MIT'
+      org.opencontainers.image.description: 'An open-source, cloud-native, high-performance gateway unifying multiple LLM providers, from local solutions like Ollama to major cloud providers such as OpenAI, Groq, Cohere, Anthropic, Cloudflare and DeepSeek.'
 
 archives:
   - formats:


### PR DESCRIPTION
## Summary

- Added OCI image annotations to the GoReleaser docker configuration
- Annotations mirror the existing labels for consistency and OCI compliance
- Includes metadata: created date, title, revision, version, source URL, project URL, license, and description

## Test plan

- [ ] Verify GoReleaser config syntax is valid
- [ ] Confirm multi-arch builds complete successfully
- [ ] Check that resulting Docker images contain proper OCI annotations

🤖 Generated with [Claude Code](https://claude.com/claude-code)