### PR TITLE
refactor(providers): Improve Claude 4 vision model detection

### DIFF
--- a/providers/management.go
+++ b/providers/management.go
@@ -361,7 +361,9 @@ func (p *ProviderImpl) SupportsVision(ctx context.Context, model string) (bool, 
 		return false, nil
 	case AnthropicID:
 		return strings.Contains(modelLower, "claude-3") ||
-			strings.Contains(modelLower, "claude-4"), nil
+			strings.Contains(modelLower, "opus-4") ||
+			strings.Contains(modelLower, "sonnet-4") ||
+			strings.Contains(modelLower, "haiku-4"), nil
 	default:
 		return strings.Contains(modelLower, "vision") ||
 			strings.Contains(modelLower, "multimodal") ||


### PR DESCRIPTION
## Summary

- Refactored vision detection logic for Anthropic Claude 4 models to use more specific pattern matching
- Changed from checking "claude-4" substring to explicitly checking for "opus-4", "sonnet-4", and "haiku-4" patterns
- Ensures all Claude 4.x model variants are correctly identified as vision-capable

This resolves the error "image content sent to non-vision model" that occurred when using models like `claude-opus-4-20250514`.

## Test plan

- [ ] Verify `claude-opus-4-20250514` is detected as vision-capable
- [ ] Verify `claude-sonnet-4-*` models are detected as vision-capable
- [ ] Verify `claude-haiku-4-*` models are detected as vision-capable
- [ ] Verify Claude 3.x models still work correctly
- [ ] Test with actual image content to ensure no errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)