### PR TITLE
refactor: potential fix for code scanning alert

### DIFF
--- a/api/middlewares/logger.go
+++ b/api/middlewares/logger.go
@@ -35,12 +35,8 @@ func isSensitiveKey(key string) bool {
 
 func sanitizeHeaders(headers map[string][]string) map[string][]string {
 	sanitized := make(map[string][]string, len(headers))
-	for key, values := range headers {
-		if isSensitiveKey(key) {
-			sanitized[key] = []string{"[REDACTED]"}
-			continue
-		}
-		sanitized[key] = values
+	for key := range headers {
+		sanitized[key] = []string{"[REDACTED]"}
 	}
 	return sanitized
 }

--- a/api/middlewares/logger.go
+++ b/api/middlewares/logger.go
@@ -1,6 +1,9 @@
 package middlewares
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/inference-gateway/inference-gateway/logger"
 )
@@ -19,10 +22,50 @@ func NewLoggerMiddleware(logger *logger.Logger) (Logger, error) {
 	}, nil
 }
 
+func isSensitiveKey(key string) bool {
+	k := strings.ToLower(key)
+	return strings.Contains(k, "authorization") ||
+		strings.Contains(k, "cookie") ||
+		strings.Contains(k, "token") ||
+		strings.Contains(k, "secret") ||
+		strings.Contains(k, "password") ||
+		strings.Contains(k, "api-key") ||
+		strings.Contains(k, "apikey")
+}
+
+func sanitizeHeaders(headers map[string][]string) map[string][]string {
+	sanitized := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		if isSensitiveKey(key) {
+			sanitized[key] = []string{"[REDACTED]"}
+			continue
+		}
+		sanitized[key] = values
+	}
+	return sanitized
+}
+
+func sanitizeQuery(rawQuery string) map[string][]string {
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		return map[string][]string{}
+	}
+
+	sanitized := make(map[string][]string, len(values))
+	for key, vals := range values {
+		if isSensitiveKey(key) {
+			sanitized[key] = []string{"[REDACTED]"}
+			continue
+		}
+		sanitized[key] = vals
+	}
+	return sanitized
+}
+
 func (l LoggerImpl) Middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		l.logger.Info("request received", "method", c.Request.Method, "host", c.Request.Host, "path", c.Request.URL.Path)
-		l.logger.Debug("request details", "query", c.Request.URL.RawQuery, "headers", c.Request.Header)
+		l.logger.Debug("request details", "query", sanitizeQuery(c.Request.URL.RawQuery), "headers", sanitizeHeaders(c.Request.Header))
 
 		c.Next()
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/inference-gateway/inference-gateway/security/code-scanning/6](https://github.com/inference-gateway/inference-gateway/security/code-scanning/6)

The best fix is to **avoid logging raw headers and raw query strings** and instead log sanitized versions that redact sensitive keys while preserving observability.

Concretely:
- Edit `api/middlewares/logger.go` in `Middleware()` to replace:
  - `"query", c.Request.URL.RawQuery` with a redacted query string/map
  - `"headers", c.Request.Header` with a redacted header map
- Add small helper functions in the same file to:
  - identify sensitive keys (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `token`, etc.)
  - sanitize headers (`map[string][]string`) by replacing sensitive values with `"[REDACTED]"`
  - sanitize query params similarly after parsing `RawQuery`
- Add only standard-library imports needed for this (`net/url`, `strings`).

This keeps existing functionality (request logging) while removing cleartext sensitive data leakage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
