### PR TITLE
docs: Add Go version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@
   <a href="https://github.com/inference-gateway/inference-gateway/blob/main/LICENSE">
     <img src="https://img.shields.io/github/license/inference-gateway/inference-gateway?color=blue&style=flat-square" alt="License"/>
   </a>
+  <!-- Go Version Badge -->
+  <a href="https://github.com/inference-gateway/inference-gateway/blob/main/go.mod">
+    <img src="https://img.shields.io/github/go-mod/go-version/inference-gateway/inference-gateway?color=blue&style=flat-square&logo=go" alt="Go Version"/>
+  </a>
 </p>
 
 The Inference Gateway is a proxy server designed to facilitate access to various


### PR DESCRIPTION
## Summary
- Add a Go version badge to the README header alongside CI, Version, and License badges
- Badge is sourced from shields.io and reads the version directly from `go.mod`, so it stays in sync automatically