### PR TITLE
docs: Add installation guide and version/help flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ The Inference Gateway is a proxy server designed to facilitate access to various
   - [Available Tools](#available-tools)
   - [Common Commands](#common-commands)
   - [Environment Details](#environment-details)
+- [Installation](#installation)
+  - [Using Install Script](#using-install-script)
+  - [Manual Download](#manual-download)
+  - [Verify Installation](#verify-installation)
+  - [Running the Gateway](#running-the-gateway)
 - [Configuration](#configuration)
 - [Examples](#examples)
 - [SDKs](#sdks)
@@ -591,6 +596,85 @@ To exit the development environment, simply run:
 ```bash
 exit
 ```
+
+## Installation
+
+> **Recommended**: For production deployments, running the Inference Gateway as a container is recommended. This provides better isolation, easier updates, and simplified configuration management. See [Docker](examples/docker-compose/) or [Kubernetes](examples/kubernetes/) deployment examples.
+
+The Inference Gateway can also be installed as a standalone binary using the provided install script or by downloading pre-built binaries from GitHub releases.
+
+### Using Install Script
+
+The easiest way to install the Inference Gateway is using the automated install script:
+
+**Install latest version:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | bash
+```
+
+**Install specific version:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | VERSION=v0.20.1 bash
+```
+
+**Install to custom directory:**
+
+```bash
+# Install to custom location
+curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | INSTALL_DIR=~/.local/bin bash
+
+# Install to current directory
+curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | INSTALL_DIR=. bash
+```
+
+**What the script does:**
+
+- Automatically detects your operating system (Linux/macOS) and architecture (x86_64/arm64/armv7)
+- Downloads the appropriate binary from GitHub releases
+- Extracts and installs to `/usr/local/bin` (or custom directory)
+- Verifies the installation
+
+**Supported platforms:**
+
+- Linux: x86_64, arm64, armv7
+- macOS (Darwin): x86_64 (Intel), arm64 (Apple Silicon)
+
+### Manual Download
+
+Download pre-built binaries directly from the [releases page](https://github.com/inference-gateway/inference-gateway/releases):
+
+1. Download the appropriate archive for your platform
+2. Extract the binary:
+   ```bash
+   tar -xzf inference-gateway_<OS>_<ARCH>.tar.gz
+   ```
+3. Move to a directory in your PATH:
+   ```bash
+   sudo mv inference-gateway /usr/local/bin/
+   chmod +x /usr/local/bin/inference-gateway
+   ```
+
+### Verify Installation
+
+```bash
+inference-gateway --version
+```
+
+### Running the Gateway
+
+Once installed, start the gateway with your configuration:
+
+```bash
+# Set required environment variables
+export OPENAI_API_KEY="your-api-key"
+
+# Start the gateway
+inference-gateway
+```
+
+For detailed configuration options, see the [Configuration](#configuration) section below.
 
 ## Configuration
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -15,14 +17,50 @@ import (
 	middlewares "github.com/inference-gateway/inference-gateway/api/middlewares"
 	config "github.com/inference-gateway/inference-gateway/config"
 	l "github.com/inference-gateway/inference-gateway/logger"
-	"github.com/inference-gateway/inference-gateway/mcp"
+	mcp "github.com/inference-gateway/inference-gateway/mcp"
 	otel "github.com/inference-gateway/inference-gateway/otel"
 	providers "github.com/inference-gateway/inference-gateway/providers"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sethvargo/go-envconfig"
+	promhttp "github.com/prometheus/client_golang/prometheus/promhttp"
+	envconfig "github.com/sethvargo/go-envconfig"
+)
+
+var (
+	version = "dev"
 )
 
 func main() {
+	versionFlag := flag.Bool("version", false, "Print version information")
+	helpFlag := flag.Bool("help", false, "Print help information")
+	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(version)
+		os.Exit(0)
+	}
+
+	if *helpFlag {
+		fmt.Println("Inference Gateway - Unified API gateway for multiple LLM providers")
+		fmt.Println()
+		fmt.Println("Usage:")
+		fmt.Println("  inference-gateway [flags]")
+		fmt.Println()
+		fmt.Println("Flags:")
+		fmt.Println("  --version    Print version information")
+		fmt.Println("  --help       Print help information")
+		fmt.Println()
+		fmt.Println("Configuration:")
+		fmt.Println("  The gateway is configured via environment variables.")
+		fmt.Println("  See https://github.com/inference-gateway/inference-gateway/blob/main/Configurations.md")
+		fmt.Println()
+		fmt.Println("Examples:")
+		fmt.Println("  # Start the gateway with default configuration")
+		fmt.Println("  inference-gateway")
+		fmt.Println()
+		fmt.Println("  # Start with specific provider configured")
+		fmt.Println("  export OPENAI_API_KEY=your-key")
+		fmt.Println("  inference-gateway")
+		os.Exit(0)
+	}
 	var config config.Config
 	cfg, err := config.Load(envconfig.OsLookuper())
 	if err != nil {

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -e
+
+VERSION="${VERSION:-latest}"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+REPO="inference-gateway/inference-gateway"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}Warning:${NC} $1"
+}
+
+error() {
+    echo -e "${RED}Error:${NC} $1" >&2
+    exit 1
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Linux*)     echo "Linux";;
+        Darwin*)    echo "Darwin";;
+        *)          error "Unsupported operating system: $(uname -s)";;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64)   echo "x86_64";;
+        aarch64|arm64)  echo "arm64";;
+        armv7l)         echo "armv7";;
+        *)              error "Unsupported architecture: $(uname -m)";;
+    esac
+}
+
+get_download_url() {
+    local os="$1"
+    local arch="$2"
+    local version="$3"
+
+    if [ "$version" = "latest" ]; then
+        local release_url="https://api.github.com/repos/${REPO}/releases/latest"
+    else
+        local release_url="https://api.github.com/repos/${REPO}/releases/tags/${version}"
+    fi
+
+    local release_json=$(curl -fsSL "$release_url")
+
+    local tag_name=$(echo "$release_json" | grep -o '"tag_name": *"[^"]*"' | head -1 | sed 's/"tag_name": *"\(.*\)"/\1/')
+
+    local asset_name="inference-gateway_${os}_${arch}.tar.gz"
+
+    local download_url=$(echo "$release_json" | grep -o "\"browser_download_url\": *\"[^\"]*${asset_name}\"" | sed 's/"browser_download_url": *"\(.*\)"/\1/')
+
+    if [ -z "$download_url" ]; then
+        error "Could not find binary for ${os}/${arch} in release ${tag_name}"
+    fi
+
+    echo "$download_url"
+}
+
+main() {
+    info "Installing Inference Gateway..."
+
+    local os=$(detect_os)
+    local arch=$(detect_arch)
+
+    info "Detected platform: ${os}/${arch}"
+
+    info "Fetching release information..."
+    local download_url=$(get_download_url "$os" "$arch" "$VERSION")
+
+    info "Downloading from: $download_url"
+
+    local tmp_dir=$(mktemp -d)
+    trap "rm -rf $tmp_dir" EXIT
+
+    local archive_path="${tmp_dir}/inference-gateway.tar.gz"
+    if ! curl -fsSL -o "$archive_path" "$download_url"; then
+        error "Failed to download binary"
+    fi
+
+    info "Extracting binary..."
+    tar -xzf "$archive_path" -C "$tmp_dir"
+
+    local binary_path=$(find "$tmp_dir" -name "inference-gateway" -type f | head -1)
+
+    if [ -z "$binary_path" ]; then
+        error "Binary not found in archive"
+    fi
+
+    chmod +x "$binary_path"
+
+    info "Installing to ${INSTALL_DIR}..."
+
+    if [ -w "$INSTALL_DIR" ]; then
+        mv "$binary_path" "${INSTALL_DIR}/inference-gateway"
+    else
+        warn "Need sudo permissions to install to ${INSTALL_DIR}"
+        sudo mv "$binary_path" "${INSTALL_DIR}/inference-gateway"
+    fi
+
+    if command -v inference-gateway &> /dev/null; then
+        local installed_version=$(inference-gateway --version 2>/dev/null || echo "unknown")
+        info "✓ Successfully installed inference-gateway"
+        info "Version: $installed_version"
+        info "Location: ${INSTALL_DIR}/inference-gateway"
+    else
+        error "Installation failed - binary not found in PATH"
+    fi
+}
+
+usage() {
+    cat <<EOF
+Usage: install.sh [OPTIONS]
+
+Install the inference-gateway binary from GitHub releases.
+
+Options:
+    VERSION=<version>       Specify version to install (default: latest)
+    INSTALL_DIR=<path>      Installation directory (default: /usr/local/bin)
+
+Examples:
+    # Install latest version to /usr/local/bin
+    curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | bash
+
+    # Install specific version
+    curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | VERSION=v1.2.3 bash
+
+    # Install to custom directory
+    curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | INSTALL_DIR=~/.local/bin bash
+
+    # Install to current directory
+    curl -fsSL https://raw.githubusercontent.com/inference-gateway/inference-gateway/main/install.sh | INSTALL_DIR=. bash
+
+EOF
+}
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+    usage
+    exit 0
+fi
+
+main


### PR DESCRIPTION
## Summary

- Add comprehensive installation guide to README with install script usage examples
- Add `--version` and `--help` command-line flags to the gateway binary
- Update install script to properly display version information
- Include container deployment recommendation for production deployments

## Changes

### README.md
- Added new **Installation** section after Development Environment
- Documents install script usage with examples for:
  - Installing latest version
  - Installing specific version (e.g., `VERSION=v0.20.1`)
  - Installing to custom directory
- Added manual download instructions
- Included container deployment recommendation for production
- Updated table of contents

### cmd/gateway/main.go
- Added `--version` flag that outputs simple version string (e.g., "v0.20.1")
- Added `--help` flag with usage information and examples
- Version information injected at build time via GoReleaser ldflags
- Clean, formatted help output with flags and descriptions on same line

### install.sh
- Updated to properly capture and display version from `--version` flag
- Suppressed stderr to avoid configuration warnings during version check

## Test Plan

- [x] Built binary locally and verified `--version` outputs version string
- [x] Verified `--help` displays formatted usage information
- [x] Tested install script version detection
- [x] Verified README rendering and table of contents links
- [x] Confirmed install script examples work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)