### PR TITLE
fix(providers): Add Ollama Cloud to stream_options exception list

### DIFF
--- a/providers/management.go
+++ b/providers/management.go
@@ -24,9 +24,9 @@ func (p *ProviderImpl) prepareStreamingRequest(clientReq CreateChatCompletionReq
 		IncludeUsage: true,
 	}
 
-	// Special case - cohere and mistral don't like stream_options, so we don't
+	// Special case - cohere, mistral, and ollama_cloud don't like stream_options, so we don't
 	// include it - probably they haven't implemented it yet in their OpenAI "compatible" API
-	if *p.GetID() == CohereID || *p.GetID() == MistralID {
+	if *p.GetID() == CohereID || *p.GetID() == MistralID || *p.GetID() == OllamaCloudID {
 		clientReq.StreamOptions = nil
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes the missing usage statistics issue for Ollama Cloud streaming responses by adding it to the stream_options exception list.

## Changes

- Added `OllamaCloudID` to the exception list in `prepareStreamingRequest()`
- Updated comment to reflect that Cohere, Mistral, and Ollama Cloud don't support `stream_options`

## Why This Fix Works

Ollama Cloud's OpenAI-compatible API doesn't support the `stream_options` parameter yet. When the gateway sends this parameter, the upstream API ignores it and may not return usage statistics. By excluding this parameter from requests to Ollama Cloud, we allow the provider to respond with its default streaming format.

## Testing

Test with:
```bash
curl -X POST http://localhost:8080/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"ollama_cloud/kimi-k2-thinking","messages":[{"role":"user","content":"Hi"}],"stream":true}' \
  | grep -E "(usage|finish_reason)"
```

Fixes #206

Generated with [Claude Code](https://claude.ai/code)