### PR TITLE
fix: route minimax through its own transformer + label it in telemetry

### DIFF
--- a/api/middlewares/telemetry.go
+++ b/api/middlewares/telemetry.go
@@ -90,6 +90,8 @@ func (t *TelemetryImpl) Middleware() gin.HandlerFunc {
 			provider = "mistral"
 		case strings.HasPrefix(model, "moonshot/"):
 			provider = "moonshot"
+		case strings.HasPrefix(model, "minimax/"):
+			provider = "minimax"
 		case strings.HasPrefix(model, "ollama_cloud/"):
 			provider = "ollama_cloud"
 		}
@@ -116,6 +118,8 @@ func (t *TelemetryImpl) Middleware() gin.HandlerFunc {
 				provider = "mistral"
 			case strings.Contains(c.Request.URL.RawQuery, "moonshot"):
 				provider = "moonshot"
+			case strings.Contains(c.Request.URL.RawQuery, "minimax"):
+				provider = "minimax"
 			}
 		}
 

--- a/examples/rest-endpoints/README.md
+++ b/examples/rest-endpoints/README.md
@@ -36,7 +36,7 @@ interact with the Inference Gateway using curl commands.
 | api.deepseek.com                  | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"deepseek/deepseek-v4-pro","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                  |
 | generativelanguage.googleapis.com | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"google/models/gemini-2.5-flash-lite","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`       |
 | api.mistral.ai                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"mistral/pixtral-large-latest","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`              |
-| api.minimax.io                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"minimax/MiniMax-Text-01","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                   |
+| api.minimax.io                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"minimax/MiniMax-M3","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                   |
 | api.moonshot.ai                   | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"moonshot/moonshot-v1-8k","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                   |
 
 You can set the stream as an optional flag in the request body to enable

--- a/examples/rest-endpoints/README.md
+++ b/examples/rest-endpoints/README.md
@@ -36,7 +36,7 @@ interact with the Inference Gateway using curl commands.
 | api.deepseek.com                  | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"deepseek/deepseek-v4-pro","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                  |
 | generativelanguage.googleapis.com | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"google/models/gemini-2.5-flash-lite","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`       |
 | api.mistral.ai                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"mistral/pixtral-large-latest","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`              |
-| api.minimax.io                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"minimax/MiniMax-M3","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                   |
+| api.minimax.io                    | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"minimax/MiniMax-M3","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                        |
 | api.moonshot.ai                   | `curl -X POST http://localhost:8080/v1/chat/completions -d '{"model":"moonshot/moonshot-v1-8k","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hi"}]}'`                   |
 
 You can set the stream as an optional flag in the request body to enable

--- a/providers/core/provider.go
+++ b/providers/core/provider.go
@@ -225,6 +225,13 @@ func (p *ProviderImpl) ListModels(ctx context.Context) (types.ListModelsResponse
 			return types.ListModelsResponse{}, err
 		}
 		transformer = &resp
+	case constants.MinimaxID:
+		var resp transformers.ListModelsResponseMinimax
+		if err := json.NewDecoder(response.Body).Decode(&resp); err != nil {
+			p.Logger.Error("Failed to unmarshal response", err, "provider", p.GetName(), "url", url)
+			return types.ListModelsResponse{}, err
+		}
+		transformer = &resp
 	default:
 		var resp transformers.ListModelsResponseOpenai
 		if err := json.NewDecoder(response.Body).Decode(&resp); err != nil {


### PR DESCRIPTION
## Summary

MiniMax was added in #357 but two hand-maintained `switch` statements were never given a `minimax` case, so minimax silently fell through to OpenAI defaults.

- **`fix`** - `ProviderImpl.ListModels` had no `case constants.MinimaxID`, so `GET /v1/models?provider=minimax` returned model IDs prefixed with `openai/` and `served_by: "openai"` instead of `minimax/` and `served_by: "minimax"`. Wired up `ListModelsResponseMinimax`.
- **`feat(metrics)`** - the telemetry middleware's provider-detection switches (by model prefix and by query string) had no minimax case, so minimax requests were recorded as the `unknown` provider in metrics. Added minimax to both.

Chat completions was unaffected - it has no per-provider transformer switch and forwards OpenAI-compatible requests generically.

## Verification

Before:
```
{"id":"openai/MiniMax-M3","served_by":"openai", ...}
```
After the fix, the minimax transformer prepends `minimax/` and sets `served_by: "minimax"`.

`go build ./...` and `go test ./providers/... ./api/...` pass.