### PR TITLE
fix(mcp): Keep gateway running when all MCP servers are unreachable at startup

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -317,6 +317,7 @@ func main() {
 
 	if cfg.MCP.Enable && mcpClient != nil {
 		mcpClient.StopStatusPolling()
+		mcpClient.StopBackgroundReconnection()
 	}
 
 	ctxShutdown, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -195,13 +195,6 @@ func main() {
 			case initErr == nil:
 				logger.Info("mcp client initialized successfully")
 			case errors.Is(initErr, mcp.ErrNoClientsInitialized) && cfg.MCP.EnableReconnect:
-				// Defense in depth: the MCP client already treats this as a
-				// recoverable startup state when reconnect is enabled, but if a
-				// future code path ever returns ErrNoClientsInitialized while
-				// background reconnect is still wired up, keep the gateway
-				// running so tool calls fail gracefully instead of
-				// crash-looping the pod.
-				// See: https://github.com/inference-gateway/inference-gateway/issues/304
 				logger.Warn("no mcp servers initialized at startup; continuing with background reconnection enabled",
 					"error", initErr.Error())
 			default:

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -190,11 +191,23 @@ func main() {
 
 			logger.Info("starting mcp client initialization", "timeout", cfg.MCP.RequestTimeout.String())
 			initErr := mcpClient.InitializeAll(initCtx)
-			if initErr != nil {
+			switch {
+			case initErr == nil:
+				logger.Info("mcp client initialized successfully")
+			case errors.Is(initErr, mcp.ErrNoClientsInitialized) && cfg.MCP.EnableReconnect:
+				// Defense in depth: the MCP client already treats this as a
+				// recoverable startup state when reconnect is enabled, but if a
+				// future code path ever returns ErrNoClientsInitialized while
+				// background reconnect is still wired up, keep the gateway
+				// running so tool calls fail gracefully instead of
+				// crash-looping the pod.
+				// See: https://github.com/inference-gateway/inference-gateway/issues/304
+				logger.Warn("no mcp servers initialized at startup; continuing with background reconnection enabled",
+					"error", initErr.Error())
+			default:
 				logger.Error("failed to initialize mcp client", initErr)
 				return
 			}
-			logger.Info("mcp client initialized successfully")
 
 			mcpClient.StartStatusPolling(context.Background())
 			mcpAgent = mcp.NewAgent(logger, mcpClient)

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -412,13 +412,11 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 	mc.Initialized = true
 
 	if successfulInitializations == 0 {
-		mc.Logger.Warn("no servers successfully initialized, but enabling MCP with background reconnection",
-			"total_servers", len(mc.ServerURLs),
-			"failed_servers", len(failedServers),
-			"component", "mcp_client")
-
-		if mc.Config.MCP.EnableReconnect && len(failedServers) > 0 {
-			mc.spawnBackgroundReconnection(failedServers)
+		if mc.scheduleReconnectionIfEnabled(failedServers) {
+			mc.Logger.Warn("no servers successfully initialized; enabling MCP with background reconnection",
+				"total_servers", len(mc.ServerURLs),
+				"failed_servers", len(failedServers),
+				"component", "mcp_client")
 			return nil
 		}
 
@@ -458,14 +456,24 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 		"total_servers", len(mc.ServerURLs),
 		"component", "mcp_client")
 
-	if mc.Config.MCP.EnableReconnect && len(failedServers) > 0 {
-		mc.Logger.Info("starting background reconnection for failed servers",
-			"failed_servers", failedServers,
-			"component", "mcp_client")
-		mc.spawnBackgroundReconnection(failedServers)
-	}
+	mc.scheduleReconnectionIfEnabled(failedServers)
 
 	return nil
+}
+
+// scheduleReconnectionIfEnabled is the single guard point for kicking off the
+// background reconnection goroutine. It spawns the loop iff reconnect is
+// enabled and at least one server failed, and reports whether reconnection
+// was scheduled so callers can branch on it (e.g. the "no servers
+// initialized" path needs to know whether to return nil or surface
+// ErrNoClientsInitialized). Callers should not re-check EnableReconnect
+// themselves — keep that policy in one place.
+func (mc *MCPClient) scheduleReconnectionIfEnabled(failedServers []string) bool {
+	if !mc.Config.MCP.EnableReconnect || len(failedServers) == 0 {
+		return false
+	}
+	mc.spawnBackgroundReconnection(failedServers)
+	return true
 }
 
 // spawnBackgroundReconnection launches the reconnect goroutine with a

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -409,7 +409,14 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 			"component", "mcp_client")
 
 		if mc.Config.MCP.EnableReconnect && len(failedServers) > 0 {
-			go mc.startBackgroundReconnection(ctx, failedServers)
+			// Background reconnection will keep retrying until at least one server
+			// becomes reachable. Treat startup as successful so the gateway can
+			// continue serving non-MCP traffic and graceful tool-call failures
+			// instead of crash-looping when every MCP backend is temporarily
+			// unreachable (cold starts, DNS races, MCP rollouts, etc.).
+			// See: https://github.com/inference-gateway/inference-gateway/issues/304
+			go mc.startBackgroundReconnection(context.Background(), failedServers)
+			return nil
 		}
 
 		if lastError != nil {
@@ -452,7 +459,10 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 		mc.Logger.Info("starting background reconnection for failed servers",
 			"failed_servers", failedServers,
 			"component", "mcp_client")
-		go mc.startBackgroundReconnection(ctx, failedServers)
+		// Detach from the initialization context (which has a short timeout)
+		// so the background reconnect ticker can keep running for the lifetime
+		// of the process.
+		go mc.startBackgroundReconnection(context.Background(), failedServers)
 	}
 
 	return nil

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -89,6 +89,12 @@ type MCPClientInterface interface {
 
 	// StopStatusPolling stops the background status polling goroutine
 	StopStatusPolling()
+
+	// StopBackgroundReconnection stops the background reconnection goroutine
+	// (started internally by InitializeAll when some servers fail and
+	// EnableReconnect is true). Safe to call even if reconnection was never
+	// started.
+	StopBackgroundReconnection()
 }
 
 // MCPClient provides methods to interact with MCP servers
@@ -105,6 +111,9 @@ type MCPClient struct {
 	statusMutex         sync.RWMutex
 	pollingCancel       context.CancelFunc
 	pollingDone         chan struct{}
+	reconnectCancel     context.CancelFunc
+	reconnectDone       chan struct{}
+	reconnectMutex      sync.Mutex
 }
 
 // TransportMode represents the type of transport being used
@@ -415,7 +424,7 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 			// instead of crash-looping when every MCP backend is temporarily
 			// unreachable (cold starts, DNS races, MCP rollouts, etc.).
 			// See: https://github.com/inference-gateway/inference-gateway/issues/304
-			go mc.startBackgroundReconnection(context.Background(), failedServers)
+			mc.spawnBackgroundReconnection(failedServers)
 			return nil
 		}
 
@@ -461,11 +470,62 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 			"component", "mcp_client")
 		// Detach from the initialization context (which has a short timeout)
 		// so the background reconnect ticker can keep running for the lifetime
-		// of the process.
-		go mc.startBackgroundReconnection(context.Background(), failedServers)
+		// of the process — but use a cancellable context owned by the client
+		// so StopBackgroundReconnection() can shut the goroutine down cleanly
+		// during graceful shutdown.
+		mc.spawnBackgroundReconnection(failedServers)
 	}
 
 	return nil
+}
+
+// spawnBackgroundReconnection launches the reconnect goroutine with a
+// cancellable context owned by the client. It is safe to call multiple times:
+// only the first call starts the goroutine; subsequent calls are no-ops while
+// a reconnection loop is already in flight. The context is cancelled by
+// StopBackgroundReconnection during graceful shutdown.
+func (mc *MCPClient) spawnBackgroundReconnection(failedServers []string) {
+	mc.reconnectMutex.Lock()
+	defer mc.reconnectMutex.Unlock()
+
+	if mc.reconnectCancel != nil {
+		// Reconnection already running; do not start a second loop.
+		return
+	}
+
+	reconnectCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	mc.reconnectCancel = cancel
+	mc.reconnectDone = done
+
+	go func() {
+		// Capture `done` locally so that StopBackgroundReconnection nilling
+		// out mc.reconnectDone (under the mutex) does not race with the
+		// goroutine exit.
+		defer close(done)
+		mc.startBackgroundReconnection(reconnectCtx, failedServers)
+	}()
+}
+
+// StopBackgroundReconnection cancels the reconnection goroutine (if any) and
+// waits for it to exit. Safe to call when no reconnection has been started.
+func (mc *MCPClient) StopBackgroundReconnection() {
+	mc.reconnectMutex.Lock()
+	cancel := mc.reconnectCancel
+	done := mc.reconnectDone
+	mc.reconnectCancel = nil
+	mc.reconnectDone = nil
+	mc.reconnectMutex.Unlock()
+
+	if cancel == nil {
+		return
+	}
+
+	cancel()
+	if done != nil {
+		<-done
+	}
+	mc.Logger.Info("stopped mcp background reconnection", "component", "mcp_client")
 }
 
 // initializeServer initializes a single server with retry logic
@@ -838,6 +898,15 @@ func (mc *MCPClient) startBackgroundReconnection(ctx context.Context, failedServ
 		"servers", failedServers,
 		"interval", mc.Config.MCP.ReconnectInterval,
 		"component", "mcp_client")
+
+	// When the loop exits (either via ctx cancellation or because every server
+	// has been reconnected), clear the bookkeeping so a future failure can
+	// start a fresh reconnect loop via spawnBackgroundReconnection.
+	defer func() {
+		mc.reconnectMutex.Lock()
+		mc.reconnectCancel = nil
+		mc.reconnectMutex.Unlock()
+	}()
 
 	ticker := time.NewTicker(mc.Config.MCP.ReconnectInterval)
 	defer ticker.Stop()

--- a/mcp/client.go
+++ b/mcp/client.go
@@ -418,12 +418,6 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 			"component", "mcp_client")
 
 		if mc.Config.MCP.EnableReconnect && len(failedServers) > 0 {
-			// Background reconnection will keep retrying until at least one server
-			// becomes reachable. Treat startup as successful so the gateway can
-			// continue serving non-MCP traffic and graceful tool-call failures
-			// instead of crash-looping when every MCP backend is temporarily
-			// unreachable (cold starts, DNS races, MCP rollouts, etc.).
-			// See: https://github.com/inference-gateway/inference-gateway/issues/304
 			mc.spawnBackgroundReconnection(failedServers)
 			return nil
 		}
@@ -468,11 +462,6 @@ func (mc *MCPClient) InitializeAll(ctx context.Context) error {
 		mc.Logger.Info("starting background reconnection for failed servers",
 			"failed_servers", failedServers,
 			"component", "mcp_client")
-		// Detach from the initialization context (which has a short timeout)
-		// so the background reconnect ticker can keep running for the lifetime
-		// of the process — but use a cancellable context owned by the client
-		// so StopBackgroundReconnection() can shut the goroutine down cleanly
-		// during graceful shutdown.
 		mc.spawnBackgroundReconnection(failedServers)
 	}
 
@@ -489,7 +478,6 @@ func (mc *MCPClient) spawnBackgroundReconnection(failedServers []string) {
 	defer mc.reconnectMutex.Unlock()
 
 	if mc.reconnectCancel != nil {
-		// Reconnection already running; do not start a second loop.
 		return
 	}
 
@@ -499,9 +487,6 @@ func (mc *MCPClient) spawnBackgroundReconnection(failedServers []string) {
 	mc.reconnectDone = done
 
 	go func() {
-		// Capture `done` locally so that StopBackgroundReconnection nilling
-		// out mc.reconnectDone (under the mutex) does not race with the
-		// goroutine exit.
 		defer close(done)
 		mc.startBackgroundReconnection(reconnectCtx, failedServers)
 	}()
@@ -899,9 +884,6 @@ func (mc *MCPClient) startBackgroundReconnection(ctx context.Context, failedServ
 		"interval", mc.Config.MCP.ReconnectInterval,
 		"component", "mcp_client")
 
-	// When the loop exits (either via ctx cancellation or because every server
-	// has been reconnected), clear the bookkeeping so a future failure can
-	// start a fresh reconnect loop via spawnBackgroundReconnection.
 	defer func() {
 		mc.reconnectMutex.Lock()
 		mc.reconnectCancel = nil

--- a/tests/mcp_enhanced_test.go
+++ b/tests/mcp_enhanced_test.go
@@ -102,9 +102,6 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 				RetryInterval:         10 * time.Millisecond,
 				InitialBackoff:        10 * time.Millisecond,
 				EnableReconnect:       true,
-				// Use a long reconnect interval so the loop is guaranteed to be
-				// waiting on the ticker when we call Stop — exercising the
-				// ctx.Done() exit path.
 				ReconnectInterval: 1 * time.Hour,
 			},
 		}
@@ -119,9 +116,6 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 
 		require.NoError(t, mcpClient.InitializeAll(ctx))
 
-		// Stop must return promptly — if the context were context.Background()
-		// (the pre-fix behavior) the goroutine would sit on the 1h ticker
-		// forever and Stop would block until the test timeout.
 		stopped := make(chan struct{})
 		go func() {
 			mcpClient.StopBackgroundReconnection()
@@ -134,7 +128,6 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 			t.Fatal("StopBackgroundReconnection blocked — reconnect goroutine is not respecting cancellation")
 		}
 
-		// Calling Stop a second time must be a safe no-op.
 		mcpClient.StopBackgroundReconnection()
 	})
 
@@ -176,10 +169,6 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 func reserveUnreachableURL(t *testing.T) string {
 	t.Helper()
 
-	// httptest.NewServer gives us a real listening address. Closing it makes the
-	// address refuse new connections (or at least fail handshake quickly), which
-	// is a reliable way to produce a guaranteed-unreachable URL in CI without
-	// depending on external hosts.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	addr := srv.Listener.Addr().(*net.TCPAddr)
 	srv.Close()

--- a/tests/mcp_enhanced_test.go
+++ b/tests/mcp_enhanced_test.go
@@ -102,7 +102,7 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 				RetryInterval:         10 * time.Millisecond,
 				InitialBackoff:        10 * time.Millisecond,
 				EnableReconnect:       true,
-				ReconnectInterval: 1 * time.Hour,
+				ReconnectInterval:     1 * time.Hour,
 			},
 		}
 

--- a/tests/mcp_enhanced_test.go
+++ b/tests/mcp_enhanced_test.go
@@ -89,6 +89,55 @@ func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
 			"client should report as initialized so the gateway pipeline can continue")
 	})
 
+	t.Run("StopBackgroundReconnection cancels the loop cleanly", func(t *testing.T) {
+		cfg := config.Config{
+			MCP: &config.MCPConfig{
+				DialTimeout:           100 * time.Millisecond,
+				TlsHandshakeTimeout:   100 * time.Millisecond,
+				ResponseHeaderTimeout: 100 * time.Millisecond,
+				ExpectContinueTimeout: 100 * time.Millisecond,
+				ClientTimeout:         200 * time.Millisecond,
+				RequestTimeout:        500 * time.Millisecond,
+				MaxRetries:            1,
+				RetryInterval:         10 * time.Millisecond,
+				InitialBackoff:        10 * time.Millisecond,
+				EnableReconnect:       true,
+				// Use a long reconnect interval so the loop is guaranteed to be
+				// waiting on the ticker when we call Stop — exercising the
+				// ctx.Done() exit path.
+				ReconnectInterval: 1 * time.Hour,
+			},
+		}
+
+		testLogger, err := logger.NewLogger("test")
+		require.NoError(t, err)
+
+		mcpClient := mcp.NewMCPClient([]string{unreachableURL}, testLogger, cfg)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		require.NoError(t, mcpClient.InitializeAll(ctx))
+
+		// Stop must return promptly — if the context were context.Background()
+		// (the pre-fix behavior) the goroutine would sit on the 1h ticker
+		// forever and Stop would block until the test timeout.
+		stopped := make(chan struct{})
+		go func() {
+			mcpClient.StopBackgroundReconnection()
+			close(stopped)
+		}()
+
+		select {
+		case <-stopped:
+		case <-time.After(5 * time.Second):
+			t.Fatal("StopBackgroundReconnection blocked — reconnect goroutine is not respecting cancellation")
+		}
+
+		// Calling Stop a second time must be a safe no-op.
+		mcpClient.StopBackgroundReconnection()
+	})
+
 	t.Run("EnableReconnect=false still returns ErrNoClientsInitialized", func(t *testing.T) {
 		cfg := config.Config{
 			MCP: &config.MCPConfig{

--- a/tests/mcp_enhanced_test.go
+++ b/tests/mcp_enhanced_test.go
@@ -1,6 +1,10 @@
 package tests
 
 import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -42,6 +46,96 @@ func TestMCPClientTransportModes(t *testing.T) {
 		client3 := mcpClient.(*mcp.MCPClient).NewClientWithTransport(serverURL, mcp.TransportModeHTTP)
 		assert.NotNil(t, client3)
 	})
+}
+
+// TestInitializeAllWithUnreachableServersAndReconnect verifies that when all
+// configured MCP servers are unreachable at startup, InitializeAll returns nil
+// (instead of ErrNoClientsInitialized) as long as EnableReconnect is true. The
+// background reconnection loop is expected to keep retrying so the gateway can
+// continue serving requests without crash-looping.
+// Regression test for: https://github.com/inference-gateway/inference-gateway/issues/304
+func TestInitializeAllWithUnreachableServersAndReconnect(t *testing.T) {
+	unreachableURL := reserveUnreachableURL(t)
+
+	t.Run("EnableReconnect=true returns nil (non-fatal)", func(t *testing.T) {
+		cfg := config.Config{
+			MCP: &config.MCPConfig{
+				DialTimeout:           100 * time.Millisecond,
+				TlsHandshakeTimeout:   100 * time.Millisecond,
+				ResponseHeaderTimeout: 100 * time.Millisecond,
+				ExpectContinueTimeout: 100 * time.Millisecond,
+				ClientTimeout:         200 * time.Millisecond,
+				RequestTimeout:        500 * time.Millisecond,
+				MaxRetries:            1,
+				RetryInterval:         10 * time.Millisecond,
+				InitialBackoff:        10 * time.Millisecond,
+				EnableReconnect:       true,
+				ReconnectInterval:     30 * time.Second,
+			},
+		}
+
+		testLogger, err := logger.NewLogger("test")
+		require.NoError(t, err)
+
+		mcpClient := mcp.NewMCPClient([]string{unreachableURL}, testLogger, cfg)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		initErr := mcpClient.InitializeAll(ctx)
+		assert.NoError(t, initErr,
+			"InitializeAll must not return a fatal error when reconnect is enabled — background reconnection takes over")
+		assert.True(t, mcpClient.IsInitialized(),
+			"client should report as initialized so the gateway pipeline can continue")
+	})
+
+	t.Run("EnableReconnect=false still returns ErrNoClientsInitialized", func(t *testing.T) {
+		cfg := config.Config{
+			MCP: &config.MCPConfig{
+				DialTimeout:           100 * time.Millisecond,
+				TlsHandshakeTimeout:   100 * time.Millisecond,
+				ResponseHeaderTimeout: 100 * time.Millisecond,
+				ExpectContinueTimeout: 100 * time.Millisecond,
+				ClientTimeout:         200 * time.Millisecond,
+				RequestTimeout:        500 * time.Millisecond,
+				MaxRetries:            1,
+				RetryInterval:         10 * time.Millisecond,
+				InitialBackoff:        10 * time.Millisecond,
+				EnableReconnect:       false,
+			},
+		}
+
+		testLogger, err := logger.NewLogger("test")
+		require.NoError(t, err)
+
+		mcpClient := mcp.NewMCPClient([]string{unreachableURL}, testLogger, cfg)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		initErr := mcpClient.InitializeAll(ctx)
+		require.Error(t, initErr,
+			"InitializeAll must still surface a fatal error when reconnect is disabled")
+		assert.ErrorIs(t, initErr, mcp.ErrNoClientsInitialized)
+	})
+}
+
+// reserveUnreachableURL returns an http URL pointing at a port that was bound
+// briefly and then released — there is a non-zero chance the OS rebinds the
+// port to something else, so the test falls back to httptest.NewServer's closed
+// listener pattern.
+func reserveUnreachableURL(t *testing.T) string {
+	t.Helper()
+
+	// httptest.NewServer gives us a real listening address. Closing it makes the
+	// address refuse new connections (or at least fail handshake quickly), which
+	// is a reliable way to produce a guaranteed-unreachable URL in CI without
+	// depending on external hosts.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	addr := srv.Listener.Addr().(*net.TCPAddr)
+	srv.Close()
+
+	return "http://" + addr.String() + "/mcp"
 }
 
 // TestSSEFallbackURLGeneration tests the SSE fallback URL generation logic

--- a/tests/mocks/mcp/client.go
+++ b/tests/mocks/mcp/client.go
@@ -236,3 +236,15 @@ func (mr *MockMCPClientInterfaceMockRecorder) StopStatusPolling() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopStatusPolling", reflect.TypeOf((*MockMCPClientInterface)(nil).StopStatusPolling))
 }
+
+// StopBackgroundReconnection mocks base method.
+func (m *MockMCPClientInterface) StopBackgroundReconnection() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "StopBackgroundReconnection")
+}
+
+// StopBackgroundReconnection indicates an expected call of StopBackgroundReconnection.
+func (mr *MockMCPClientInterfaceMockRecorder) StopBackgroundReconnection() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StopBackgroundReconnection", reflect.TypeOf((*MockMCPClientInterface)(nil).StopBackgroundReconnection))
+}


### PR DESCRIPTION
## Summary

Fixes #304. When `MCP_ENABLE=true` and every configured MCP server is temporarily unreachable at startup (cold-start, DNS race, MCP rollouts), the gateway was exiting with `failed to initialize mcp client` and entering `CrashLoopBackOff` — even though the MCP subsystem logged `enabling MCP with background reconnection` immediately above.

Two compounding bugs were responsible:

1. `MCPClient.InitializeAll` returned `ErrNoClientsInitialized` even when reconnect was enabled, contradicting its own warn log.
2. The background reconnection goroutine was started with the short-lived initialization context (default 5s), so its ticker context expired almost immediately.

## Changes

- `mcp/client.go`: Return `nil` from `InitializeAll` after starting background reconnection when `EnableReconnect=true`. Detach the goroutine from the init context in both call sites so it survives for the lifetime of the process.
- `cmd/gateway/main.go`: Defense in depth — if `ErrNoClientsInitialized` ever resurfaces with reconnect enabled, log a warning and keep serving instead of exiting.
- `tests/mcp_enhanced_test.go`: Regression test against a closed TCP port covering both `EnableReconnect=true` (returns nil) and `EnableReconnect=false` (still returns `ErrNoClientsInitialized`).

## Test plan

- [x] `task test` passes
- [x] `task lint` (golangci-lint) reports 0 issues
- [x] `task build` succeeds
- [ ] Manual: start gateway with `MCP_ENABLE=true` and `MCP_SERVERS=http://unreachable.example:3001`, verify it stays up on :8080 and logs background reconnection attempts.
- [ ] Manual: start gateway with `MCP_ENABLE_RECONNECT=false` against unreachable servers, verify fail-fast behavior is preserved.

🤖 Generated with [Claude Code](https://claude.ai/code)