### PR TITLE
refactor(providers): Improve vision model detection

### DIFF
--- a/providers/management.go
+++ b/providers/management.go
@@ -364,6 +364,8 @@ func (p *ProviderImpl) SupportsVision(ctx context.Context, model string) (bool, 
 			strings.Contains(modelLower, "claude-4"), nil
 	default:
 		return strings.Contains(modelLower, "vision") ||
-			strings.Contains(modelLower, "multimodal"), nil
+			strings.Contains(modelLower, "multimodal") ||
+			strings.Contains(modelLower, "-vl") ||
+			strings.Contains(modelLower, "qwen") && strings.Contains(modelLower, "vl"), nil
 	}
 }


### PR DESCRIPTION
Enhance SupportsVision function to detect additional vision-capable models:
- Add detection for models with "-vl" suffix (vision-language models)
- Add specific detection for Qwen VL models

This improves compatibility with vision models from various providers
that use alternative naming conventions.

Signed-off-by: Eden Reich <eden.reich@gmail.com>
