### PR TITLE
chore(deps): Bump SDK to v1.16.3 and refresh generated types

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,7 +27,7 @@ tasks:
       - go run cmd/generate/main.go -type ProvidersClientConfig -output providers/client/client.go
       - go run cmd/generate/main.go -type ProvidersConstants -output providers/constants/constants.go
       - go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest --config=.oapi-codegen.yaml -o providers/types/common_types.go openapi.yaml
-      - sed -i '' 's/interface{}/any/g' providers/types/common_types.go
+      - sed -i.bak 's/interface{}/any/g' providers/types/common_types.go && rm providers/types/common_types.go.bak
       - go run cmd/generate/main.go -type Providers -output providers/transformers
       - go run cmd/generate/main.go -type ProviderRegistry -output providers/registry/registry.go
       - go run cmd/generate/main.go -type Config -output config/config.go

--- a/examples/kubernetes/agent/logs-analyzer/go.mod
+++ b/examples/kubernetes/agent/logs-analyzer/go.mod
@@ -3,7 +3,7 @@ module github.com/youraccount/yourrepo
 go 1.26.2
 
 require (
-	github.com/inference-gateway/sdk v1.16.2
+	github.com/inference-gateway/sdk v1.16.3
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
@@ -18,7 +18,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.21.1 // indirect
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.1 // indirect
-	github.com/go-resty/resty/v2 v2.16.5 // indirect
+	github.com/go-resty/resty/v2 v2.17.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -27,7 +27,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/oapi-codegen/runtime v1.1.2 // indirect
+	github.com/oapi-codegen/runtime v1.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/examples/kubernetes/agent/logs-analyzer/go.sum
+++ b/examples/kubernetes/agent/logs-analyzer/go.sum
@@ -18,8 +18,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.1 h1:lpsStH0n2ittzTnbaSloVZLuB5+fvSY/+hnagBjSNZU=
 github.com/go-openapi/swag v0.23.1/go.mod h1:STZs8TbRvEQQKUA+JZNAm3EWlgaOBGpyFDqQnDHMef0=
-github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
-github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
+github.com/go-resty/resty/v2 v2.17.2 h1:FQW5oHYcIlkCNrMD2lloGScxcHJ0gkjshV3qcQAyHQk=
+github.com/go-resty/resty/v2 v2.17.2/go.mod h1:kCKZ3wWmwJaNc7S29BRtUhJwy7iqmn+2mLtQrOyQlVA=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -27,8 +27,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/inference-gateway/sdk v1.16.2 h1:9sw/42Icwcsb4cSDx0ELqF4WhU95IRBVNvirDXIv6OY=
-github.com/inference-gateway/sdk v1.16.2/go.mod h1:lNTq/c42VviO2pKPXdvEf/cWwFpgQjSX7CUP1F7T+0U=
+github.com/inference-gateway/sdk v1.16.3 h1:qIiqYePG4GQyWE92iEPmxQsR0jBJDAG0u9h50CbspcU=
+github.com/inference-gateway/sdk v1.16.3/go.mod h1:Qcm7duXS/Hz/xvs8yQhxLUbCUTWN/x88+npRWyeRst4=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -48,8 +48,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
-github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=
+github.com/oapi-codegen/runtime v1.4.0 h1:KLOSFOp7UzkbS7Cs1ms6NBEKYr0WmH2wZG0KKbd2er4=
+github.com/oapi-codegen/runtime v1.4.0/go.mod h1:5sw5fxCDmnOzKNYmkVNF8d34kyUeejJEY8HNT2WaPec=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/examples/kubernetes/agent/logs-analyzer/main.go
+++ b/examples/kubernetes/agent/logs-analyzer/main.go
@@ -111,17 +111,20 @@ func main() {
 						if pattern.MatchString(line) {
 							ctx := context.Background()
 
-							// Prepare request for logging
-							messages := []sdk.Message{
-								{
-									Role:    sdk.System,
-									Content: fmt.Sprintf(systemPrompt, line),
-								},
-								{
-									Role:    sdk.User,
-									Content: "Analyze this error",
-								},
+							// Prepare request for logging. As of SDK v1.16.x, Message.Content
+							// is a MessageContent union (text or multimodal parts), so we
+							// build messages via the NewTextMessage helper.
+							systemMsg, err := sdk.NewTextMessage(sdk.System, fmt.Sprintf(systemPrompt, line))
+							if err != nil {
+								log.Printf("Error building system message: %v", err)
+								continue
 							}
+							userMsg, err := sdk.NewTextMessage(sdk.User, "Analyze this error")
+							if err != nil {
+								log.Printf("Error building user message: %v", err)
+								continue
+							}
+							messages := []sdk.Message{systemMsg, userMsg}
 
 							// Log the request
 							requestJSON, _ := json.MarshalIndent(map[string]any{
@@ -150,8 +153,14 @@ func main() {
 							responseJSON, _ := json.MarshalIndent(response, "", "  ")
 							log.Printf("Received response from inference gateway:\n%s", string(responseJSON))
 
+							// Message.Content is a union; extract the text variant for logging.
+							analysis, err := response.Choices[0].Message.Content.AsMessageContent0()
+							if err != nil {
+								log.Printf("Error extracting analysis text from response: %v", err)
+								break
+							}
 							log.Printf("Found error in %s/%s:\nError: %s\nAnalysis: %s",
-								ns.Name, pod.Name, line, response.Choices[0].Message.Content)
+								ns.Name, pod.Name, line, analysis)
 							break
 						}
 					}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -157,7 +157,16 @@ paths:
                 $ref: '#/components/schemas/CreateChatCompletionResponse'
             text/event-stream:
               schema:
-                $ref: '#/components/schemas/SSEvent'
+                description: |
+                  Server-Sent Events stream. Each frame is an `SSEvent` whose
+                  `data` field contains the JSON-serialized payload for that
+                  event. For content/message chunk events the payload is a
+                  `CreateChatCompletionStreamResponse`. The `oneOf` here makes
+                  the streaming payload schemas reachable from this operation
+                  so that code generators emit types for them.
+                oneOf:
+                  - $ref: '#/components/schemas/SSEvent'
+                  - $ref: '#/components/schemas/CreateChatCompletionStreamResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1072,11 +1081,28 @@ components:
           description: The index of the choice in the list of choices.
         message:
           $ref: '#/components/schemas/Message'
+        logprobs:
+          description: Log probability information for the choice.
+          type: object
+          nullable: true
+          properties:
+            content:
+              description: A list of message content tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+            refusal:
+              description: A list of message refusal tokens with log probability information.
+              type: array
+              items:
+                $ref: '#/components/schemas/ChatCompletionTokenLogprob'
+          required:
+            - content
+            - refusal
       required:
         - finish_reason
         - index
         - message
-        - logprobs
     ChatCompletionStreamChoice:
       type: object
       required:

--- a/providers/types/common_types.go
+++ b/providers/types/common_types.go
@@ -702,7 +702,7 @@ type ToolCallExtraContent_Google struct {
 	// ThoughtSignature Opaque signature returned with reasoning-enabled tool calls.
 	// Must be echoed back verbatim in the next request that includes
 	// this tool call, or Google will reject the request.
-	ThoughtSignature     *string                `json:"thought_signature,omitempty"`
+	ThoughtSignature     *string        `json:"thought_signature,omitempty"`
 	AdditionalProperties map[string]any `json:"-"`
 }
 

--- a/providers/types/common_types.go
+++ b/providers/types/common_types.go
@@ -244,6 +244,15 @@ type ChatCompletionChoice struct {
 	// Index The index of the choice in the list of choices.
 	Index int `json:"index"`
 
+	// Logprobs Log probability information for the choice.
+	Logprobs *struct {
+		// Content A list of message content tokens with log probability information.
+		Content []ChatCompletionTokenLogprob `json:"content"`
+
+		// Refusal A list of message refusal tokens with log probability information.
+		Refusal []ChatCompletionTokenLogprob `json:"refusal"`
+	} `json:"logprobs,omitempty"`
+
 	// Message Message structure for provider requests
 	Message Message `json:"message"`
 }
@@ -693,7 +702,7 @@ type ToolCallExtraContent_Google struct {
 	// ThoughtSignature Opaque signature returned with reasoning-enabled tool calls.
 	// Must be echoed back verbatim in the next request that includes
 	// this tool call, or Google will reject the request.
-	ThoughtSignature     *string        `json:"thought_signature,omitempty"`
+	ThoughtSignature     *string                `json:"thought_signature,omitempty"`
 	AdditionalProperties map[string]any `json:"-"`
 }
 


### PR DESCRIPTION
## Summary

- Pull the latest `openapi.yaml` from `inference-gateway/schemas` and regenerate `providers/types/common_types.go` — adds the `logprobs` object on `ChatCompletionChoice` and wires `CreateChatCompletionStreamResponse` into the SSE response via `oneOf`.
- Bump `github.com/inference-gateway/sdk` from v1.16.2 → v1.16.3 in `examples/kubernetes/agent/logs-analyzer`. v1.16.3 introduces a `MessageContent` union type (breaking), so the example now builds messages via `sdk.NewTextMessage` and extracts the response text via `Content.AsMessageContent0`.
- Fix BSD-only `sed -i ''` invocation in `Taskfile.yml` so `task generate` works on GNU sed (Linux CI) in addition to macOS.

## Test plan

- [x] `task generate` regenerates `providers/types/common_types.go` cleanly
- [x] `go build ./...` at repo root passes
- [x] `go vet ./...` at repo root passes
- [x] `golangci-lint v2` reports 0 issues
- [x] `go test ./...` at repo root — all packages pass
- [x] `go build ./...` succeeds in every example module (docker-compose + kubernetes MCP servers, logs-analyzer)

Resolves #298

Generated with [Claude Code](https://claude.ai/code)