### PR TITLE
ci: potential fix for code scanning alert no. 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/inference-gateway/inference-gateway/security/code-scanning/4](https://github.com/inference-gateway/inference-gateway/security/code-scanning/4)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (recommended here since there is one job and the same restriction should apply globally). Set:

- `contents: read`

This preserves current functionality (checkout and read operations) while preventing unnecessary token write access. No imports, methods, or dependencies are needed; this is a YAML configuration-only change near the top of the workflow, after the `on:` trigger block and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
