### PR TITLE
feat(mcp): sync MCP schema to schemas v0.4.0 (SubscriptionsListenResult)

### DIFF
--- a/internal/mcp/generated_types.go
+++ b/internal/mcp/generated_types.go
@@ -2,9 +2,9 @@
 package mcp
 
 // The user action in response to the elicitation.
-// - "accept": User submitted the form/confirmed the action
-// - "decline": User explicitly decline the action
-// - "cancel": User dismissed without making an explicit choice
+// - `"accept"`: User submitted the form/confirmed the action
+// - `"decline"`: User explicitly declined the action
+// - `"cancel"`: User dismissed without making an explicit choice
 type Action string
 
 // Action enum values
@@ -12,6 +12,24 @@ const (
 	ActionAccept  Action = "accept"
 	ActionCancel  Action = "cancel"
 	ActionDecline Action = "decline"
+)
+
+// Indicates the intended scope of the cached response, analogous to HTTP
+// `Cache-Control: public` vs `Cache-Control: private`.
+//
+// - `"public"`: The response does not contain user-specific data. Any
+// client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+// the response and serve it across authorization contexts.
+// - `"private"`: The response MAY be cached and reused only within the
+// same authorization context. Caches MUST NOT be shared across
+// authorization contexts (e.g., a different access token requires a
+// different cache).
+type CacheScope string
+
+// CacheScope enum values
+const (
+	CacheScopePrivate CacheScope = "private"
+	CacheScopePublic  CacheScope = "public"
 )
 
 type Format string
@@ -22,6 +40,47 @@ const (
 	FormatDateTime Format = "date-time"
 	FormatEmail    Format = "email"
 	FormatURI      Format = "uri"
+)
+
+// A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
+// The client MAY ignore this request.
+//
+// Default is `"none"`. The values `"thisServer"` and `"allServers"` are deprecated (SEP-2596): servers SHOULD
+// omit this field or use `"none"`, and SHOULD only use the deprecated values if the client declares
+// {@link ClientCapabilities.sampling.context}.
+type IncludeContext string
+
+// IncludeContext enum values
+const (
+	IncludeContextAllServers IncludeContext = "allServers"
+	IncludeContextNone       IncludeContext = "none"
+	IncludeContextThisServer IncludeContext = "thisServer"
+)
+
+// Controls the tool use ability of the model:
+// - `"auto"`: Model decides whether to use tools (default)
+// - `"required"`: Model MUST use at least one tool before completing
+// - `"none"`: Model MUST NOT use any tools
+type Mode string
+
+// Mode enum values
+const (
+	ModeAuto     Mode = "auto"
+	ModeNone     Mode = "none"
+	ModeRequired Mode = "required"
+)
+
+// Optional specifier for the theme this icon is designed for. `"light"` indicates
+// the icon is designed to be used with a light background, and `"dark"` indicates
+// the icon is designed to be used with a dark background.
+//
+// If not provided, the client should assume the icon can be used with any theme.
+type Theme string
+
+// Theme enum values
+const (
+	ThemeDark  Theme = "dark"
+	ThemeLight Theme = "light"
 )
 
 type Type string
@@ -68,11 +127,11 @@ type Annotations struct {
 
 // Audio provided to or from an LLM.
 type AudioContent struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Data        []byte         `json:"data"`
-	MIMEType    string         `json:"mimeType"`
-	Type        string         `json:"type"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Data        []byte       `json:"data"`
+	MIMEType    string       `json:"mimeType"`
+	Type        string       `json:"type"`
 }
 
 // Base interface for metadata with name (identifier) and title (display name) properties.
@@ -82,10 +141,10 @@ type BaseMetadata struct {
 }
 
 type BlobResourceContents struct {
-	Meta     map[string]any `json:"_meta,omitempty"`
-	Blob     []byte         `json:"blob"`
-	MIMEType *string        `json:"mimeType,omitempty"`
-	URI      string         `json:"uri"`
+	Meta     *MetaObject `json:"_meta,omitempty"`
+	Blob     []byte      `json:"blob"`
+	MIMEType *string     `json:"mimeType,omitempty"`
+	URI      string      `json:"uri"`
 }
 
 type BooleanSchema struct {
@@ -95,87 +154,216 @@ type BooleanSchema struct {
 	Type        string  `json:"type"`
 }
 
+// A result that supports a time-to-live (TTL) hint for client-side caching.
+type CacheableResult struct {
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	CacheScope CacheScope  `json:"cacheScope"`
+	ResultType string      `json:"resultType"`
+	TtlMs      int         `json:"ttlMs"`
+}
+
 // Used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	ID      RequestId             `json:"id"`
+	JSONRPC string                `json:"jsonrpc"`
+	Method  string                `json:"method"`
+	Params  CallToolRequestParams `json:"params"`
 }
 
-// The server's response to a tool call.
+// Parameters for a `tools/call` request.
+type CallToolRequestParams struct {
+	Meta           RequestMetaObject `json:"_meta"`
+	Arguments      map[string]any    `json:"arguments,omitempty"`
+	InputResponses *InputResponses   `json:"inputResponses,omitempty"`
+	Name           string            `json:"name"`
+	RequestState   *string           `json:"requestState,omitempty"`
+}
+
+// The result returned by the server for a {@link CallToolRequesttools/call} request.
 type CallToolResult struct {
-	Meta              map[string]any `json:"_meta,omitempty"`
+	Meta              *MetaObject    `json:"_meta,omitempty"`
 	Content           []ContentBlock `json:"content"`
 	IsError           *bool          `json:"isError,omitempty"`
-	StructuredContent map[string]any `json:"structuredContent,omitempty"`
+	ResultType        string         `json:"resultType"`
+	StructuredContent *any           `json:"structuredContent,omitempty"`
 }
 
-// This notification can be sent by either side to indicate that it is cancelling a previously-issued request.
+// A successful response from the server for a {@link CallToolRequesttools/call} request.
+type CallToolResultResponse struct {
+	ID      RequestId `json:"id"`
+	JSONRPC string    `json:"jsonrpc"`
+	Result  any       `json:"result"`
+}
+
+// This notification is sent by the client to indicate that it is cancelling a request it previously issued.
+//
+// On stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.
 //
 // The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
 //
 // This notification indicates that the result will be unused, so any associated processing SHOULD cease.
-//
-// A client MUST NOT attempt to cancel its `initialize` request.
 type CancelledNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	JSONRPC string                      `json:"jsonrpc"`
+	Method  string                      `json:"method"`
+	Params  CancelledNotificationParams `json:"params"`
+}
+
+// Parameters for a `notifications/cancelled` notification.
+type CancelledNotificationParams struct {
+	Meta      *NotificationMetaObject `json:"_meta,omitempty"`
+	Reason    *string                 `json:"reason,omitempty"`
+	RequestID RequestId               `json:"requestId"`
 }
 
 // Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.
 type ClientCapabilities struct {
-	Elicitation  map[string]any            `json:"elicitation,omitempty"`
-	Experimental map[string]map[string]any `json:"experimental,omitempty"`
-	Roots        map[string]any            `json:"roots,omitempty"`
-	Sampling     map[string]any            `json:"sampling,omitempty"`
+	Elicitation  map[string]any        `json:"elicitation,omitempty"`
+	Experimental map[string]JSONObject `json:"experimental,omitempty"`
+	Extensions   map[string]JSONObject `json:"extensions,omitempty"`
+	Roots        map[string]any        `json:"roots,omitempty"`
+	Sampling     map[string]any        `json:"sampling,omitempty"`
 }
 
-type ClientNotification any
+// This notification is sent by the client to indicate that it is cancelling a request it previously issued.
+//
+// On stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.
+//
+// The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
+//
+// This notification indicates that the result will be unused, so any associated processing SHOULD cease.
+type ClientNotification struct {
+	JSONRPC string                      `json:"jsonrpc"`
+	Method  string                      `json:"method"`
+	Params  CancelledNotificationParams `json:"params"`
+}
 
 type ClientRequest any
 
-type ClientResult any
+// Common result fields.
+type ClientResult struct {
+}
 
 // A request from the client to the server, to ask for completion options.
 type CompleteRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	ID      RequestId             `json:"id"`
+	JSONRPC string                `json:"jsonrpc"`
+	Method  string                `json:"method"`
+	Params  CompleteRequestParams `json:"params"`
 }
 
-// The server's response to a completion/complete request
+// Parameters for a `completion/complete` request.
+type CompleteRequestParams struct {
+	Meta     RequestMetaObject `json:"_meta"`
+	Argument map[string]any    `json:"argument"`
+	Context  map[string]any    `json:"context,omitempty"`
+	Ref      any               `json:"ref"`
+}
+
+// The result returned by the server for a {@link CompleteRequestcompletion/complete} request.
 type CompleteResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
+	Meta       *MetaObject    `json:"_meta,omitempty"`
 	Completion map[string]any `json:"completion"`
+	ResultType string         `json:"resultType"`
+}
+
+// A successful response from the server for a {@link CompleteRequestcompletion/complete} request.
+type CompleteResultResponse struct {
+	ID      RequestId      `json:"id"`
+	JSONRPC string         `json:"jsonrpc"`
+	Result  CompleteResult `json:"result"`
 }
 
 type ContentBlock any
 
 // A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
 type CreateMessageRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	Method string                     `json:"method"`
+	Params CreateMessageRequestParams `json:"params"`
 }
 
-// The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.
+// Parameters for a `sampling/createMessage` request.
+type CreateMessageRequestParams struct {
+	IncludeContext   *IncludeContext   `json:"includeContext,omitempty"`
+	MaxTokens        int               `json:"maxTokens"`
+	Messages         []SamplingMessage `json:"messages"`
+	Metadata         *JSONObject       `json:"metadata,omitempty"`
+	ModelPreferences *ModelPreferences `json:"modelPreferences,omitempty"`
+	StopSequences    []string          `json:"stopSequences,omitempty"`
+	SystemPrompt     *string           `json:"systemPrompt,omitempty"`
+	Temperature      *float64          `json:"temperature,omitempty"`
+	ToolChoice       *ToolChoice       `json:"toolChoice,omitempty"`
+	Tools            []Tool            `json:"tools,omitempty"`
+}
+
+// The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.
+// The client should inform the user before returning the sampled message, to allow them
+// to inspect the response (human in the loop) and decide whether to allow the server to see it.
 type CreateMessageResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	Content    any            `json:"content"`
-	Model      string         `json:"model"`
-	Role       Role           `json:"role"`
-	StopReason *string        `json:"stopReason,omitempty"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	Content    any         `json:"content"`
+	Model      string      `json:"model"`
+	Role       Role        `json:"role"`
+	StopReason *string     `json:"stopReason,omitempty"`
 }
 
 // An opaque token used to represent a cursor for pagination.
 type Cursor = string
 
-// A request from the server to elicit additional information from the user via the client.
-type ElicitRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+// A request from the client asking the server to advertise its supported
+// protocol versions, capabilities, and other metadata. Servers **MUST**
+// implement `server/discover`. Clients **MAY** call it but are not required
+// to — version negotiation can also happen inline via per-request `_meta`.
+type DiscoverRequest struct {
+	ID      RequestId     `json:"id"`
+	JSONRPC string        `json:"jsonrpc"`
+	Method  string        `json:"method"`
+	Params  RequestParams `json:"params"`
 }
 
-// The client's response to an elicitation request.
+// The result returned by the server for a {@link DiscoverRequestserver/discover} request.
+type DiscoverResult struct {
+	Meta              *MetaObject        `json:"_meta,omitempty"`
+	CacheScope        CacheScope         `json:"cacheScope"`
+	Capabilities      ServerCapabilities `json:"capabilities"`
+	Instructions      *string            `json:"instructions,omitempty"`
+	ResultType        string             `json:"resultType"`
+	ServerInfo        Implementation     `json:"serverInfo"`
+	SupportedVersions []string           `json:"supportedVersions"`
+	TtlMs             int                `json:"ttlMs"`
+}
+
+// A successful response from the server for a {@link DiscoverRequestserver/discover} request.
+type DiscoverResultResponse struct {
+	ID      RequestId      `json:"id"`
+	JSONRPC string         `json:"jsonrpc"`
+	Result  DiscoverResult `json:"result"`
+}
+
+// A request from the server to elicit additional information from the user via the client.
+type ElicitRequest struct {
+	Method string              `json:"method"`
+	Params ElicitRequestParams `json:"params"`
+}
+
+// The parameters for a request to elicit non-sensitive information from the user via a form in the client.
+type ElicitRequestFormParams struct {
+	Message         string         `json:"message"`
+	Mode            *string        `json:"mode,omitempty"`
+	RequestedSchema map[string]any `json:"requestedSchema"`
+}
+
+// The parameters for a request to elicit additional information from the user via the client.
+type ElicitRequestParams any
+
+// The parameters for a request to elicit information from the user via a URL in the client.
+type ElicitRequestURLParams struct {
+	Message string `json:"message"`
+	Mode    string `json:"mode"`
+	URL     string `json:"url"`
+}
+
+// The result returned by the client for an {@link ElicitRequestelicitation/create} request.
 type ElicitResult struct {
-	Meta    map[string]any `json:"_meta,omitempty"`
 	Action  Action         `json:"action"`
 	Content map[string]any `json:"content,omitempty"`
 }
@@ -185,78 +373,167 @@ type ElicitResult struct {
 // It is up to the client how best to render embedded resources for the benefit
 // of the LLM and/or the user.
 type EmbeddedResource struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Resource    any            `json:"resource"`
-	Type        string         `json:"type"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Resource    any          `json:"resource"`
+	Type        string       `json:"type"`
 }
 
+// Common result fields.
 type EmptyResult struct {
 }
 
-type EnumSchema struct {
-	Description *string  `json:"description,omitempty"`
-	Enum        []string `json:"enum"`
-	EnumNames   []string `json:"enumNames,omitempty"`
-	Title       *string  `json:"title,omitempty"`
-	Type        string   `json:"type"`
+type EnumSchema any
+
+type Error struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
 }
 
 // Used by the client to get a prompt provided by the server.
 type GetPromptRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  GetPromptRequestParams `json:"params"`
 }
 
-// The server's response to a prompts/get request from the client.
+// Parameters for a `prompts/get` request.
+type GetPromptRequestParams struct {
+	Meta           RequestMetaObject `json:"_meta"`
+	Arguments      map[string]string `json:"arguments,omitempty"`
+	InputResponses *InputResponses   `json:"inputResponses,omitempty"`
+	Name           string            `json:"name"`
+	RequestState   *string           `json:"requestState,omitempty"`
+}
+
+// The result returned by the server for a {@link GetPromptRequestprompts/get} request.
 type GetPromptResult struct {
-	Meta        map[string]any  `json:"_meta,omitempty"`
+	Meta        *MetaObject     `json:"_meta,omitempty"`
 	Description *string         `json:"description,omitempty"`
 	Messages    []PromptMessage `json:"messages"`
+	ResultType  string          `json:"resultType"`
+}
+
+// A successful response from the server for a {@link GetPromptRequestprompts/get} request.
+type GetPromptResultResponse struct {
+	ID      RequestId `json:"id"`
+	JSONRPC string    `json:"jsonrpc"`
+	Result  any       `json:"result"`
+}
+
+// Returned when a server rejects a request because the values in the HTTP
+// headers do not match the corresponding values in the request body, or
+// because required headers are missing or malformed. For HTTP, the response
+// status code MUST be `400 Bad Request`.
+type HeaderMismatchError struct {
+	Error   any        `json:"error"`
+	ID      *RequestId `json:"id,omitempty"`
+	JSONRPC string     `json:"jsonrpc"`
+}
+
+// An optionally-sized icon that can be displayed in a user interface.
+type Icon struct {
+	MIMEType *string  `json:"mimeType,omitempty"`
+	Sizes    []string `json:"sizes,omitempty"`
+	Src      string   `json:"src"`
+	Theme    *Theme   `json:"theme,omitempty"`
+}
+
+// Base interface to add `icons` property.
+type Icons struct {
+	Icons []Icon `json:"icons,omitempty"`
 }
 
 // An image provided to or from an LLM.
 type ImageContent struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Data        []byte         `json:"data"`
-	MIMEType    string         `json:"mimeType"`
-	Type        string         `json:"type"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Data        []byte       `json:"data"`
+	MIMEType    string       `json:"mimeType"`
+	Type        string       `json:"type"`
 }
 
-// Describes the name and version of an MCP implementation, with an optional title for UI representation.
+// Describes the MCP implementation.
 type Implementation struct {
-	Name    string  `json:"name"`
-	Title   *string `json:"title,omitempty"`
-	Version string  `json:"version"`
+	Description *string `json:"description,omitempty"`
+	Icons       []Icon  `json:"icons,omitempty"`
+	Name        string  `json:"name"`
+	Title       *string `json:"title,omitempty"`
+	Version     string  `json:"version"`
+	WebsiteURL  *string `json:"websiteUrl,omitempty"`
 }
 
-// This request is sent from the client to the server when it first connects, asking it to begin initialization.
-type InitializeRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+type InputRequest any
+
+// A map of server-initiated requests that the client must fulfill.
+// Keys are server-assigned identifiers; values are the request objects.
+type InputRequests = map[string]InputRequest
+
+// An InputRequiredResult sent by the server to indicate that additional input is needed
+// before the request can be completed.
+//
+// At least one of `inputRequests` or `requestState` MUST be present.
+type InputRequiredResult struct {
+	Meta          *MetaObject    `json:"_meta,omitempty"`
+	InputRequests *InputRequests `json:"inputRequests,omitempty"`
+	RequestState  *string        `json:"requestState,omitempty"`
+	ResultType    string         `json:"resultType"`
 }
 
-// After receiving an initialize request from the client, the server sends this response.
-type InitializeResult struct {
-	Meta            map[string]any     `json:"_meta,omitempty"`
-	Capabilities    ServerCapabilities `json:"capabilities"`
-	Instructions    *string            `json:"instructions,omitempty"`
-	ProtocolVersion string             `json:"protocolVersion"`
-	ServerInfo      Implementation     `json:"serverInfo"`
+type InputResponse any
+
+type InputResponseRequestParams struct {
+	Meta           RequestMetaObject `json:"_meta"`
+	InputResponses *InputResponses   `json:"inputResponses,omitempty"`
+	RequestState   *string           `json:"requestState,omitempty"`
 }
 
-// This notification is sent from the client to the server after initialization has finished.
-type InitializedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+// A map of client responses to server-initiated requests.
+// Keys correspond to the keys in the {@link InputRequests} map;
+// values are the client's result for each request.
+type InputResponses = map[string]InputResponse
+
+// A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.
+type InternalError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
 }
+
+// A JSON-RPC error indicating that the method parameters are invalid or malformed.
+//
+// In MCP, this error is returned in various contexts when request parameters fail validation:
+//
+// - **Tools**: Unknown tool name or invalid tool arguments
+// - **Prompts**: Unknown prompt name or missing required arguments
+// - **Pagination**: Invalid or expired cursor values
+// - **Logging**: Invalid log level
+// - **Elicitation**: Server requests an elicitation mode not declared in client capabilities
+// - **Sampling**: Missing tool result or tool results mixed with other content
+type InvalidParamsError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
+}
+
+// A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).
+type InvalidRequestError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
+}
+
+type JSONArray = []JSONValue
+
+type JSONObject = map[string]JSONValue
 
 // A response to a request that indicates an error occurred.
-type JSONRPCError struct {
-	Error   map[string]any `json:"error"`
-	ID      RequestId      `json:"id"`
-	JSONRPC string         `json:"jsonrpc"`
+type JSONRPCErrorResponse struct {
+	Error   Error      `json:"error"`
+	ID      *RequestId `json:"id,omitempty"`
+	JSONRPC string     `json:"jsonrpc"`
 }
 
 // Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
@@ -277,50 +554,102 @@ type JSONRPCRequest struct {
 	Params  map[string]any `json:"params,omitempty"`
 }
 
+// A response to a request, containing either the result or error.
+type JSONRPCResponse any
+
 // A successful (non-error) response to a request.
-type JSONRPCResponse struct {
+type JSONRPCResultResponse struct {
 	ID      RequestId `json:"id"`
 	JSONRPC string    `json:"jsonrpc"`
 	Result  Result    `json:"result"`
 }
 
-// Sent from the client to request a list of prompts and prompt templates the server has.
-type ListPromptsRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+type JSONValue any
+
+// Use {@link TitledSingleSelectEnumSchema} instead.
+// This interface will be removed in a future version.
+type LegacyTitledEnumSchema struct {
+	Default     *string  `json:"default,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Enum        []string `json:"enum"`
+	EnumNames   []string `json:"enumNames,omitempty"`
+	Title       *string  `json:"title,omitempty"`
+	Type        string   `json:"type"`
 }
 
-// The server's response to a prompts/list request from the client.
+// Sent from the client to request a list of prompts and prompt templates the server has.
+type ListPromptsRequest struct {
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  PaginatedRequestParams `json:"params"`
+}
+
+// The result returned by the server for a {@link ListPromptsRequestprompts/list} request.
 type ListPromptsResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	NextCursor *string        `json:"nextCursor,omitempty"`
-	Prompts    []Prompt       `json:"prompts"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	CacheScope CacheScope  `json:"cacheScope"`
+	NextCursor *string     `json:"nextCursor,omitempty"`
+	Prompts    []Prompt    `json:"prompts"`
+	ResultType string      `json:"resultType"`
+	TtlMs      int         `json:"ttlMs"`
+}
+
+// A successful response from the server for a {@link ListPromptsRequestprompts/list} request.
+type ListPromptsResultResponse struct {
+	ID      RequestId         `json:"id"`
+	JSONRPC string            `json:"jsonrpc"`
+	Result  ListPromptsResult `json:"result"`
 }
 
 // Sent from the client to request a list of resource templates the server has.
 type ListResourceTemplatesRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  PaginatedRequestParams `json:"params"`
 }
 
-// The server's response to a resources/templates/list request from the client.
+// The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.
 type ListResourceTemplatesResult struct {
-	Meta              map[string]any     `json:"_meta,omitempty"`
+	Meta              *MetaObject        `json:"_meta,omitempty"`
+	CacheScope        CacheScope         `json:"cacheScope"`
 	NextCursor        *string            `json:"nextCursor,omitempty"`
 	ResourceTemplates []ResourceTemplate `json:"resourceTemplates"`
+	ResultType        string             `json:"resultType"`
+	TtlMs             int                `json:"ttlMs"`
+}
+
+// A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.
+type ListResourceTemplatesResultResponse struct {
+	ID      RequestId                   `json:"id"`
+	JSONRPC string                      `json:"jsonrpc"`
+	Result  ListResourceTemplatesResult `json:"result"`
 }
 
 // Sent from the client to request a list of resources the server has.
 type ListResourcesRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  PaginatedRequestParams `json:"params"`
 }
 
-// The server's response to a resources/list request from the client.
+// The result returned by the server for a {@link ListResourcesRequestresources/list} request.
 type ListResourcesResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	NextCursor *string        `json:"nextCursor,omitempty"`
-	Resources  []Resource     `json:"resources"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	CacheScope CacheScope  `json:"cacheScope"`
+	NextCursor *string     `json:"nextCursor,omitempty"`
+	Resources  []Resource  `json:"resources"`
+	ResultType string      `json:"resultType"`
+	TtlMs      int         `json:"ttlMs"`
+}
+
+// A successful response from the server for a {@link ListResourcesRequestresources/list} request.
+type ListResourcesResultResponse struct {
+	ID      RequestId           `json:"id"`
+	JSONRPC string              `json:"jsonrpc"`
+	Result  ListResourcesResult `json:"result"`
 }
 
 // Sent from the server to request a list of root URIs from the client. Roots allow
@@ -335,31 +664,88 @@ type ListRootsRequest struct {
 	Params map[string]any `json:"params,omitempty"`
 }
 
-// The client's response to a roots/list request from the server.
-// This result contains an array of Root objects, each representing a root directory
+// The result returned by the client for a {@link ListRootsRequestroots/list} request.
+// This result contains an array of {@link Root} objects, each representing a root directory
 // or file that the server can operate on.
 type ListRootsResult struct {
-	Meta  map[string]any `json:"_meta,omitempty"`
-	Roots []Root         `json:"roots"`
+	Roots []Root `json:"roots"`
 }
 
 // Sent from the client to request a list of tools the server has.
 type ListToolsRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  PaginatedRequestParams `json:"params"`
 }
 
-// The server's response to a tools/list request from the client.
+// The result returned by the server for a {@link ListToolsRequesttools/list} request.
 type ListToolsResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	NextCursor *string        `json:"nextCursor,omitempty"`
-	Tools      []Tool         `json:"tools"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	CacheScope CacheScope  `json:"cacheScope"`
+	NextCursor *string     `json:"nextCursor,omitempty"`
+	ResultType string      `json:"resultType"`
+	Tools      []Tool      `json:"tools"`
+	TtlMs      int         `json:"ttlMs"`
 }
 
-// Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
+// A successful response from the server for a {@link ListToolsRequesttools/list} request.
+type ListToolsResultResponse struct {
+	ID      RequestId       `json:"id"`
+	JSONRPC string          `json:"jsonrpc"`
+	Result  ListToolsResult `json:"result"`
+}
+
+// JSONRPCNotification of a log message passed from server to client. The client opts in by setting `"io.modelcontextprotocol/logLevel"` in a request's `_meta`.
 type LoggingMessageNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	JSONRPC string                           `json:"jsonrpc"`
+	Method  string                           `json:"method"`
+	Params  LoggingMessageNotificationParams `json:"params"`
+}
+
+// Parameters for a `notifications/message` notification.
+type LoggingMessageNotificationParams struct {
+	Meta   *NotificationMetaObject `json:"_meta,omitempty"`
+	Data   any                     `json:"data"`
+	Level  LoggingLevel            `json:"level"`
+	Logger *string                 `json:"logger,omitempty"`
+}
+
+// Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.
+//
+// Certain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.
+//
+// Valid keys have two segments:
+//
+// **Prefix:**
+// - Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).
+// - Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).
+// - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+// - Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
+//
+// **Name:**
+// - Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).
+// - Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).
+type MetaObject = map[string]any
+
+// A JSON-RPC error indicating that the requested method does not exist or is not available.
+//
+// In MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).
+//
+// A request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).
+type MethodNotFoundError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
+}
+
+// Returned when processing a request requires a capability the client did not
+// declare in `clientCapabilities`. For HTTP, the response status code MUST be
+// `400 Bad Request`.
+type MissingRequiredClientCapabilityError struct {
+	Error   any        `json:"error"`
+	ID      *RequestId `json:"id,omitempty"`
+	JSONRPC string     `json:"jsonrpc"`
 }
 
 // Hints to use for model selection.
@@ -388,33 +774,56 @@ type ModelPreferences struct {
 	SpeedPriority        *float64    `json:"speedPriority,omitempty"`
 }
 
+type MultiSelectEnumSchema any
+
 type Notification struct {
 	Method string         `json:"method"`
 	Params map[string]any `json:"params,omitempty"`
 }
 
+// Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.
+type NotificationMetaObject struct {
+	IoModelcontextprotocolsubscriptionID *RequestId `json:"io.modelcontextprotocol/subscriptionId,omitempty"`
+}
+
+// Common params for any notification.
+type NotificationParams struct {
+	Meta *NotificationMetaObject `json:"_meta,omitempty"`
+}
+
 type NumberSchema struct {
-	Description *string `json:"description,omitempty"`
-	Maximum     *int    `json:"maximum,omitempty"`
-	Minimum     *int    `json:"minimum,omitempty"`
-	Title       *string `json:"title,omitempty"`
-	Type        Type    `json:"type"`
+	Default     *float64 `json:"default,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Maximum     *float64 `json:"maximum,omitempty"`
+	Minimum     *float64 `json:"minimum,omitempty"`
+	Title       *string  `json:"title,omitempty"`
+	Type        Type     `json:"type"`
 }
 
 type PaginatedRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	ID      RequestId              `json:"id"`
+	JSONRPC string                 `json:"jsonrpc"`
+	Method  string                 `json:"method"`
+	Params  PaginatedRequestParams `json:"params"`
+}
+
+// Common params for paginated requests.
+type PaginatedRequestParams struct {
+	Meta   RequestMetaObject `json:"_meta"`
+	Cursor *string           `json:"cursor,omitempty"`
 }
 
 type PaginatedResult struct {
-	Meta       map[string]any `json:"_meta,omitempty"`
-	NextCursor *string        `json:"nextCursor,omitempty"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	NextCursor *string     `json:"nextCursor,omitempty"`
+	ResultType string      `json:"resultType"`
 }
 
-// A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.
-type PingRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+// A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.
+type ParseError struct {
+	Code    int    `json:"code"`
+	Data    *any   `json:"data,omitempty"`
+	Message string `json:"message"`
 }
 
 // Restricted schema definitions that only allow primitive types
@@ -423,8 +832,18 @@ type PrimitiveSchemaDefinition any
 
 // An out-of-band notification used to inform the receiver of a progress update for a long-running request.
 type ProgressNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	JSONRPC string                     `json:"jsonrpc"`
+	Method  string                     `json:"method"`
+	Params  ProgressNotificationParams `json:"params"`
+}
+
+// Parameters for a {@link ProgressNotificationnotifications/progress} notification.
+type ProgressNotificationParams struct {
+	Meta          *NotificationMetaObject `json:"_meta,omitempty"`
+	Message       *string                 `json:"message,omitempty"`
+	Progress      float64                 `json:"progress"`
+	ProgressToken ProgressToken           `json:"progressToken"`
+	Total         *float64                `json:"total,omitempty"`
 }
 
 // A progress token, used to associate progress notifications with the original request.
@@ -433,9 +852,10 @@ type ProgressToken struct {
 
 // A prompt or prompt template that the server offers.
 type Prompt struct {
-	Meta        map[string]any   `json:"_meta,omitempty"`
+	Meta        *MetaObject      `json:"_meta,omitempty"`
 	Arguments   []PromptArgument `json:"arguments,omitempty"`
 	Description *string          `json:"description,omitempty"`
+	Icons       []Icon           `json:"icons,omitempty"`
 	Name        string           `json:"name"`
 	Title       *string          `json:"title,omitempty"`
 }
@@ -448,15 +868,16 @@ type PromptArgument struct {
 	Title       *string `json:"title,omitempty"`
 }
 
-// An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
+// An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.
 type PromptListChangedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	JSONRPC string              `json:"jsonrpc"`
+	Method  string              `json:"method"`
+	Params  *NotificationParams `json:"params,omitempty"`
 }
 
 // Describes a message returned as part of a prompt.
 //
-// This is similar to `SamplingMessage`, but also supports the embedding of
+// This is similar to {@link SamplingMessage}, but also supports the embedding of
 // resources from the MCP server.
 type PromptMessage struct {
 	Content ContentBlock `json:"content"`
@@ -472,14 +893,34 @@ type PromptReference struct {
 
 // Sent from the client to the server, to read a specific resource URI.
 type ReadResourceRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	ID      RequestId                 `json:"id"`
+	JSONRPC string                    `json:"jsonrpc"`
+	Method  string                    `json:"method"`
+	Params  ReadResourceRequestParams `json:"params"`
 }
 
-// The server's response to a resources/read request from the client.
+// Parameters for a `resources/read` request.
+type ReadResourceRequestParams struct {
+	Meta           RequestMetaObject `json:"_meta"`
+	InputResponses *InputResponses   `json:"inputResponses,omitempty"`
+	RequestState   *string           `json:"requestState,omitempty"`
+	URI            string            `json:"uri"`
+}
+
+// The result returned by the server for a {@link ReadResourceRequestresources/read} request.
 type ReadResourceResult struct {
-	Meta     map[string]any `json:"_meta,omitempty"`
-	Contents []any          `json:"contents"`
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	CacheScope CacheScope  `json:"cacheScope"`
+	Contents   []any       `json:"contents"`
+	ResultType string      `json:"resultType"`
+	TtlMs      int         `json:"ttlMs"`
+}
+
+// A successful response from the server for a {@link ReadResourceRequestresources/read} request.
+type ReadResourceResultResponse struct {
+	ID      RequestId `json:"id"`
+	JSONRPC string    `json:"jsonrpc"`
+	Result  any       `json:"result"`
 }
 
 type Request struct {
@@ -491,55 +932,79 @@ type Request struct {
 type RequestId struct {
 }
 
+// Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.
+type RequestMetaObject struct {
+	IoModelcontextprotocolclientCapabilities ClientCapabilities `json:"io.modelcontextprotocol/clientCapabilities"`
+	IoModelcontextprotocolclientInfo         Implementation     `json:"io.modelcontextprotocol/clientInfo"`
+	IoModelcontextprotocollogLevel           *LoggingLevel      `json:"io.modelcontextprotocol/logLevel,omitempty"`
+	IoModelcontextprotocolprotocolVersion    string             `json:"io.modelcontextprotocol/protocolVersion"`
+	ProgressToken                            *ProgressToken     `json:"progressToken,omitempty"`
+}
+
+// Common params for any request.
+type RequestParams struct {
+	Meta RequestMetaObject `json:"_meta"`
+}
+
 // A known resource that the server is capable of reading.
 type Resource struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Description *string        `json:"description,omitempty"`
-	MIMEType    *string        `json:"mimeType,omitempty"`
-	Name        string         `json:"name"`
-	Size        *int           `json:"size,omitempty"`
-	Title       *string        `json:"title,omitempty"`
-	URI         string         `json:"uri"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	Icons       []Icon       `json:"icons,omitempty"`
+	MIMEType    *string      `json:"mimeType,omitempty"`
+	Name        string       `json:"name"`
+	Size        *int         `json:"size,omitempty"`
+	Title       *string      `json:"title,omitempty"`
+	URI         string       `json:"uri"`
 }
 
 // The contents of a specific resource or sub-resource.
 type ResourceContents struct {
-	Meta     map[string]any `json:"_meta,omitempty"`
-	MIMEType *string        `json:"mimeType,omitempty"`
-	URI      string         `json:"uri"`
+	Meta     *MetaObject `json:"_meta,omitempty"`
+	MIMEType *string     `json:"mimeType,omitempty"`
+	URI      string      `json:"uri"`
 }
 
 // A resource that the server is capable of reading, included in a prompt or tool call result.
 //
-// Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
+// Note: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.
 type ResourceLink struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Description *string        `json:"description,omitempty"`
-	MIMEType    *string        `json:"mimeType,omitempty"`
-	Name        string         `json:"name"`
-	Size        *int           `json:"size,omitempty"`
-	Title       *string        `json:"title,omitempty"`
-	Type        string         `json:"type"`
-	URI         string         `json:"uri"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	Icons       []Icon       `json:"icons,omitempty"`
+	MIMEType    *string      `json:"mimeType,omitempty"`
+	Name        string       `json:"name"`
+	Size        *int         `json:"size,omitempty"`
+	Title       *string      `json:"title,omitempty"`
+	Type        string       `json:"type"`
+	URI         string       `json:"uri"`
 }
 
-// An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.
+// An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.
 type ResourceListChangedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	JSONRPC string              `json:"jsonrpc"`
+	Method  string              `json:"method"`
+	Params  *NotificationParams `json:"params,omitempty"`
+}
+
+// Common params for resource-related requests.
+type ResourceRequestParams struct {
+	Meta RequestMetaObject `json:"_meta"`
+	URI  string            `json:"uri"`
 }
 
 // A template description for resources available on the server.
 type ResourceTemplate struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Description *string        `json:"description,omitempty"`
-	MIMEType    *string        `json:"mimeType,omitempty"`
-	Name        string         `json:"name"`
-	Title       *string        `json:"title,omitempty"`
-	URITemplate string         `json:"uriTemplate"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Description *string      `json:"description,omitempty"`
+	Icons       []Icon       `json:"icons,omitempty"`
+	MIMEType    *string      `json:"mimeType,omitempty"`
+	Name        string       `json:"name"`
+	Title       *string      `json:"title,omitempty"`
+	URITemplate string       `json:"uriTemplate"`
 }
 
 // A reference to a resource or resource template definition.
@@ -548,60 +1013,67 @@ type ResourceTemplateReference struct {
 	URI  string `json:"uri"`
 }
 
-// A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.
+// A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.
 type ResourceUpdatedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+	JSONRPC string                            `json:"jsonrpc"`
+	Method  string                            `json:"method"`
+	Params  ResourceUpdatedNotificationParams `json:"params"`
 }
 
-type Result struct {
-	Meta map[string]any `json:"_meta,omitempty"`
+// Parameters for a `notifications/resources/updated` notification.
+type ResourceUpdatedNotificationParams struct {
+	Meta *NotificationMetaObject `json:"_meta,omitempty"`
+	URI  string                  `json:"uri"`
 }
+
+// Common result fields.
+type Result struct {
+	Meta       *MetaObject `json:"_meta,omitempty"`
+	ResultType string      `json:"resultType"`
+}
+
+// Indicates the type of a {@link Result} object, allowing the client to
+// determine how to parse the response.
+//
+// complete - the request completed successfully and the result contains the final content.
+// input_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.
+type ResultType = string
 
 // Represents a root directory or file that the server can operate on.
 type Root struct {
-	Meta map[string]any `json:"_meta,omitempty"`
-	Name *string        `json:"name,omitempty"`
-	URI  string         `json:"uri"`
-}
-
-// A notification from the client to the server, informing it that the list of roots has changed.
-// This notification should be sent whenever the client adds, removes, or modifies any root.
-// The server should then request an updated list of roots using the ListRootsRequest.
-type RootsListChangedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+	Meta *MetaObject `json:"_meta,omitempty"`
+	Name *string     `json:"name,omitempty"`
+	URI  string      `json:"uri"`
 }
 
 // Describes a message issued to or received from an LLM API.
 type SamplingMessage struct {
-	Content any  `json:"content"`
-	Role    Role `json:"role"`
+	Meta    *MetaObject `json:"_meta,omitempty"`
+	Content any         `json:"content"`
+	Role    Role        `json:"role"`
 }
+
+type SamplingMessageContentBlock any
 
 // Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.
 type ServerCapabilities struct {
-	Completions  map[string]any            `json:"completions,omitempty"`
-	Experimental map[string]map[string]any `json:"experimental,omitempty"`
-	Logging      map[string]any            `json:"logging,omitempty"`
-	Prompts      map[string]any            `json:"prompts,omitempty"`
-	Resources    map[string]any            `json:"resources,omitempty"`
-	Tools        map[string]any            `json:"tools,omitempty"`
+	Completions  *JSONObject           `json:"completions,omitempty"`
+	Experimental map[string]JSONObject `json:"experimental,omitempty"`
+	Extensions   map[string]JSONObject `json:"extensions,omitempty"`
+	Logging      *JSONObject           `json:"logging,omitempty"`
+	Prompts      map[string]any        `json:"prompts,omitempty"`
+	Resources    map[string]any        `json:"resources,omitempty"`
+	Tools        map[string]any        `json:"tools,omitempty"`
 }
 
 type ServerNotification any
 
-type ServerRequest any
-
 type ServerResult any
 
-// A request from the client to the server, to enable or adjust logging.
-type SetLevelRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
-}
+type SingleSelectEnumSchema any
 
 type StringSchema struct {
+	Default     *string `json:"default,omitempty"`
 	Description *string `json:"description,omitempty"`
 	Format      *Format `json:"format,omitempty"`
 	MaxLength   *int    `json:"maxLength,omitempty"`
@@ -610,45 +1082,120 @@ type StringSchema struct {
 	Type        string  `json:"type"`
 }
 
-// Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.
-type SubscribeRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+// The set of notification types a client may opt in to on a
+// {@link SubscriptionsListenRequestsubscriptions/listen} request.
+//
+// Each notification type is **opt-in**; the server **MUST NOT** send
+// notification types the client has not explicitly requested here.
+type SubscriptionFilter struct {
+	PromptsListChanged    *bool    `json:"promptsListChanged,omitempty"`
+	ResourceSubscriptions []string `json:"resourceSubscriptions,omitempty"`
+	ResourcesListChanged  *bool    `json:"resourcesListChanged,omitempty"`
+	ToolsListChanged      *bool    `json:"toolsListChanged,omitempty"`
+}
+
+// Sent by the server as the first message on a
+// {@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge
+// that the subscription has been established and to report which notification
+// types it agreed to honor.
+type SubscriptionsAcknowledgedNotification struct {
+	JSONRPC string                                      `json:"jsonrpc"`
+	Method  string                                      `json:"method"`
+	Params  SubscriptionsAcknowledgedNotificationParams `json:"params"`
+}
+
+// Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.
+type SubscriptionsAcknowledgedNotificationParams struct {
+	Meta          *NotificationMetaObject `json:"_meta,omitempty"`
+	Notifications SubscriptionFilter      `json:"notifications"`
+}
+
+// Sent from the client to open a long-lived channel for receiving notifications
+// outside the context of a specific request. Replaces the previous HTTP GET
+// endpoint and ensures consistent behavior between HTTP and STDIO.
+type SubscriptionsListenRequest struct {
+	ID      RequestId                        `json:"id"`
+	JSONRPC string                           `json:"jsonrpc"`
+	Method  string                           `json:"method"`
+	Params  SubscriptionsListenRequestParams `json:"params"`
+}
+
+// Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.
+type SubscriptionsListenRequestParams struct {
+	Meta          RequestMetaObject  `json:"_meta"`
+	Notifications SubscriptionFilter `json:"notifications"`
+}
+
+// The response to a {@link SubscriptionsListenRequestsubscriptions/listen}
+// request, signalling that the subscription has ended gracefully (for example,
+// during server shutdown). Because the listen stream is long-lived, this result
+// is sent only when the server tears the subscription down; an abrupt transport
+// close carries no response. The result body is otherwise empty.
+type SubscriptionsListenResult struct {
+	Meta       SubscriptionsListenResultMeta `json:"_meta"`
+	ResultType string                        `json:"resultType"`
+}
+
+// Extends {@link MetaObject} with the subscription-stream identifier carried by a
+// {@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.
+type SubscriptionsListenResultMeta struct {
+	IoModelcontextprotocolsubscriptionID RequestId `json:"io.modelcontextprotocol/subscriptionId"`
 }
 
 // Text provided to or from an LLM.
 type TextContent struct {
-	Meta        map[string]any `json:"_meta,omitempty"`
-	Annotations *Annotations   `json:"annotations,omitempty"`
-	Text        string         `json:"text"`
-	Type        string         `json:"type"`
+	Meta        *MetaObject  `json:"_meta,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
+	Text        string       `json:"text"`
+	Type        string       `json:"type"`
 }
 
 type TextResourceContents struct {
-	Meta     map[string]any `json:"_meta,omitempty"`
-	MIMEType *string        `json:"mimeType,omitempty"`
-	Text     string         `json:"text"`
-	URI      string         `json:"uri"`
+	Meta     *MetaObject `json:"_meta,omitempty"`
+	MIMEType *string     `json:"mimeType,omitempty"`
+	Text     string      `json:"text"`
+	URI      string      `json:"uri"`
+}
+
+// Schema for multiple-selection enumeration with display titles for each option.
+type TitledMultiSelectEnumSchema struct {
+	Default     []string       `json:"default,omitempty"`
+	Description *string        `json:"description,omitempty"`
+	Items       map[string]any `json:"items"`
+	MaxItems    *int           `json:"maxItems,omitempty"`
+	MinItems    *int           `json:"minItems,omitempty"`
+	Title       *string        `json:"title,omitempty"`
+	Type        string         `json:"type"`
+}
+
+// Schema for single-selection enumeration with display titles for each option.
+type TitledSingleSelectEnumSchema struct {
+	Default     *string          `json:"default,omitempty"`
+	Description *string          `json:"description,omitempty"`
+	OneOf       []map[string]any `json:"oneOf"`
+	Title       *string          `json:"title,omitempty"`
+	Type        string           `json:"type"`
 }
 
 // Definition for a tool the client can call.
 type Tool struct {
-	Meta         map[string]any   `json:"_meta,omitempty"`
+	Meta         *MetaObject      `json:"_meta,omitempty"`
 	Annotations  *ToolAnnotations `json:"annotations,omitempty"`
 	Description  *string          `json:"description,omitempty"`
+	Icons        []Icon           `json:"icons,omitempty"`
 	InputSchema  map[string]any   `json:"inputSchema"`
 	Name         string           `json:"name"`
 	OutputSchema map[string]any   `json:"outputSchema,omitempty"`
 	Title        *string          `json:"title,omitempty"`
 }
 
-// Additional properties describing a Tool to clients.
+// Additional properties describing a {@link Tool} to clients.
 //
-// NOTE: all properties in ToolAnnotations are **hints**.
+// NOTE: all properties in `ToolAnnotations` are **hints**.
 // They are not guaranteed to provide a faithful description of
 // tool behavior (including descriptive properties like `title`).
 //
-// Clients should never make tool use decisions based on ToolAnnotations
+// Clients should never make tool use decisions based on `ToolAnnotations`
 // received from untrusted servers.
 type ToolAnnotations struct {
 	DestructiveHint *bool   `json:"destructiveHint,omitempty"`
@@ -658,14 +1205,63 @@ type ToolAnnotations struct {
 	Title           *string `json:"title,omitempty"`
 }
 
-// An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.
-type ToolListChangedNotification struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params,omitempty"`
+// Controls tool selection behavior for sampling requests.
+type ToolChoice struct {
+	Mode *Mode `json:"mode,omitempty"`
 }
 
-// Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.
-type UnsubscribeRequest struct {
-	Method string         `json:"method"`
-	Params map[string]any `json:"params"`
+// An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.
+type ToolListChangedNotification struct {
+	JSONRPC string              `json:"jsonrpc"`
+	Method  string              `json:"method"`
+	Params  *NotificationParams `json:"params,omitempty"`
+}
+
+// The result of a tool use, provided by the user back to the assistant.
+type ToolResultContent struct {
+	Meta              *MetaObject    `json:"_meta,omitempty"`
+	Content           []ContentBlock `json:"content"`
+	IsError           *bool          `json:"isError,omitempty"`
+	StructuredContent *any           `json:"structuredContent,omitempty"`
+	ToolUseID         string         `json:"toolUseId"`
+	Type              string         `json:"type"`
+}
+
+// A request from the assistant to call a tool.
+type ToolUseContent struct {
+	Meta  *MetaObject    `json:"_meta,omitempty"`
+	ID    string         `json:"id"`
+	Input map[string]any `json:"input"`
+	Name  string         `json:"name"`
+	Type  string         `json:"type"`
+}
+
+// Returned when the request's protocol version is unknown to the server or
+// unsupported (e.g., a known experimental or draft version the server has
+// chosen not to implement). For HTTP, the response status code MUST be
+// `400 Bad Request`.
+type UnsupportedProtocolVersionError struct {
+	Error   any        `json:"error"`
+	ID      *RequestId `json:"id,omitempty"`
+	JSONRPC string     `json:"jsonrpc"`
+}
+
+// Schema for multiple-selection enumeration without display titles for options.
+type UntitledMultiSelectEnumSchema struct {
+	Default     []string       `json:"default,omitempty"`
+	Description *string        `json:"description,omitempty"`
+	Items       map[string]any `json:"items"`
+	MaxItems    *int           `json:"maxItems,omitempty"`
+	MinItems    *int           `json:"minItems,omitempty"`
+	Title       *string        `json:"title,omitempty"`
+	Type        string         `json:"type"`
+}
+
+// Schema for single-selection enumeration without display titles for options.
+type UntitledSingleSelectEnumSchema struct {
+	Default     *string  `json:"default,omitempty"`
+	Description *string  `json:"description,omitempty"`
+	Enum        []string `json:"enum"`
+	Title       *string  `json:"title,omitempty"`
+	Type        string   `json:"type"`
 }

--- a/internal/mcp/mcp-schema.json
+++ b/internal/mcp/mcp-schema.json
@@ -1,13 +1,13 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$defs": {
     "Annotations": {
       "description": "Optional annotations for the client. The client can use annotations to inform how objects are used or displayed",
       "properties": {
         "audience": {
-          "description": "Describes who the intended customer of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
+          "description": "Describes who the intended audience of this object or data is.\n\nIt can include multiple entries to indicate content useful for multiple audiences (e.g., `[\"user\", \"assistant\"]`).",
           "items": {
-            "$ref": "#/definitions/Role"
+            "$ref": "#/$defs/Role"
           },
           "type": "array"
         },
@@ -28,12 +28,10 @@
       "description": "Audio provided to or from an LLM.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "data": {
@@ -61,7 +59,7 @@
           "type": "string"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         }
       },
@@ -71,9 +69,7 @@
     "BlobResourceContents": {
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "blob": {
           "description": "A base64-encoded string representing the binary data of the item.",
@@ -112,42 +108,86 @@
       "required": ["type"],
       "type": "object"
     },
+    "CacheableResult": {
+      "description": "A result that supports a time-to-live (TTL) hint for client-side caching.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": ["cacheScope", "resultType", "ttlMs"],
+      "type": "object"
+    },
     "CallToolRequest": {
       "description": "Used by the client to invoke a tool provided by the server.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "tools/call",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "arguments": {
-              "additionalProperties": {},
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            }
-          },
-          "required": ["name"],
-          "type": "object"
+          "$ref": "#/$defs/CallToolRequestParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "CallToolRequestParams": {
+      "description": "Parameters for a `tools/call` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {},
+          "description": "Arguments to use for the tool call.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the tool.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": ["_meta", "name"],
       "type": "object"
     },
     "CallToolResult": {
-      "description": "The server's response to a tool call.",
+      "description": "The result returned by the server for a {@link CallToolRequesttools/call} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "content": {
           "description": "A list of content objects that represent the unstructured result of the tool call.",
           "items": {
-            "$ref": "#/definitions/ContentBlock"
+            "$ref": "#/$defs/ContentBlock"
           },
           "type": "array"
         },
@@ -155,214 +195,258 @@
           "description": "Whether the tool call ended in an error.\n\nIf not set, this is assumed to be false (the call was successful).\n\nAny errors that originate from the tool SHOULD be reported inside the result\nobject, with `isError` set to true, _not_ as an MCP protocol-level error\nresponse. Otherwise, the LLM would not be able to see that an error occurred\nand self-correct.\n\nHowever, any errors in _finding_ the tool, an error indicating that the\nserver does not support tool calls, or any other exceptional conditions,\nshould be reported as an MCP error response.",
           "type": "boolean"
         },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
         "structuredContent": {
-          "additionalProperties": {},
-          "description": "An optional JSON object that represents the structured result of the tool call.",
-          "type": "object"
+          "description": "An optional JSON value that represents the structured result of the tool call.\n\nThis can be any JSON value (object, array, string, number, boolean, or null)\nthat conforms to the tool's outputSchema if one is defined."
         }
       },
-      "required": ["content"],
+      "required": ["content", "resultType"],
+      "type": "object"
+    },
+    "CallToolResultResponse": {
+      "description": "A successful response from the server for a {@link CallToolRequesttools/call} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/CallToolResult"
+            }
+          ]
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "CancelledNotification": {
-      "description": "This notification can be sent by either side to indicate that it is cancelling a previously-issued request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.\n\nA client MUST NOT attempt to cancel its `initialize` request.",
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/cancelled",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "reason": {
-              "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
-              "type": "string"
-            },
-            "requestId": {
-              "$ref": "#/definitions/RequestId",
-              "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request previously issued in the same direction."
-            }
-          },
-          "required": ["requestId"],
-          "type": "object"
+          "$ref": "#/$defs/CancelledNotificationParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "CancelledNotificationParams": {
+      "description": "Parameters for a `notifications/cancelled` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "reason": {
+          "description": "An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.",
+          "type": "string"
+        },
+        "requestId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "The ID of the request to cancel.\n\nThis MUST correspond to the ID of a request the client previously issued."
+        }
+      },
+      "required": ["requestId"],
       "type": "object"
     },
     "ClientCapabilities": {
       "description": "Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.",
       "properties": {
         "elicitation": {
-          "additionalProperties": true,
           "description": "Present if the client supports elicitation from the server.",
-          "properties": {},
-          "type": "object"
-        },
-        "experimental": {
-          "additionalProperties": {
-            "additionalProperties": true,
-            "properties": {},
-            "type": "object"
-          },
-          "description": "Experimental, non-standard capabilities that the client supports.",
-          "type": "object"
-        },
-        "roots": {
-          "description": "Present if the client supports listing roots.",
           "properties": {
-            "listChanged": {
-              "description": "Whether the client supports notifications for changes to the roots list.",
-              "type": "boolean"
+            "form": {
+              "$ref": "#/$defs/JSONObject"
+            },
+            "url": {
+              "$ref": "#/$defs/JSONObject"
             }
           },
           "type": "object"
         },
-        "sampling": {
-          "additionalProperties": true,
-          "description": "Present if the client supports sampling from an LLM.",
+        "experimental": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Experimental, non-standard capabilities that the client supports.",
+          "type": "object"
+        },
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the client supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/oauth-client-credentials\"), and values are\nper-extension settings objects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
+          "type": "object"
+        },
+        "roots": {
+          "description": "Present if the client supports listing roots.",
           "properties": {},
+          "type": "object"
+        },
+        "sampling": {
+          "description": "Present if the client supports sampling from an LLM.",
+          "properties": {
+            "context": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports context inclusion via `includeContext` parameter.\nIf not declared, servers SHOULD only use `includeContext: \"none\"` (or omit it)."
+            },
+            "tools": {
+              "$ref": "#/$defs/JSONObject",
+              "description": "Whether the client supports tool use via `tools` and `toolChoice` parameters."
+            }
+          },
           "type": "object"
         }
       },
       "type": "object"
     },
     "ClientNotification": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/CancelledNotification"
+      "description": "This notification is sent by the client to indicate that it is cancelling a request it previously issued.\n\nOn stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.\n\nThe request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.\n\nThis notification indicates that the result will be unused, so any associated processing SHOULD cease.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
         },
-        {
-          "$ref": "#/definitions/InitializedNotification"
+        "method": {
+          "const": "notifications/cancelled",
+          "type": "string"
         },
-        {
-          "$ref": "#/definitions/ProgressNotification"
-        },
-        {
-          "$ref": "#/definitions/RootsListChangedNotification"
+        "params": {
+          "$ref": "#/$defs/CancelledNotificationParams"
         }
-      ]
+      },
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
     },
     "ClientRequest": {
       "anyOf": [
         {
-          "$ref": "#/definitions/InitializeRequest"
+          "$ref": "#/$defs/DiscoverRequest"
         },
         {
-          "$ref": "#/definitions/PingRequest"
+          "$ref": "#/$defs/ListResourcesRequest"
         },
         {
-          "$ref": "#/definitions/ListResourcesRequest"
+          "$ref": "#/$defs/ListResourceTemplatesRequest"
         },
         {
-          "$ref": "#/definitions/ListResourceTemplatesRequest"
+          "$ref": "#/$defs/ReadResourceRequest"
         },
         {
-          "$ref": "#/definitions/ReadResourceRequest"
+          "$ref": "#/$defs/SubscriptionsListenRequest"
         },
         {
-          "$ref": "#/definitions/SubscribeRequest"
+          "$ref": "#/$defs/ListPromptsRequest"
         },
         {
-          "$ref": "#/definitions/UnsubscribeRequest"
+          "$ref": "#/$defs/GetPromptRequest"
         },
         {
-          "$ref": "#/definitions/ListPromptsRequest"
+          "$ref": "#/$defs/ListToolsRequest"
         },
         {
-          "$ref": "#/definitions/GetPromptRequest"
+          "$ref": "#/$defs/CallToolRequest"
         },
         {
-          "$ref": "#/definitions/ListToolsRequest"
-        },
-        {
-          "$ref": "#/definitions/CallToolRequest"
-        },
-        {
-          "$ref": "#/definitions/SetLevelRequest"
-        },
-        {
-          "$ref": "#/definitions/CompleteRequest"
+          "$ref": "#/$defs/CompleteRequest"
         }
       ]
     },
     "ClientResult": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/Result"
-        },
-        {
-          "$ref": "#/definitions/CreateMessageResult"
-        },
-        {
-          "$ref": "#/definitions/ListRootsResult"
-        },
-        {
-          "$ref": "#/definitions/ElicitResult"
-        }
-      ]
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
     },
     "CompleteRequest": {
       "description": "A request from the client to the server, to ask for completion options.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "completion/complete",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "argument": {
-              "description": "The argument's information",
-              "properties": {
-                "name": {
-                  "description": "The name of the argument",
-                  "type": "string"
-                },
-                "value": {
-                  "description": "The value of the argument to use for completion matching.",
-                  "type": "string"
-                }
-              },
-              "required": ["name", "value"],
-              "type": "object"
-            },
-            "context": {
-              "description": "Additional, optional context for completions",
-              "properties": {
-                "arguments": {
-                  "additionalProperties": {
-                    "type": "string"
-                  },
-                  "description": "Previously-resolved variables in a URI template or prompt.",
-                  "type": "object"
-                }
-              },
-              "type": "object"
-            },
-            "ref": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PromptReference"
-                },
-                {
-                  "$ref": "#/definitions/ResourceTemplateReference"
-                }
-              ]
-            }
-          },
-          "required": ["argument", "ref"],
-          "type": "object"
+          "$ref": "#/$defs/CompleteRequestParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "CompleteRequestParams": {
+      "description": "Parameters for a `completion/complete` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "argument": {
+          "description": "The argument's information",
+          "properties": {
+            "name": {
+              "description": "The name of the argument",
+              "type": "string"
+            },
+            "value": {
+              "description": "The value of the argument to use for completion matching.",
+              "type": "string"
+            }
+          },
+          "required": ["name", "value"],
+          "type": "object"
+        },
+        "context": {
+          "description": "Additional, optional context for completions",
+          "properties": {
+            "arguments": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "description": "Previously-resolved variables in a URI template or prompt.",
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "ref": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PromptReference"
+            },
+            {
+              "$ref": "#/$defs/ResourceTemplateReference"
+            }
+          ]
+        }
+      },
+      "required": ["_meta", "argument", "ref"],
       "type": "object"
     },
     "CompleteResult": {
-      "description": "The server's response to a completion/complete request",
+      "description": "The result returned by the server for a {@link CompleteRequestcompletion/complete} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "completion": {
           "properties": {
@@ -379,32 +463,54 @@
               "items": {
                 "type": "string"
               },
+              "maxItems": 100,
               "type": "array"
             }
           },
           "required": ["values"],
           "type": "object"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
         }
       },
-      "required": ["completion"],
+      "required": ["completion", "resultType"],
+      "type": "object"
+    },
+    "CompleteResultResponse": {
+      "description": "A successful response from the server for a {@link CompleteRequestcompletion/complete} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/CompleteResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "ContentBlock": {
       "anyOf": [
         {
-          "$ref": "#/definitions/TextContent"
+          "$ref": "#/$defs/TextContent"
         },
         {
-          "$ref": "#/definitions/ImageContent"
+          "$ref": "#/$defs/ImageContent"
         },
         {
-          "$ref": "#/definitions/AudioContent"
+          "$ref": "#/$defs/AudioContent"
         },
         {
-          "$ref": "#/definitions/ResourceLink"
+          "$ref": "#/$defs/ResourceLink"
         },
         {
-          "$ref": "#/definitions/EmbeddedResource"
+          "$ref": "#/$defs/EmbeddedResource"
         }
       ]
     },
@@ -416,71 +522,94 @@
           "type": "string"
         },
         "params": {
-          "properties": {
-            "includeContext": {
-              "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.",
-              "enum": ["allServers", "none", "thisServer"],
-              "type": "string"
-            },
-            "maxTokens": {
-              "description": "The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.",
-              "type": "integer"
-            },
-            "messages": {
-              "items": {
-                "$ref": "#/definitions/SamplingMessage"
-              },
-              "type": "array"
-            },
-            "metadata": {
-              "additionalProperties": true,
-              "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.",
-              "properties": {},
-              "type": "object"
-            },
-            "modelPreferences": {
-              "$ref": "#/definitions/ModelPreferences",
-              "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
-            },
-            "stopSequences": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "systemPrompt": {
-              "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
-              "type": "string"
-            },
-            "temperature": {
-              "type": "number"
-            }
-          },
-          "required": ["maxTokens", "messages"],
-          "type": "object"
+          "$ref": "#/$defs/CreateMessageRequestParams"
         }
       },
       "required": ["method", "params"],
       "type": "object"
     },
+    "CreateMessageRequestParams": {
+      "description": "Parameters for a `sampling/createMessage` request.",
+      "properties": {
+        "includeContext": {
+          "description": "A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.\nThe client MAY ignore this request.\n\nDefault is `\"none\"`. The values `\"thisServer\"` and `\"allServers\"` are deprecated (SEP-2596): servers SHOULD\nomit this field or use `\"none\"`, and SHOULD only use the deprecated values if the client declares\n{@link ClientCapabilities.sampling.context}.",
+          "enum": ["allServers", "none", "thisServer"],
+          "type": "string"
+        },
+        "maxTokens": {
+          "description": "The requested maximum number of tokens to sample (to prevent runaway completions).\n\nThe client MAY choose to sample fewer tokens than the requested maximum.",
+          "type": "integer"
+        },
+        "messages": {
+          "items": {
+            "$ref": "#/$defs/SamplingMessage"
+          },
+          "type": "array"
+        },
+        "metadata": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific."
+        },
+        "modelPreferences": {
+          "$ref": "#/$defs/ModelPreferences",
+          "description": "The server's preferences for which model to select. The client MAY ignore these preferences."
+        },
+        "stopSequences": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "systemPrompt": {
+          "description": "An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.",
+          "type": "string"
+        },
+        "temperature": {
+          "type": "number"
+        },
+        "toolChoice": {
+          "$ref": "#/$defs/ToolChoice",
+          "description": "Controls how the model uses tools.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.\nDefault is `{ mode: \"auto\" }`."
+        },
+        "tools": {
+          "description": "Tools that the model may use during generation.\nThe client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.",
+          "items": {
+            "$ref": "#/$defs/Tool"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["maxTokens", "messages"],
+      "type": "object"
+    },
     "CreateMessageResult": {
-      "description": "The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.",
+      "description": "The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.\nThe client should inform the user before returning the sampled message, to allow them\nto inspect the response (human in the loop) and decide whether to allow the server to see it.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "content": {
           "anyOf": [
             {
-              "$ref": "#/definitions/TextContent"
+              "$ref": "#/$defs/TextContent"
             },
             {
-              "$ref": "#/definitions/ImageContent"
+              "$ref": "#/$defs/ImageContent"
             },
             {
-              "$ref": "#/definitions/AudioContent"
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
             }
           ]
         },
@@ -489,10 +618,10 @@
           "type": "string"
         },
         "role": {
-          "$ref": "#/definitions/Role"
+          "$ref": "#/$defs/Role"
         },
         "stopReason": {
-          "description": "The reason why sampling stopped, if known.",
+          "description": "The reason why sampling stopped, if known.\n\nStandard values:\n- `\"endTurn\"`: Natural end of the assistant's turn\n- `\"stopSequence\"`: A stop sequence was encountered\n- `\"maxTokens\"`: Maximum token limit was reached\n- `\"toolUse\"`: The model wants to use one or more tools\n\nThis field is an open string to allow for provider-specific stop reasons.",
           "type": "string"
         }
       },
@@ -503,6 +632,94 @@
       "description": "An opaque token used to represent a cursor for pagination.",
       "type": "string"
     },
+    "DiscoverRequest": {
+      "description": "A request from the client asking the server to advertise its supported\nprotocol versions, capabilities, and other metadata. Servers **MUST**\nimplement `server/discover`. Clients **MAY** call it but are not required\nto — version negotiation can also happen inline via per-request `_meta`.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "server/discover",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/RequestParams"
+        }
+      },
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "DiscoverResult": {
+      "description": "The result returned by the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/ServerCapabilities",
+          "description": "The capabilities of the server."
+        },
+        "instructions": {
+          "description": "Natural-language guidance describing the server and its features.\n\nThis can be used by clients to improve an LLM's understanding of\navailable tools (e.g., by including it in a system prompt). It should\nfocus on information that helps the model use the server effectively\nand should not duplicate information already in tool descriptions.",
+          "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "serverInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Information about the server software implementation."
+        },
+        "supportedVersions": {
+          "description": "MCP Protocol Versions this server supports. The client should choose a\nversion from this list for use in subsequent requests.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "cacheScope",
+        "capabilities",
+        "resultType",
+        "serverInfo",
+        "supportedVersions",
+        "ttlMs"
+      ],
+      "type": "object"
+    },
+    "DiscoverResultResponse": {
+      "description": "A successful response from the server for a {@link DiscoverRequestserver/discover} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/DiscoverResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
+      "type": "object"
+    },
     "ElicitRequest": {
       "description": "A request from the server to elicit additional information from the user via the client.",
       "properties": {
@@ -511,60 +728,109 @@
           "type": "string"
         },
         "params": {
-          "properties": {
-            "message": {
-              "description": "The message to present to the user.",
-              "type": "string"
-            },
-            "requestedSchema": {
-              "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
-              "properties": {
-                "properties": {
-                  "additionalProperties": {
-                    "$ref": "#/definitions/PrimitiveSchemaDefinition"
-                  },
-                  "type": "object"
-                },
-                "required": {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                "type": {
-                  "const": "object",
-                  "type": "string"
-                }
-              },
-              "required": ["properties", "type"],
-              "type": "object"
-            }
-          },
-          "required": ["message", "requestedSchema"],
-          "type": "object"
+          "$ref": "#/$defs/ElicitRequestParams"
         }
       },
       "required": ["method", "params"],
       "type": "object"
     },
-    "ElicitResult": {
-      "description": "The client's response to an elicitation request.",
+    "ElicitRequestFormParams": {
+      "description": "The parameters for a request to elicit non-sensitive information from the user via a form in the client.",
       "properties": {
-        "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+        "message": {
+          "description": "The message to present to the user describing what information is being requested.",
+          "type": "string"
         },
+        "mode": {
+          "const": "form",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "requestedSchema": {
+          "description": "A restricted subset of JSON Schema.\nOnly top-level properties are allowed, without nesting.",
+          "properties": {
+            "$schema": {
+              "type": "string"
+            },
+            "properties": {
+              "additionalProperties": {
+                "$ref": "#/$defs/PrimitiveSchemaDefinition"
+              },
+              "type": "object"
+            },
+            "required": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "object",
+              "type": "string"
+            }
+          },
+          "required": ["properties", "type"],
+          "type": "object"
+        }
+      },
+      "required": ["message", "requestedSchema"],
+      "type": "object"
+    },
+    "ElicitRequestParams": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ElicitRequestFormParams"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequestURLParams"
+        }
+      ],
+      "description": "The parameters for a request to elicit additional information from the user via the client."
+    },
+    "ElicitRequestURLParams": {
+      "description": "The parameters for a request to elicit information from the user via a URL in the client.",
+      "properties": {
+        "message": {
+          "description": "The message to present to the user explaining why the interaction is needed.",
+          "type": "string"
+        },
+        "mode": {
+          "const": "url",
+          "description": "The elicitation mode.",
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL that the user should navigate to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": ["message", "mode", "url"],
+      "type": "object"
+    },
+    "ElicitResult": {
+      "description": "The result returned by the client for an {@link ElicitRequestelicitation/create} request.",
+      "properties": {
         "action": {
-          "description": "The user action in response to the elicitation.\n- \"accept\": User submitted the form/confirmed the action\n- \"decline\": User explicitly decline the action\n- \"cancel\": User dismissed without making an explicit choice",
+          "description": "The user action in response to the elicitation.\n- `\"accept\"`: User submitted the form/confirmed the action\n- `\"decline\"`: User explicitly declined the action\n- `\"cancel\"`: User dismissed without making an explicit choice",
           "enum": ["accept", "cancel", "decline"],
           "type": "string"
         },
         "content": {
           "additionalProperties": {
-            "type": ["string", "integer", "boolean"]
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": ["string", "integer", "boolean"]
+              }
+            ]
           },
-          "description": "The submitted form data, only present when action is \"accept\".\nContains values matching the requested schema.",
+          "description": "The submitted form data, only present when action is `\"accept\"` and mode was `\"form\"`.\nContains values matching the requested schema.\nOmitted for out-of-band mode responses.",
           "type": "object"
         }
       },
@@ -575,21 +841,19 @@
       "description": "The contents of a resource, embedded into a prompt or tool call result.\n\nIt is up to the client how best to render embedded resources for the benefit\nof the LLM and/or the user.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "resource": {
           "anyOf": [
             {
-              "$ref": "#/definitions/TextResourceContents"
+              "$ref": "#/$defs/TextResourceContents"
             },
             {
-              "$ref": "#/definitions/BlobResourceContents"
+              "$ref": "#/$defs/BlobResourceContents"
             }
           ]
         },
@@ -602,71 +866,98 @@
       "type": "object"
     },
     "EmptyResult": {
-      "$ref": "#/definitions/Result"
+      "$ref": "#/$defs/Result",
+      "description": "Common result fields."
     },
     "EnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
+        }
+      ]
+    },
+    "Error": {
       "properties": {
-        "description": {
-          "type": "string"
+        "code": {
+          "description": "The error type that occurred.",
+          "type": "integer"
         },
-        "enum": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
         },
-        "enumNames": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "title": {
-          "type": "string"
-        },
-        "type": {
-          "const": "string",
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
           "type": "string"
         }
       },
-      "required": ["enum", "type"],
+      "required": ["code", "message"],
       "type": "object"
     },
     "GetPromptRequest": {
       "description": "Used by the client to get a prompt provided by the server.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "prompts/get",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "arguments": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "description": "Arguments to use for templating the prompt.",
-              "type": "object"
-            },
-            "name": {
-              "description": "The name of the prompt or prompt template.",
-              "type": "string"
-            }
-          },
-          "required": ["name"],
-          "type": "object"
+          "$ref": "#/$defs/GetPromptRequestParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "GetPromptRequestParams": {
+      "description": "Parameters for a `prompts/get` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "arguments": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Arguments to use for templating the prompt.",
+          "type": "object"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "name": {
+          "description": "The name of the prompt or prompt template.",
+          "type": "string"
+        },
+        "requestState": {
+          "type": "string"
+        }
+      },
+      "required": ["_meta", "name"],
       "type": "object"
     },
     "GetPromptResult": {
-      "description": "The server's response to a prompts/get request from the client.",
+      "description": "The result returned by the server for a {@link GetPromptRequestprompts/get} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "description": {
           "description": "An optional description for the prompt.",
@@ -674,24 +965,122 @@
         },
         "messages": {
           "items": {
-            "$ref": "#/definitions/PromptMessage"
+            "$ref": "#/$defs/PromptMessage"
+          },
+          "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": ["messages", "resultType"],
+      "type": "object"
+    },
+    "GetPromptResultResponse": {
+      "description": "A successful response from the server for a {@link GetPromptRequestprompts/get} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/GetPromptResult"
+            }
+          ]
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
+      "type": "object"
+    },
+    "HeaderMismatchError": {
+      "description": "Returned when a server rejects a request because the values in the HTTP\nheaders do not match the corresponding values in the request body, or\nbecause required headers are missing or malformed. For HTTP, the response\nstatus code MUST be `400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32020,
+                  "type": "integer"
+                }
+              },
+              "required": ["code"],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": ["error", "jsonrpc"],
+      "type": "object"
+    },
+    "Icon": {
+      "description": "An optionally-sized icon that can be displayed in a user interface.",
+      "properties": {
+        "mimeType": {
+          "description": "Optional MIME type override if the source MIME type is missing or generic.\nFor example: `\"image/png\"`, `\"image/jpeg\"`, or `\"image/svg+xml\"`.",
+          "type": "string"
+        },
+        "sizes": {
+          "description": "Optional array of strings that specify sizes at which the icon can be used.\nEach string should be in WxH format (e.g., `\"48x48\"`, `\"96x96\"`) or `\"any\"` for scalable formats like SVG.\n\nIf not provided, the client should assume that the icon can be used at any size.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "src": {
+          "description": "A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a\n`data:` URI with Base64-encoded image data.\n\nConsumers SHOULD take steps to ensure URLs serving icons are from the\nsame domain as the client/server or a trusted domain.\n\nConsumers SHOULD take appropriate precautions when consuming SVGs as they can contain\nexecutable JavaScript.",
+          "format": "uri",
+          "type": "string"
+        },
+        "theme": {
+          "description": "Optional specifier for the theme this icon is designed for. `\"light\"` indicates\nthe icon is designed to be used with a light background, and `\"dark\"` indicates\nthe icon is designed to be used with a dark background.\n\nIf not provided, the client should assume the icon can be used with any theme.",
+          "enum": ["dark", "light"],
+          "type": "string"
+        }
+      },
+      "required": ["src"],
+      "type": "object"
+    },
+    "Icons": {
+      "description": "Base interface to add `icons` property.",
+      "properties": {
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
           },
           "type": "array"
         }
       },
-      "required": ["messages"],
       "type": "object"
     },
     "ImageContent": {
       "description": "An image provided to or from an LLM.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "data": {
@@ -712,142 +1101,214 @@
       "type": "object"
     },
     "Implementation": {
-      "description": "Describes the name and version of an MCP implementation, with an optional title for UI representation.",
+      "description": "Describes the MCP implementation.",
       "properties": {
+        "description": {
+          "description": "An optional human-readable description of what this implementation does.\n\nThis can be used by clients or servers to provide context about their purpose\nand capabilities. For example, a server might describe the types of resources\nor tools it provides, while a client might describe its intended use case.",
+          "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
         "name": {
           "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
           "type": "string"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "version": {
+          "description": "The version of this implementation.",
+          "type": "string"
+        },
+        "websiteUrl": {
+          "description": "An optional URL of the website for this implementation.",
+          "format": "uri",
           "type": "string"
         }
       },
       "required": ["name", "version"],
       "type": "object"
     },
-    "InitializeRequest": {
-      "description": "This request is sent from the client to the server when it first connects, asking it to begin initialization.",
-      "properties": {
-        "method": {
-          "const": "initialize",
-          "type": "string"
+    "InputRequest": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageRequest"
         },
-        "params": {
-          "properties": {
-            "capabilities": {
-              "$ref": "#/definitions/ClientCapabilities"
-            },
-            "clientInfo": {
-              "$ref": "#/definitions/Implementation"
-            },
-            "protocolVersion": {
-              "description": "The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.",
-              "type": "string"
-            }
-          },
-          "required": ["capabilities", "clientInfo", "protocolVersion"],
-          "type": "object"
+        {
+          "$ref": "#/$defs/ListRootsRequest"
+        },
+        {
+          "$ref": "#/$defs/ElicitRequest"
         }
+      ]
+    },
+    "InputRequests": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputRequest"
       },
-      "required": ["method", "params"],
+      "description": "A map of server-initiated requests that the client must fulfill.\nKeys are server-assigned identifiers; values are the request objects.",
       "type": "object"
     },
-    "InitializeResult": {
-      "description": "After receiving an initialize request from the client, the server sends this response.",
+    "InputRequiredResult": {
+      "description": "An InputRequiredResult sent by the server to indicate that additional input is needed\nbefore the request can be completed.\n\nAt least one of `inputRequests` or `requestState` MUST be present.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
-        "capabilities": {
-          "$ref": "#/definitions/ServerCapabilities"
+        "inputRequests": {
+          "$ref": "#/$defs/InputRequests"
         },
-        "instructions": {
-          "description": "Instructions describing how to use the server and its features.\n\nThis can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a \"hint\" to the model. For example, this information MAY be added to the system prompt.",
+        "requestState": {
           "type": "string"
         },
-        "protocolVersion": {
-          "description": "The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.",
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
           "type": "string"
-        },
-        "serverInfo": {
-          "$ref": "#/definitions/Implementation"
         }
       },
-      "required": ["capabilities", "protocolVersion", "serverInfo"],
+      "required": ["resultType"],
       "type": "object"
     },
-    "InitializedNotification": {
-      "description": "This notification is sent from the client to the server after initialization has finished.",
+    "InputResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/CreateMessageResult"
+        },
+        {
+          "$ref": "#/$defs/ListRootsResult"
+        },
+        {
+          "$ref": "#/$defs/ElicitResult"
+        }
+      ]
+    },
+    "InputResponseRequestParams": {
       "properties": {
-        "method": {
-          "const": "notifications/initialized",
-          "type": "string"
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
         },
-        "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
-          "type": "object"
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
         }
       },
-      "required": ["method"],
+      "required": ["_meta"],
       "type": "object"
     },
-    "JSONRPCError": {
+    "InputResponses": {
+      "additionalProperties": {
+        "$ref": "#/$defs/InputResponse"
+      },
+      "description": "A map of client responses to server-initiated requests.\nKeys correspond to the keys in the {@link InputRequests} map;\nvalues are the client's result for each request.",
+      "type": "object"
+    },
+    "InternalError": {
+      "description": "A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.",
+      "properties": {
+        "code": {
+          "const": -32603,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": ["code", "message"],
+      "type": "object"
+    },
+    "InvalidParamsError": {
+      "description": "A JSON-RPC error indicating that the method parameters are invalid or malformed.\n\nIn MCP, this error is returned in various contexts when request parameters fail validation:\n\n- **Tools**: Unknown tool name or invalid tool arguments\n- **Prompts**: Unknown prompt name or missing required arguments\n- **Pagination**: Invalid or expired cursor values\n- **Logging**: Invalid log level\n- **Elicitation**: Server requests an elicitation mode not declared in client capabilities\n- **Sampling**: Missing tool result or tool results mixed with other content",
+      "properties": {
+        "code": {
+          "const": -32602,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": ["code", "message"],
+      "type": "object"
+    },
+    "InvalidRequestError": {
+      "description": "A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).",
+      "properties": {
+        "code": {
+          "const": -32600,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": ["code", "message"],
+      "type": "object"
+    },
+    "JSONArray": {
+      "items": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "array"
+    },
+    "JSONObject": {
+      "additionalProperties": {
+        "$ref": "#/$defs/JSONValue"
+      },
+      "type": "object"
+    },
+    "JSONRPCErrorResponse": {
       "description": "A response to a request that indicates an error occurred.",
       "properties": {
         "error": {
-          "properties": {
-            "code": {
-              "description": "The error type that occurred.",
-              "type": "integer"
-            },
-            "data": {
-              "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
-            },
-            "message": {
-              "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
-              "type": "string"
-            }
-          },
-          "required": ["code", "message"],
-          "type": "object"
+          "$ref": "#/$defs/Error"
         },
         "id": {
-          "$ref": "#/definitions/RequestId"
+          "$ref": "#/$defs/RequestId"
         },
         "jsonrpc": {
           "const": "2.0",
           "type": "string"
         }
       },
-      "required": ["error", "id", "jsonrpc"],
+      "required": ["error", "jsonrpc"],
       "type": "object"
     },
     "JSONRPCMessage": {
       "anyOf": [
         {
-          "$ref": "#/definitions/JSONRPCRequest"
+          "$ref": "#/$defs/JSONRPCRequest"
         },
         {
-          "$ref": "#/definitions/JSONRPCNotification"
+          "$ref": "#/$defs/JSONRPCNotification"
         },
         {
-          "$ref": "#/definitions/JSONRPCResponse"
+          "$ref": "#/$defs/JSONRPCResultResponse"
         },
         {
-          "$ref": "#/definitions/JSONRPCError"
+          "$ref": "#/$defs/JSONRPCErrorResponse"
         }
       ],
       "description": "Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent."
@@ -864,13 +1325,6 @@
         },
         "params": {
           "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
           "type": "object"
         }
       },
@@ -881,7 +1335,7 @@
       "description": "A request that expects a response.",
       "properties": {
         "id": {
-          "$ref": "#/definitions/RequestId"
+          "$ref": "#/$defs/RequestId"
         },
         "jsonrpc": {
           "const": "2.0",
@@ -892,19 +1346,6 @@
         },
         "params": {
           "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "properties": {
-                "progressToken": {
-                  "$ref": "#/definitions/ProgressToken",
-                  "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                }
-              },
-              "type": "object"
-            }
-          },
           "type": "object"
         }
       },
@@ -912,49 +1353,113 @@
       "type": "object"
     },
     "JSONRPCResponse": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONRPCResultResponse"
+        },
+        {
+          "$ref": "#/$defs/JSONRPCErrorResponse"
+        }
+      ],
+      "description": "A response to a request, containing either the result or error."
+    },
+    "JSONRPCResultResponse": {
       "description": "A successful (non-error) response to a request.",
       "properties": {
         "id": {
-          "$ref": "#/definitions/RequestId"
+          "$ref": "#/$defs/RequestId"
         },
         "jsonrpc": {
           "const": "2.0",
           "type": "string"
         },
         "result": {
-          "$ref": "#/definitions/Result"
+          "$ref": "#/$defs/Result"
         }
       },
       "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
+    "JSONValue": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/JSONObject"
+        },
+        {
+          "items": {
+            "$ref": "#/$defs/JSONValue"
+          },
+          "type": "array"
+        },
+        {
+          "type": ["string", "integer", "boolean"]
+        }
+      ]
+    },
+    "LegacyTitledEnumSchema": {
+      "description": "Use {@link TitledSingleSelectEnumSchema} instead.\nThis interface will be removed in a future version.",
+      "properties": {
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enum": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enumNames": {
+          "description": "(Legacy) Display names for enum values.\nNon-standard according to JSON schema 2020-12.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": ["enum", "type"],
+      "type": "object"
+    },
     "ListPromptsRequest": {
       "description": "Sent from the client to request a list of prompts and prompt templates the server has.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "prompts/list",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "cursor": {
-              "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/PaginatedRequestParams"
         }
       },
-      "required": ["method"],
+      "required": ["id", "jsonrpc", "method", "params"],
       "type": "object"
     },
     "ListPromptsResult": {
-      "description": "The server's response to a prompts/list request from the client.",
+      "description": "The result returned by the server for a {@link ListPromptsRequestprompts/list} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
         },
         "nextCursor": {
           "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
@@ -962,41 +1467,71 @@
         },
         "prompts": {
           "items": {
-            "$ref": "#/definitions/Prompt"
+            "$ref": "#/$defs/Prompt"
           },
           "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
         }
       },
-      "required": ["prompts"],
+      "required": ["cacheScope", "prompts", "resultType", "ttlMs"],
+      "type": "object"
+    },
+    "ListPromptsResultResponse": {
+      "description": "A successful response from the server for a {@link ListPromptsRequestprompts/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListPromptsResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "ListResourceTemplatesRequest": {
       "description": "Sent from the client to request a list of resource templates the server has.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "resources/templates/list",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "cursor": {
-              "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/PaginatedRequestParams"
         }
       },
-      "required": ["method"],
+      "required": ["id", "jsonrpc", "method", "params"],
       "type": "object"
     },
     "ListResourceTemplatesResult": {
-      "description": "The server's response to a resources/templates/list request from the client.",
+      "description": "The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
         },
         "nextCursor": {
           "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
@@ -1004,41 +1539,71 @@
         },
         "resourceTemplates": {
           "items": {
-            "$ref": "#/definitions/ResourceTemplate"
+            "$ref": "#/$defs/ResourceTemplate"
           },
           "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
         }
       },
-      "required": ["resourceTemplates"],
+      "required": ["cacheScope", "resourceTemplates", "resultType", "ttlMs"],
+      "type": "object"
+    },
+    "ListResourceTemplatesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourceTemplatesResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "ListResourcesRequest": {
       "description": "Sent from the client to request a list of resources the server has.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "resources/list",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "cursor": {
-              "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/PaginatedRequestParams"
         }
       },
-      "required": ["method"],
+      "required": ["id", "jsonrpc", "method", "params"],
       "type": "object"
     },
     "ListResourcesResult": {
-      "description": "The server's response to a resources/list request from the client.",
+      "description": "The result returned by the server for a {@link ListResourcesRequestresources/list} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
         },
         "nextCursor": {
           "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
@@ -1046,12 +1611,38 @@
         },
         "resources": {
           "items": {
-            "$ref": "#/definitions/Resource"
+            "$ref": "#/$defs/Resource"
           },
           "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
         }
       },
-      "required": ["resources"],
+      "required": ["cacheScope", "resources", "resultType", "ttlMs"],
+      "type": "object"
+    },
+    "ListResourcesResultResponse": {
+      "description": "A successful response from the server for a {@link ListResourcesRequestresources/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListResourcesResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "ListRootsRequest": {
@@ -1062,18 +1653,9 @@
           "type": "string"
         },
         "params": {
-          "additionalProperties": {},
           "properties": {
             "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "properties": {
-                "progressToken": {
-                  "$ref": "#/definitions/ProgressToken",
-                  "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                }
-              },
-              "type": "object"
+              "$ref": "#/$defs/MetaObject"
             }
           },
           "type": "object"
@@ -1083,16 +1665,11 @@
       "type": "object"
     },
     "ListRootsResult": {
-      "description": "The client's response to a roots/list request from the server.\nThis result contains an array of Root objects, each representing a root directory\nor file that the server can operate on.",
+      "description": "The result returned by the client for a {@link ListRootsRequestroots/list} request.\nThis result contains an array of {@link Root} objects, each representing a root directory\nor file that the server can operate on.",
       "properties": {
-        "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
-        },
         "roots": {
           "items": {
-            "$ref": "#/definitions/Root"
+            "$ref": "#/$defs/Root"
           },
           "type": "array"
         }
@@ -1103,43 +1680,73 @@
     "ListToolsRequest": {
       "description": "Sent from the client to request a list of tools the server has.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "tools/list",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "cursor": {
-              "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/PaginatedRequestParams"
         }
       },
-      "required": ["method"],
+      "required": ["id", "jsonrpc", "method", "params"],
       "type": "object"
     },
     "ListToolsResult": {
-      "description": "The server's response to a tools/list request from the client.",
+      "description": "The result returned by the server for a {@link ListToolsRequesttools/list} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
         },
         "nextCursor": {
           "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
           "type": "string"
         },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
         "tools": {
           "items": {
-            "$ref": "#/definitions/Tool"
+            "$ref": "#/$defs/Tool"
           },
           "type": "array"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
         }
       },
-      "required": ["tools"],
+      "required": ["cacheScope", "resultType", "tools", "ttlMs"],
+      "type": "object"
+    },
+    "ListToolsResultResponse": {
+      "description": "A successful response from the server for a {@link ListToolsRequesttools/list} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "$ref": "#/$defs/ListToolsResult"
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "LoggingLevel": {
@@ -1157,31 +1764,106 @@
       "type": "string"
     },
     "LoggingMessageNotification": {
-      "description": "Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.",
+      "description": "JSONRPCNotification of a log message passed from server to client. The client opts in by setting `\"io.modelcontextprotocol/logLevel\"` in a request's `_meta`.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/message",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "data": {
-              "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
-            },
-            "level": {
-              "$ref": "#/definitions/LoggingLevel",
-              "description": "The severity of this log message."
-            },
-            "logger": {
-              "description": "An optional name of the logger issuing this message.",
-              "type": "string"
-            }
-          },
-          "required": ["data", "level"],
-          "type": "object"
+          "$ref": "#/$defs/LoggingMessageNotificationParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "LoggingMessageNotificationParams": {
+      "description": "Parameters for a `notifications/message` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "data": {
+          "description": "The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here."
+        },
+        "level": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The severity of this log message."
+        },
+        "logger": {
+          "description": "An optional name of the logger issuing this message.",
+          "type": "string"
+        }
+      },
+      "required": ["data", "level"],
+      "type": "object"
+    },
+    "MetaObject": {
+      "description": "Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.\n\nCertain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.\n\nValid keys have two segments:\n\n**Prefix:**\n- Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).\n- Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).\n- Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).\n- Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.\n\n**Name:**\n- Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).\n- Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).",
+      "type": "object"
+    },
+    "MethodNotFoundError": {
+      "description": "A JSON-RPC error indicating that the requested method does not exist or is not available.\n\nIn MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).\n\nA request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).",
+      "properties": {
+        "code": {
+          "const": -32601,
+          "description": "The error type that occurred.",
+          "type": "integer"
+        },
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
+        }
+      },
+      "required": ["code", "message"],
+      "type": "object"
+    },
+    "MissingRequiredClientCapabilityError": {
+      "description": "Returned when processing a request requires a capability the client did not\ndeclare in `clientCapabilities`. For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32021,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requiredCapabilities": {
+                      "$ref": "#/$defs/ClientCapabilities",
+                      "description": "The capabilities the server requires from the client to process this request."
+                    }
+                  },
+                  "required": ["requiredCapabilities"],
+                  "type": "object"
+                }
+              },
+              "required": ["code", "data"],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": ["error", "jsonrpc"],
       "type": "object"
     },
     "ModelHint": {
@@ -1206,7 +1888,7 @@
         "hints": {
           "description": "Optional hints to use for model selection.\n\nIf multiple hints are specified, the client MUST evaluate them in order\n(such that the first match is taken).\n\nThe client SHOULD prioritize these hints over the numeric priorities, but\nMAY still use the priorities to select from ambiguous matches.",
           "items": {
-            "$ref": "#/definitions/ModelHint"
+            "$ref": "#/$defs/ModelHint"
           },
           "type": "array"
         },
@@ -1225,6 +1907,16 @@
       },
       "type": "object"
     },
+    "MultiSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        }
+      ]
+    },
     "Notification": {
       "properties": {
         "method": {
@@ -1232,29 +1924,44 @@
         },
         "params": {
           "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
           "type": "object"
         }
       },
       "required": ["method"],
       "type": "object"
     },
+    "NotificationMetaObject": {
+      "description": "Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream a notification was delivered on. The\nserver MUST include this key on every notification delivered via a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream, so the\nclient can correlate the notification with the originating subscription.\nThe key is absent on notifications not delivered via a subscription\nstream (e.g. progress notifications for an in-flight request), which is\nwhy it is optional here.\n\nThe value is the JSON-RPC ID of the `subscriptions/listen` request that\nopened the stream."
+        }
+      },
+      "type": "object"
+    },
+    "NotificationParams": {
+      "description": "Common params for any notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        }
+      },
+      "type": "object"
+    },
     "NumberSchema": {
       "properties": {
+        "default": {
+          "type": "number"
+        },
         "description": {
           "type": "string"
         },
         "maximum": {
-          "type": "integer"
+          "type": "number"
         },
         "minimum": {
-          "type": "integer"
+          "type": "number"
         },
         "title": {
           "type": "string"
@@ -1269,77 +1976,98 @@
     },
     "PaginatedRequest": {
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "type": "string"
         },
         "params": {
-          "properties": {
-            "cursor": {
-              "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
-              "type": "string"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/PaginatedRequestParams"
         }
       },
-      "required": ["method"],
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "PaginatedRequestParams": {
+      "description": "Common params for paginated requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "cursor": {
+          "description": "An opaque token representing the current pagination position.\nIf provided, the server should return results starting after this cursor.",
+          "type": "string"
+        }
+      },
+      "required": ["_meta"],
       "type": "object"
     },
     "PaginatedResult": {
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "nextCursor": {
           "description": "An opaque token representing the pagination position after the last returned result.\nIf present, there may be more results available.",
           "type": "string"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
         }
       },
+      "required": ["resultType"],
       "type": "object"
     },
-    "PingRequest": {
-      "description": "A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.",
+    "ParseError": {
+      "description": "A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.",
       "properties": {
-        "method": {
-          "const": "ping",
-          "type": "string"
+        "code": {
+          "const": -32700,
+          "description": "The error type that occurred.",
+          "type": "integer"
         },
-        "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "properties": {
-                "progressToken": {
-                  "$ref": "#/definitions/ProgressToken",
-                  "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                }
-              },
-              "type": "object"
-            }
-          },
-          "type": "object"
+        "data": {
+          "description": "Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.)."
+        },
+        "message": {
+          "description": "A short description of the error. The message SHOULD be limited to a concise single sentence.",
+          "type": "string"
         }
       },
-      "required": ["method"],
+      "required": ["code", "message"],
       "type": "object"
     },
     "PrimitiveSchemaDefinition": {
       "anyOf": [
         {
-          "$ref": "#/definitions/StringSchema"
+          "$ref": "#/$defs/StringSchema"
         },
         {
-          "$ref": "#/definitions/NumberSchema"
+          "$ref": "#/$defs/NumberSchema"
         },
         {
-          "$ref": "#/definitions/BooleanSchema"
+          "$ref": "#/$defs/BooleanSchema"
         },
         {
-          "$ref": "#/definitions/EnumSchema"
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/UntitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/TitledMultiSelectEnumSchema"
+        },
+        {
+          "$ref": "#/$defs/LegacyTitledEnumSchema"
         }
       ],
       "description": "Restricted schema definitions that only allow primitive types\nwithout nested objects or arrays."
@@ -1347,34 +2075,45 @@
     "ProgressNotification": {
       "description": "An out-of-band notification used to inform the receiver of a progress update for a long-running request.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/progress",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "message": {
-              "description": "An optional message describing the current progress.",
-              "type": "string"
-            },
-            "progress": {
-              "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
-              "type": "number"
-            },
-            "progressToken": {
-              "$ref": "#/definitions/ProgressToken",
-              "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
-            },
-            "total": {
-              "description": "Total number of items to process (or total progress required), if known.",
-              "type": "number"
-            }
-          },
-          "required": ["progress", "progressToken"],
-          "type": "object"
+          "$ref": "#/$defs/ProgressNotificationParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "ProgressNotificationParams": {
+      "description": "Parameters for a {@link ProgressNotificationnotifications/progress} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "message": {
+          "description": "An optional message describing the current progress.",
+          "type": "string"
+        },
+        "progress": {
+          "description": "The progress thus far. This should increase every time progress is made, even if the total is unknown.",
+          "type": "number"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "The progress token which was given in the initial request, used to associate this notification with the request that is proceeding."
+        },
+        "total": {
+          "description": "Total number of items to process (or total progress required), if known.",
+          "type": "number"
+        }
+      },
+      "required": ["progress", "progressToken"],
       "type": "object"
     },
     "ProgressToken": {
@@ -1385,14 +2124,12 @@
       "description": "A prompt or prompt template that the server offers.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "arguments": {
           "description": "A list of arguments to use for templating the prompt.",
           "items": {
-            "$ref": "#/definitions/PromptArgument"
+            "$ref": "#/$defs/PromptArgument"
           },
           "type": "array"
         },
@@ -1400,12 +2137,19 @@
           "description": "An optional description of what this prompt provides",
           "type": "string"
         },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
         "name": {
           "description": "Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).",
           "type": "string"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         }
       },
@@ -1428,7 +2172,7 @@
           "type": "boolean"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         }
       },
@@ -1436,35 +2180,31 @@
       "type": "object"
     },
     "PromptListChangedNotification": {
-      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.",
+      "description": "An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/prompts/list_changed",
           "type": "string"
         },
         "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/NotificationParams"
         }
       },
-      "required": ["method"],
+      "required": ["jsonrpc", "method"],
       "type": "object"
     },
     "PromptMessage": {
-      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to `SamplingMessage`, but also supports the embedding of\nresources from the MCP server.",
+      "description": "Describes a message returned as part of a prompt.\n\nThis is similar to {@link SamplingMessage}, but also supports the embedding of\nresources from the MCP server.",
       "properties": {
         "content": {
-          "$ref": "#/definitions/ContentBlock"
+          "$ref": "#/$defs/ContentBlock"
         },
         "role": {
-          "$ref": "#/definitions/Role"
+          "$ref": "#/$defs/Role"
         }
       },
       "required": ["content", "role"],
@@ -1478,7 +2218,7 @@
           "type": "string"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "type": {
@@ -1492,48 +2232,104 @@
     "ReadResourceRequest": {
       "description": "Sent from the client to the server, to read a specific resource URI.",
       "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "resources/read",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "uri": {
-              "description": "The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.",
-              "format": "uri",
-              "type": "string"
-            }
-          },
-          "required": ["uri"],
-          "type": "object"
+          "$ref": "#/$defs/ReadResourceRequestParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "ReadResourceRequestParams": {
+      "description": "Parameters for a `resources/read` request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "inputResponses": {
+          "$ref": "#/$defs/InputResponses"
+        },
+        "requestState": {
+          "type": "string"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": ["_meta", "uri"],
       "type": "object"
     },
     "ReadResourceResult": {
-      "description": "The server's response to a resources/read request from the client.",
+      "description": "The result returned by the server for a {@link ReadResourceRequestresources/read} request.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "cacheScope": {
+          "description": "Indicates the intended scope of the cached response, analogous to HTTP\n`Cache-Control: public` vs `Cache-Control: private`.\n\n- `\"public\"`: The response does not contain user-specific data. Any\n  client or intermediary (e.g., shared gateway, caching proxy) MAY cache\n  the response and serve it across authorization contexts.\n- `\"private\"`: The response MAY be cached and reused only within the\n  same authorization context. Caches MUST NOT be shared across\n  authorization contexts (e.g., a different access token requires a\n  different cache).",
+          "enum": ["private", "public"],
+          "type": "string"
         },
         "contents": {
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/TextResourceContents"
+                "$ref": "#/$defs/TextResourceContents"
               },
               {
-                "$ref": "#/definitions/BlobResourceContents"
+                "$ref": "#/$defs/BlobResourceContents"
               }
             ]
           },
           "type": "array"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        },
+        "ttlMs": {
+          "description": "A hint from the server indicating how long (in milliseconds) the\nclient MAY cache this response before re-fetching. Semantics are\nanalogous to HTTP Cache-Control max-age.\n\n- If 0, The response SHOULD be considered immediately stale,\n  The client MAY re-fetch every time the result is needed.\n- If positive, the client SHOULD consider the result fresh for this many\n  milliseconds after receiving the response.",
+          "minimum": 0,
+          "type": "integer"
         }
       },
-      "required": ["contents"],
+      "required": ["cacheScope", "contents", "resultType", "ttlMs"],
+      "type": "object"
+    },
+    "ReadResourceResultResponse": {
+      "description": "A successful response from the server for a {@link ReadResourceRequestresources/read} request.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "result": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InputRequiredResult"
+            },
+            {
+              "$ref": "#/$defs/ReadResourceResult"
+            }
+          ]
+        }
+      },
+      "required": ["id", "jsonrpc", "result"],
       "type": "object"
     },
     "Request": {
@@ -1543,19 +2339,6 @@
         },
         "params": {
           "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "properties": {
-                "progressToken": {
-                  "$ref": "#/definitions/ProgressToken",
-                  "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
-                }
-              },
-              "type": "object"
-            }
-          },
           "type": "object"
         }
       },
@@ -1566,21 +2349,67 @@
       "description": "A uniquely identifying ID for a request in JSON-RPC.",
       "type": ["string", "integer"]
     },
+    "RequestMetaObject": {
+      "description": "Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/clientCapabilities": {
+          "$ref": "#/$defs/ClientCapabilities",
+          "description": "The client's capabilities for this specific request. Required.\n\nCapabilities are declared per-request rather than once at initialization;\nan empty object means the client supports no optional capabilities.\nServers MUST NOT infer capabilities from prior requests."
+        },
+        "io.modelcontextprotocol/clientInfo": {
+          "$ref": "#/$defs/Implementation",
+          "description": "Identifies the client software making the request. Required.\n\nThe {@link Implementation} schema requires `name` and `version`; other\nfields are optional."
+        },
+        "io.modelcontextprotocol/logLevel": {
+          "$ref": "#/$defs/LoggingLevel",
+          "description": "The desired log level for this request. Optional.\n\nIf absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}\nnotifications for this request. The client opts in to log messages by\nexplicitly setting a level. Replaces the former `logging/setLevel` RPC."
+        },
+        "io.modelcontextprotocol/protocolVersion": {
+          "description": "The MCP Protocol Version being used for this request. Required.\n\nFor the HTTP transport, this value MUST match the `MCP-Protocol-Version`\nheader; otherwise the server MUST return a `400 Bad Request`. If the\nserver does not support the requested version, it MUST return an\n{@link UnsupportedProtocolVersionError}.",
+          "type": "string"
+        },
+        "progressToken": {
+          "$ref": "#/$defs/ProgressToken",
+          "description": "If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications."
+        }
+      },
+      "required": [
+        "io.modelcontextprotocol/clientCapabilities",
+        "io.modelcontextprotocol/clientInfo",
+        "io.modelcontextprotocol/protocolVersion"
+      ],
+      "type": "object"
+    },
+    "RequestParams": {
+      "description": "Common params for any request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        }
+      },
+      "required": ["_meta"],
+      "type": "object"
+    },
     "Resource": {
       "description": "A known resource that the server is capable of reading.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "description": {
           "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
           "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
         },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
@@ -1595,7 +2424,7 @@
           "type": "integer"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "uri": {
@@ -1611,9 +2440,7 @@
       "description": "The contents of a specific resource or sub-resource.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
@@ -1629,20 +2456,25 @@
       "type": "object"
     },
     "ResourceLink": {
-      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.",
+      "description": "A resource that the server is capable of reading, included in a prompt or tool call result.\n\nNote: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "description": {
           "description": "A description of what this resource represents.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
           "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
         },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
@@ -1657,7 +2489,7 @@
           "type": "integer"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "type": {
@@ -1674,42 +2506,58 @@
       "type": "object"
     },
     "ResourceListChangedNotification": {
-      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.",
+      "description": "An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/resources/list_changed",
           "type": "string"
         },
         "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/NotificationParams"
         }
       },
-      "required": ["method"],
+      "required": ["jsonrpc", "method"],
+      "type": "object"
+    },
+    "ResourceRequestParams": {
+      "description": "Common params for resource-related requests.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": ["_meta", "uri"],
       "type": "object"
     },
     "ResourceTemplate": {
       "description": "A template description for resources available on the server.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "description": {
           "description": "A description of what this template is for.\n\nThis can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a \"hint\" to the model.",
           "type": "string"
+        },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
         },
         "mimeType": {
           "description": "The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.",
@@ -1720,7 +2568,7 @@
           "type": "string"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         },
         "uriTemplate": {
@@ -1749,37 +2597,56 @@
       "type": "object"
     },
     "ResourceUpdatedNotification": {
-      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.",
+      "description": "A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/resources/updated",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "uri": {
-              "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
-              "format": "uri",
-              "type": "string"
-            }
-          },
-          "required": ["uri"],
-          "type": "object"
+          "$ref": "#/$defs/ResourceUpdatedNotificationParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "ResourceUpdatedNotificationParams": {
+      "description": "Parameters for a `notifications/resources/updated` notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "uri": {
+          "description": "The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.",
+          "format": "uri",
+          "type": "string"
+        }
+      },
+      "required": ["uri"],
       "type": "object"
     },
     "Result": {
       "additionalProperties": {},
+      "description": "Common result fields.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
         }
       },
+      "required": ["resultType"],
       "type": "object"
+    },
+    "ResultType": {
+      "description": "Indicates the type of a {@link Result} object, allowing the client to\ndetermine how to parse the response.\n\ncomplete - the request completed successfully and the result contains the final content.\ninput_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.",
+      "type": "string"
     },
     "Role": {
       "description": "The sender or recipient of messages and data in a conversation.",
@@ -1790,16 +2657,14 @@
       "description": "Represents a root directory or file that the server can operate on.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "name": {
           "description": "An optional name for the root. This can be used to provide a human-readable\nidentifier for the root, which may be useful for display purposes or for\nreferencing the root in other parts of the application.",
           "type": "string"
         },
         "uri": {
-          "description": "The URI identifying the root. This *must* start with file:// for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
+          "description": "The URI identifying the root. This *must* start with `file://` for now.\nThis restriction may be relaxed in future versions of the protocol to allow\nother URI schemes.",
           "format": "uri",
           "type": "string"
         }
@@ -1807,74 +2672,87 @@
       "required": ["uri"],
       "type": "object"
     },
-    "RootsListChangedNotification": {
-      "description": "A notification from the client to the server, informing it that the list of roots has changed.\nThis notification should be sent whenever the client adds, removes, or modifies any root.\nThe server should then request an updated list of roots using the ListRootsRequest.",
-      "properties": {
-        "method": {
-          "const": "notifications/roots/list_changed",
-          "type": "string"
-        },
-        "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": ["method"],
-      "type": "object"
-    },
     "SamplingMessage": {
       "description": "Describes a message issued to or received from an LLM API.",
       "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject"
+        },
         "content": {
           "anyOf": [
             {
-              "$ref": "#/definitions/TextContent"
+              "$ref": "#/$defs/TextContent"
             },
             {
-              "$ref": "#/definitions/ImageContent"
+              "$ref": "#/$defs/ImageContent"
             },
             {
-              "$ref": "#/definitions/AudioContent"
+              "$ref": "#/$defs/AudioContent"
+            },
+            {
+              "$ref": "#/$defs/ToolUseContent"
+            },
+            {
+              "$ref": "#/$defs/ToolResultContent"
+            },
+            {
+              "items": {
+                "$ref": "#/$defs/SamplingMessageContentBlock"
+              },
+              "type": "array"
             }
           ]
         },
         "role": {
-          "$ref": "#/definitions/Role"
+          "$ref": "#/$defs/Role"
         }
       },
       "required": ["content", "role"],
       "type": "object"
     },
+    "SamplingMessageContentBlock": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/TextContent"
+        },
+        {
+          "$ref": "#/$defs/ImageContent"
+        },
+        {
+          "$ref": "#/$defs/AudioContent"
+        },
+        {
+          "$ref": "#/$defs/ToolUseContent"
+        },
+        {
+          "$ref": "#/$defs/ToolResultContent"
+        }
+      ]
+    },
     "ServerCapabilities": {
       "description": "Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.",
       "properties": {
         "completions": {
-          "additionalProperties": true,
-          "description": "Present if the server supports argument autocompletion suggestions.",
-          "properties": {},
-          "type": "object"
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports argument autocompletion suggestions."
         },
         "experimental": {
           "additionalProperties": {
-            "additionalProperties": true,
-            "properties": {},
-            "type": "object"
+            "$ref": "#/$defs/JSONObject"
           },
           "description": "Experimental, non-standard capabilities that the server supports.",
           "type": "object"
         },
-        "logging": {
-          "additionalProperties": true,
-          "description": "Present if the server supports sending log messages to the client.",
-          "properties": {},
+        "extensions": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JSONObject"
+          },
+          "description": "Optional MCP extensions that the server supports. Keys are extension identifiers\n(e.g., \"io.modelcontextprotocol/tasks\"), and values are per-extension settings\nobjects. An empty object indicates support with no settings.\n\nKeys MUST follow the {@link MetaObject`_meta` key naming rules}, with a\nmandatory prefix.",
           "type": "object"
+        },
+        "logging": {
+          "$ref": "#/$defs/JSONObject",
+          "description": "Present if the server supports sending log messages to the client."
         },
         "prompts": {
           "description": "Present if the server offers any prompt templates.",
@@ -1916,101 +2794,86 @@
     "ServerNotification": {
       "anyOf": [
         {
-          "$ref": "#/definitions/CancelledNotification"
+          "$ref": "#/$defs/CancelledNotification"
         },
         {
-          "$ref": "#/definitions/ProgressNotification"
+          "$ref": "#/$defs/ProgressNotification"
         },
         {
-          "$ref": "#/definitions/ResourceListChangedNotification"
+          "$ref": "#/$defs/ResourceListChangedNotification"
         },
         {
-          "$ref": "#/definitions/ResourceUpdatedNotification"
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotification"
         },
         {
-          "$ref": "#/definitions/PromptListChangedNotification"
+          "$ref": "#/$defs/ResourceUpdatedNotification"
         },
         {
-          "$ref": "#/definitions/ToolListChangedNotification"
+          "$ref": "#/$defs/PromptListChangedNotification"
         },
         {
-          "$ref": "#/definitions/LoggingMessageNotification"
-        }
-      ]
-    },
-    "ServerRequest": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PingRequest"
+          "$ref": "#/$defs/ToolListChangedNotification"
         },
         {
-          "$ref": "#/definitions/CreateMessageRequest"
-        },
-        {
-          "$ref": "#/definitions/ListRootsRequest"
-        },
-        {
-          "$ref": "#/definitions/ElicitRequest"
+          "$ref": "#/$defs/LoggingMessageNotification"
         }
       ]
     },
     "ServerResult": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Result"
+          "$ref": "#/$defs/Result"
         },
         {
-          "$ref": "#/definitions/InitializeResult"
+          "$ref": "#/$defs/InputRequiredResult"
         },
         {
-          "$ref": "#/definitions/ListResourcesResult"
+          "$ref": "#/$defs/DiscoverResult"
         },
         {
-          "$ref": "#/definitions/ListResourceTemplatesResult"
+          "$ref": "#/$defs/ListResourcesResult"
         },
         {
-          "$ref": "#/definitions/ReadResourceResult"
+          "$ref": "#/$defs/ListResourceTemplatesResult"
         },
         {
-          "$ref": "#/definitions/ListPromptsResult"
+          "$ref": "#/$defs/ReadResourceResult"
         },
         {
-          "$ref": "#/definitions/GetPromptResult"
+          "$ref": "#/$defs/SubscriptionsListenResult"
         },
         {
-          "$ref": "#/definitions/ListToolsResult"
+          "$ref": "#/$defs/ListPromptsResult"
         },
         {
-          "$ref": "#/definitions/CallToolResult"
+          "$ref": "#/$defs/GetPromptResult"
         },
         {
-          "$ref": "#/definitions/CompleteResult"
+          "$ref": "#/$defs/ListToolsResult"
+        },
+        {
+          "$ref": "#/$defs/CallToolResult"
+        },
+        {
+          "$ref": "#/$defs/CompleteResult"
         }
       ]
     },
-    "SetLevelRequest": {
-      "description": "A request from the client to the server, to enable or adjust logging.",
-      "properties": {
-        "method": {
-          "const": "logging/setLevel",
-          "type": "string"
+    "SingleSelectEnumSchema": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/UntitledSingleSelectEnumSchema"
         },
-        "params": {
-          "properties": {
-            "level": {
-              "$ref": "#/definitions/LoggingLevel",
-              "description": "The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message."
-            }
-          },
-          "required": ["level"],
-          "type": "object"
+        {
+          "$ref": "#/$defs/TitledSingleSelectEnumSchema"
         }
-      },
-      "required": ["method", "params"],
-      "type": "object"
+      ]
     },
     "StringSchema": {
       "properties": {
+        "default": {
+          "type": "string"
+        },
         "description": {
           "type": "string"
         },
@@ -2035,38 +2898,131 @@
       "required": ["type"],
       "type": "object"
     },
-    "SubscribeRequest": {
-      "description": "Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.",
+    "SubscriptionFilter": {
+      "description": "The set of notification types a client may opt in to on a\n{@link SubscriptionsListenRequestsubscriptions/listen} request.\n\nEach notification type is **opt-in**; the server **MUST NOT** send\nnotification types the client has not explicitly requested here.",
       "properties": {
+        "promptsListChanged": {
+          "description": "If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.",
+          "type": "boolean"
+        },
+        "resourceSubscriptions": {
+          "description": "Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.\nReplaces the former `resources/subscribe` RPC.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "resourcesListChanged": {
+          "description": "If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.",
+          "type": "boolean"
+        },
+        "toolsListChanged": {
+          "description": "If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotification": {
+      "description": "Sent by the server as the first message on a\n{@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge\nthat the subscription has been established and to report which notification\ntypes it agreed to honor.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
-          "const": "resources/subscribe",
+          "const": "notifications/subscriptions/acknowledged",
           "type": "string"
         },
         "params": {
-          "properties": {
-            "uri": {
-              "description": "The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.",
-              "format": "uri",
-              "type": "string"
-            }
-          },
-          "required": ["uri"],
-          "type": "object"
+          "$ref": "#/$defs/SubscriptionsAcknowledgedNotificationParams"
         }
       },
-      "required": ["method", "params"],
+      "required": ["jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "SubscriptionsAcknowledgedNotificationParams": {
+      "description": "Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/NotificationMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The subset of requested notification types the server agreed to honor.\nOnly includes notification types the server actually supports; if the\nclient requested an unsupported type (e.g., `promptsListChanged` when\nthe server has no prompts), it is omitted from this set."
+        }
+      },
+      "required": ["notifications"],
+      "type": "object"
+    },
+    "SubscriptionsListenRequest": {
+      "description": "Sent from the client to open a long-lived channel for receiving notifications\noutside the context of a specific request. Replaces the previous HTTP GET\nendpoint and ensures consistent behavior between HTTP and STDIO.",
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
+        "method": {
+          "const": "subscriptions/listen",
+          "type": "string"
+        },
+        "params": {
+          "$ref": "#/$defs/SubscriptionsListenRequestParams"
+        }
+      },
+      "required": ["id", "jsonrpc", "method", "params"],
+      "type": "object"
+    },
+    "SubscriptionsListenRequestParams": {
+      "description": "Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/RequestMetaObject"
+        },
+        "notifications": {
+          "$ref": "#/$defs/SubscriptionFilter",
+          "description": "The notifications the client opts in to on this stream. The server\n**MUST NOT** send notification types the client has not explicitly\nrequested."
+        }
+      },
+      "required": ["_meta", "notifications"],
+      "type": "object"
+    },
+    "SubscriptionsListenResult": {
+      "description": "The response to a {@link SubscriptionsListenRequestsubscriptions/listen}\nrequest, signalling that the subscription has ended gracefully (for example,\nduring server shutdown). Because the listen stream is long-lived, this result\nis sent only when the server tears the subscription down; an abrupt transport\nclose carries no response. The result body is otherwise empty.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/SubscriptionsListenResultMeta"
+        },
+        "resultType": {
+          "description": "Indicates the type of the result, which allows the client to determine\nhow to parse the result object.\n\nServers implementing this protocol version MUST include this field.\nFor backward compatibility, when a client receives a result from a\nserver implementing an earlier protocol version (which does not include\n`resultType`), the client MUST treat the absent field as `\"complete\"`.",
+          "type": "string"
+        }
+      },
+      "required": ["_meta", "resultType"],
+      "type": "object"
+    },
+    "SubscriptionsListenResultMeta": {
+      "description": "Extends {@link MetaObject} with the subscription-stream identifier carried by a\n{@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.",
+      "properties": {
+        "io.modelcontextprotocol/subscriptionId": {
+          "$ref": "#/$defs/RequestId",
+          "description": "Identifies the subscription stream this response closes, so the client can\ncorrelate it with the originating subscription — mirroring the same key on\nthe stream's notifications. The value is the JSON-RPC ID of the\n`subscriptions/listen` request that opened the stream (and equals this\nresponse's `id`)."
+        }
+      },
+      "required": ["io.modelcontextprotocol/subscriptionId"],
       "type": "object"
     },
     "TextContent": {
       "description": "Text provided to or from an LLM.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/Annotations",
+          "$ref": "#/$defs/Annotations",
           "description": "Optional annotations for the client."
         },
         "text": {
@@ -2084,9 +3040,7 @@
     "TextResourceContents": {
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "mimeType": {
           "description": "The MIME type of this resource, if known.",
@@ -2105,38 +3059,133 @@
       "required": ["text", "uri"],
       "type": "object"
     },
+    "TitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for array items with enum options and display labels.",
+          "properties": {
+            "anyOf": {
+              "description": "Array of enum options with values and display labels.",
+              "items": {
+                "properties": {
+                  "const": {
+                    "description": "The constant enum value.",
+                    "type": "string"
+                  },
+                  "title": {
+                    "description": "Display title for this option.",
+                    "type": "string"
+                  }
+                },
+                "required": ["const", "title"],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": ["anyOf"],
+          "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
+        }
+      },
+      "required": ["items", "type"],
+      "type": "object"
+    },
+    "TitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration with display titles for each option.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "oneOf": {
+          "description": "Array of enum options with values and display labels.",
+          "items": {
+            "properties": {
+              "const": {
+                "description": "The enum value.",
+                "type": "string"
+              },
+              "title": {
+                "description": "Display label for this option.",
+                "type": "string"
+              }
+            },
+            "required": ["const", "title"],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": ["oneOf", "type"],
+      "type": "object"
+    },
     "Tool": {
       "description": "Definition for a tool the client can call.",
       "properties": {
         "_meta": {
-          "additionalProperties": {},
-          "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-          "type": "object"
+          "$ref": "#/$defs/MetaObject"
         },
         "annotations": {
-          "$ref": "#/definitions/ToolAnnotations",
-          "description": "Optional additional tool information.\n\nDisplay name precedence order is: title, annotations.title, then name."
+          "$ref": "#/$defs/ToolAnnotations",
+          "description": "Optional additional tool information.\n\nDisplay name precedence order is: `title`, `annotations.title`, then `name`."
         },
         "description": {
           "description": "A human-readable description of the tool.\n\nThis can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a \"hint\" to the model.",
           "type": "string"
         },
+        "icons": {
+          "description": "Optional set of sized icons that the client can display in a user interface.\n\nClients that support rendering icons MUST support at least the following MIME types:\n- `image/png` - PNG images (safe, universal compatibility)\n- `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)\n\nClients that support rendering icons SHOULD also support:\n- `image/svg+xml` - SVG images (scalable but requires security precautions)\n- `image/webp` - WebP images (modern, efficient format)",
+          "items": {
+            "$ref": "#/$defs/Icon"
+          },
+          "type": "array"
+        },
         "inputSchema": {
-          "description": "A JSON Schema object defining the expected parameters for the tool.",
+          "additionalProperties": {},
+          "description": "A JSON Schema object defining the expected parameters for the tool.\n\nTool arguments are always JSON objects, so `type: \"object\"` is required at the root.\nBeyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including\ncomposition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords\n(`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other\nstandard validation or annotation keywords.\n\nProperty schemas may carry an `x-mcp-header` annotation to mirror the\nargument value into an HTTP header on the Streamable HTTP transport. See\nthe Streamable HTTP transport specification for the validity and\nextraction rules.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
           "properties": {
-            "properties": {
-              "additionalProperties": {
-                "additionalProperties": true,
-                "properties": {},
-                "type": "object"
-              },
-              "type": "object"
-            },
-            "required": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
+            "$schema": {
+              "type": "string"
             },
             "type": {
               "const": "object",
@@ -2151,32 +3200,17 @@
           "type": "string"
         },
         "outputSchema": {
-          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a CallToolResult.",
+          "additionalProperties": {},
+          "description": "An optional JSON Schema object defining the structure of the tool's output returned in\nthe structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.\n\nDefaults to JSON Schema 2020-12 when no explicit `$schema` is provided.",
           "properties": {
-            "properties": {
-              "additionalProperties": {
-                "additionalProperties": true,
-                "properties": {},
-                "type": "object"
-              },
-              "type": "object"
-            },
-            "required": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "type": {
-              "const": "object",
+            "$schema": {
               "type": "string"
             }
           },
-          "required": ["type"],
           "type": "object"
         },
         "title": {
-          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for Tool,\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
+          "description": "Intended for UI and end-user contexts — optimized to be human-readable and easily understood,\neven by those unfamiliar with domain-specific terminology.\n\nIf not provided, the name should be used for display (except for {@link Tool},\nwhere `annotations.title` should be given precedence over using `name`,\nif present).",
           "type": "string"
         }
       },
@@ -2184,14 +3218,14 @@
       "type": "object"
     },
     "ToolAnnotations": {
-      "description": "Additional properties describing a Tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
+      "description": "Additional properties describing a {@link Tool} to clients.\n\nNOTE: all properties in `ToolAnnotations` are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on `ToolAnnotations`\nreceived from untrusted servers.",
       "properties": {
         "destructiveHint": {
           "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: true",
           "type": "boolean"
         },
         "idempotentHint": {
-          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on the its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
+          "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `readOnlyHint == false`)\n\nDefault: false",
           "type": "boolean"
         },
         "openWorldHint": {
@@ -2209,48 +3243,224 @@
       },
       "type": "object"
     },
-    "ToolListChangedNotification": {
-      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.",
+    "ToolChoice": {
+      "description": "Controls tool selection behavior for sampling requests.",
       "properties": {
+        "mode": {
+          "description": "Controls the tool use ability of the model:\n- `\"auto\"`: Model decides whether to use tools (default)\n- `\"required\"`: Model MUST use at least one tool before completing\n- `\"none\"`: Model MUST NOT use any tools",
+          "enum": ["auto", "none", "required"],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ToolListChangedNotification": {
+      "description": "An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.",
+      "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        },
         "method": {
           "const": "notifications/tools/list_changed",
           "type": "string"
         },
         "params": {
-          "additionalProperties": {},
-          "properties": {
-            "_meta": {
-              "additionalProperties": {},
-              "description": "See [specification/draft/basic/index#general-fields] for notes on _meta usage.",
-              "type": "object"
-            }
-          },
-          "type": "object"
+          "$ref": "#/$defs/NotificationParams"
         }
       },
-      "required": ["method"],
+      "required": ["jsonrpc", "method"],
       "type": "object"
     },
-    "UnsubscribeRequest": {
-      "description": "Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.",
+    "ToolResultContent": {
+      "description": "The result of a tool use, provided by the user back to the assistant.",
       "properties": {
-        "method": {
-          "const": "resources/unsubscribe",
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool result. Clients SHOULD preserve this field when\nincluding tool results in subsequent sampling requests to enable caching optimizations."
+        },
+        "content": {
+          "description": "The unstructured result content of the tool use.\n\nThis has the same format as {@link CallToolResult.content} and can include text, images,\naudio, resource links, and embedded resources.",
+          "items": {
+            "$ref": "#/$defs/ContentBlock"
+          },
+          "type": "array"
+        },
+        "isError": {
+          "description": "Whether the tool use resulted in an error.\n\nIf true, the content typically describes the error that occurred.\nDefault: false",
+          "type": "boolean"
+        },
+        "structuredContent": {
+          "description": "An optional structured result value.\n\nThis can be any JSON value (object, array, string, number, boolean, or null).\nIf the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema."
+        },
+        "toolUseId": {
+          "description": "The ID of the tool use this result corresponds to.\n\nThis MUST match the ID from a previous {@link ToolUseContent}.",
           "type": "string"
         },
-        "params": {
+        "type": {
+          "const": "tool_result",
+          "type": "string"
+        }
+      },
+      "required": ["content", "toolUseId", "type"],
+      "type": "object"
+    },
+    "ToolUseContent": {
+      "description": "A request from the assistant to call a tool.",
+      "properties": {
+        "_meta": {
+          "$ref": "#/$defs/MetaObject",
+          "description": "Optional metadata about the tool use. Clients SHOULD preserve this field when\nincluding tool uses in subsequent sampling requests to enable caching optimizations."
+        },
+        "id": {
+          "description": "A unique identifier for this tool use.\n\nThis ID is used to match tool results to their corresponding tool uses.",
+          "type": "string"
+        },
+        "input": {
+          "additionalProperties": {},
+          "description": "The arguments to pass to the tool, conforming to the tool's input schema.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The name of the tool to call.",
+          "type": "string"
+        },
+        "type": {
+          "const": "tool_use",
+          "type": "string"
+        }
+      },
+      "required": ["id", "input", "name", "type"],
+      "type": "object"
+    },
+    "UnsupportedProtocolVersionError": {
+      "description": "Returned when the request's protocol version is unknown to the server or\nunsupported (e.g., a known experimental or draft version the server has\nchosen not to implement). For HTTP, the response status code MUST be\n`400 Bad Request`.",
+      "properties": {
+        "error": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/Error"
+            },
+            {
+              "properties": {
+                "code": {
+                  "const": -32022,
+                  "type": "integer"
+                },
+                "data": {
+                  "properties": {
+                    "requested": {
+                      "description": "The protocol version that was requested by the client.",
+                      "type": "string"
+                    },
+                    "supported": {
+                      "description": "Protocol versions the server supports. The client should choose a\nmutually supported version from this list and retry.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": ["requested", "supported"],
+                  "type": "object"
+                }
+              },
+              "required": ["code", "data"],
+              "type": "object"
+            }
+          ]
+        },
+        "id": {
+          "$ref": "#/$defs/RequestId"
+        },
+        "jsonrpc": {
+          "const": "2.0",
+          "type": "string"
+        }
+      },
+      "required": ["error", "jsonrpc"],
+      "type": "object"
+    },
+    "UntitledMultiSelectEnumSchema": {
+      "description": "Schema for multiple-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "items": {
+          "description": "Schema for the array items.",
           "properties": {
-            "uri": {
-              "description": "The URI of the resource to unsubscribe from.",
-              "format": "uri",
+            "enum": {
+              "description": "Array of enum values to choose from.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": {
+              "const": "string",
               "type": "string"
             }
           },
-          "required": ["uri"],
+          "required": ["enum", "type"],
           "type": "object"
+        },
+        "maxItems": {
+          "description": "Maximum number of items to select.",
+          "type": "integer"
+        },
+        "minItems": {
+          "description": "Minimum number of items to select.",
+          "type": "integer"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "array",
+          "type": "string"
         }
       },
-      "required": ["method", "params"],
+      "required": ["items", "type"],
+      "type": "object"
+    },
+    "UntitledSingleSelectEnumSchema": {
+      "description": "Schema for single-selection enumeration without display titles for options.",
+      "properties": {
+        "default": {
+          "description": "Optional default value.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional description for the enum field.",
+          "type": "string"
+        },
+        "enum": {
+          "description": "Array of enum values to choose from.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "title": {
+          "description": "Optional title for the enum field.",
+          "type": "string"
+        },
+        "type": {
+          "const": "string",
+          "type": "string"
+        }
+      },
+      "required": ["enum", "type"],
       "type": "object"
     }
   }

--- a/internal/mcp/mcp-schema.yaml
+++ b/internal/mcp/mcp-schema.yaml
@@ -1,15 +1,15 @@
-$schema: http://json-schema.org/draft-07/schema#
-definitions:
+$schema: https://json-schema.org/draft/2020-12/schema
+$defs:
   Annotations:
     description: Optional annotations for the client. The client can use annotations to inform how objects are used or displayed
     properties:
       audience:
         description: |-
-          Describes who the intended customer of this object or data is.
+          Describes who the intended audience of this object or data is.
 
           It can include multiple entries to indicate content useful for multiple audiences (e.g., `["user", "assistant"]`).
         items:
-          $ref: '#/definitions/Role'
+          $ref: '#/$defs/Role'
         type: array
       lastModified:
         description: |-
@@ -35,11 +35,9 @@ definitions:
     description: Audio provided to or from an LLM.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       data:
         description: The base64-encoded audio data.
@@ -67,7 +65,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -77,9 +75,7 @@ definitions:
   BlobResourceContents:
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       blob:
         description: A base64-encoded string representing the binary data of the item.
         format: byte
@@ -109,37 +105,102 @@ definitions:
     required:
       - type
     type: object
+  CacheableResult:
+    description: A result that supports a time-to-live (TTL) hint for client-side caching.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
+    required:
+      - cacheScope
+      - resultType
+      - ttlMs
+    type: object
   CallToolRequest:
     description: Used by the client to invoke a tool provided by the server.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: tools/call
         type: string
       params:
-        properties:
-          arguments:
-            additionalProperties: {}
-            type: object
-          name:
-            type: string
-        required:
-          - name
-        type: object
+        $ref: '#/$defs/CallToolRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
       - params
     type: object
-  CallToolResult:
-    description: The server's response to a tool call.
+  CallToolRequestParams:
+    description: Parameters for a `tools/call` request.
     properties:
       _meta:
+        $ref: '#/$defs/RequestMetaObject'
+      arguments:
         additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        description: Arguments to use for the tool call.
         type: object
+      inputResponses:
+        $ref: '#/$defs/InputResponses'
+      name:
+        description: The name of the tool.
+        type: string
+      requestState:
+        type: string
+    required:
+      - _meta
+      - name
+    type: object
+  CallToolResult:
+    description: The result returned by the server for a {@link CallToolRequesttools/call} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
       content:
         description: A list of content objects that represent the unstructured result of the tool call.
         items:
-          $ref: '#/definitions/ContentBlock'
+          $ref: '#/$defs/ContentBlock'
         type: array
       isError:
         description: |-
@@ -156,148 +217,225 @@ definitions:
           server does not support tool calls, or any other exceptional conditions,
           should be reported as an MCP error response.
         type: boolean
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
       structuredContent:
-        additionalProperties: {}
-        description: An optional JSON object that represents the structured result of the tool call.
-        type: object
+        description: |-
+          An optional JSON value that represents the structured result of the tool call.
+
+          This can be any JSON value (object, array, string, number, boolean, or null)
+          that conforms to the tool's outputSchema if one is defined.
     required:
       - content
+      - resultType
+    type: object
+  CallToolResultResponse:
+    description: A successful response from the server for a {@link CallToolRequesttools/call} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        anyOf:
+          - $ref: '#/$defs/InputRequiredResult'
+          - $ref: '#/$defs/CallToolResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   CancelledNotification:
     description: |-
-      This notification can be sent by either side to indicate that it is cancelling a previously-issued request.
+      This notification is sent by the client to indicate that it is cancelling a request it previously issued.
+
+      On stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.
 
       The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
 
       This notification indicates that the result will be unused, so any associated processing SHOULD cease.
-
-      A client MUST NOT attempt to cancel its `initialize` request.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/cancelled
         type: string
       params:
-        properties:
-          reason:
-            description: An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
-            type: string
-          requestId:
-            $ref: '#/definitions/RequestId'
-            description: |-
-              The ID of the request to cancel.
-
-              This MUST correspond to the ID of a request previously issued in the same direction.
-        required:
-          - requestId
-        type: object
+        $ref: '#/$defs/CancelledNotificationParams'
     required:
+      - jsonrpc
       - method
       - params
+    type: object
+  CancelledNotificationParams:
+    description: Parameters for a `notifications/cancelled` notification.
+    properties:
+      _meta:
+        $ref: '#/$defs/NotificationMetaObject'
+      reason:
+        description: An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
+        type: string
+      requestId:
+        $ref: '#/$defs/RequestId'
+        description: |-
+          The ID of the request to cancel.
+
+          This MUST correspond to the ID of a request the client previously issued.
+    required:
+      - requestId
     type: object
   ClientCapabilities:
     description: 'Capabilities a client may support. Known capabilities are defined here, in this schema, but this is not a closed set: any client can define its own, additional capabilities.'
     properties:
       elicitation:
-        additionalProperties: true
         description: Present if the client supports elicitation from the server.
-        properties: {}
+        properties:
+          form:
+            $ref: '#/$defs/JSONObject'
+          url:
+            $ref: '#/$defs/JSONObject'
         type: object
       experimental:
         additionalProperties:
-          additionalProperties: true
-          properties: {}
-          type: object
+          $ref: '#/$defs/JSONObject'
         description: Experimental, non-standard capabilities that the client supports.
+        type: object
+      extensions:
+        additionalProperties:
+          $ref: '#/$defs/JSONObject'
+        description: |-
+          Optional MCP extensions that the client supports. Keys are extension identifiers
+          (e.g., "io.modelcontextprotocol/oauth-client-credentials"), and values are
+          per-extension settings objects. An empty object indicates support with no settings.
+
+          Keys MUST follow the {@link MetaObject`_meta` key naming rules}, with a
+          mandatory prefix.
         type: object
       roots:
         description: Present if the client supports listing roots.
-        properties:
-          listChanged:
-            description: Whether the client supports notifications for changes to the roots list.
-            type: boolean
+        properties: {}
         type: object
       sampling:
-        additionalProperties: true
         description: Present if the client supports sampling from an LLM.
-        properties: {}
+        properties:
+          context:
+            $ref: '#/$defs/JSONObject'
+            description: |-
+              Whether the client supports context inclusion via `includeContext` parameter.
+              If not declared, servers SHOULD only use `includeContext: "none"` (or omit it).
+          tools:
+            $ref: '#/$defs/JSONObject'
+            description: Whether the client supports tool use via `tools` and `toolChoice` parameters.
         type: object
     type: object
   ClientNotification:
-    anyOf:
-      - $ref: '#/definitions/CancelledNotification'
-      - $ref: '#/definitions/InitializedNotification'
-      - $ref: '#/definitions/ProgressNotification'
-      - $ref: '#/definitions/RootsListChangedNotification'
+    description: |-
+      This notification is sent by the client to indicate that it is cancelling a request it previously issued.
+
+      On stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequestsubscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.
+
+      The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
+
+      This notification indicates that the result will be unused, so any associated processing SHOULD cease.
+    properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
+      method:
+        const: notifications/cancelled
+        type: string
+      params:
+        $ref: '#/$defs/CancelledNotificationParams'
+    required:
+      - jsonrpc
+      - method
+      - params
+    type: object
   ClientRequest:
     anyOf:
-      - $ref: '#/definitions/InitializeRequest'
-      - $ref: '#/definitions/PingRequest'
-      - $ref: '#/definitions/ListResourcesRequest'
-      - $ref: '#/definitions/ListResourceTemplatesRequest'
-      - $ref: '#/definitions/ReadResourceRequest'
-      - $ref: '#/definitions/SubscribeRequest'
-      - $ref: '#/definitions/UnsubscribeRequest'
-      - $ref: '#/definitions/ListPromptsRequest'
-      - $ref: '#/definitions/GetPromptRequest'
-      - $ref: '#/definitions/ListToolsRequest'
-      - $ref: '#/definitions/CallToolRequest'
-      - $ref: '#/definitions/SetLevelRequest'
-      - $ref: '#/definitions/CompleteRequest'
+      - $ref: '#/$defs/DiscoverRequest'
+      - $ref: '#/$defs/ListResourcesRequest'
+      - $ref: '#/$defs/ListResourceTemplatesRequest'
+      - $ref: '#/$defs/ReadResourceRequest'
+      - $ref: '#/$defs/SubscriptionsListenRequest'
+      - $ref: '#/$defs/ListPromptsRequest'
+      - $ref: '#/$defs/GetPromptRequest'
+      - $ref: '#/$defs/ListToolsRequest'
+      - $ref: '#/$defs/CallToolRequest'
+      - $ref: '#/$defs/CompleteRequest'
   ClientResult:
-    anyOf:
-      - $ref: '#/definitions/Result'
-      - $ref: '#/definitions/CreateMessageResult'
-      - $ref: '#/definitions/ListRootsResult'
-      - $ref: '#/definitions/ElicitResult'
+    $ref: '#/$defs/Result'
+    description: Common result fields.
   CompleteRequest:
     description: A request from the client to the server, to ask for completion options.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: completion/complete
         type: string
       params:
-        properties:
-          argument:
-            description: The argument's information
-            properties:
-              name:
-                description: The name of the argument
-                type: string
-              value:
-                description: The value of the argument to use for completion matching.
-                type: string
-            required:
-              - name
-              - value
-            type: object
-          context:
-            description: Additional, optional context for completions
-            properties:
-              arguments:
-                additionalProperties:
-                  type: string
-                description: Previously-resolved variables in a URI template or prompt.
-                type: object
-            type: object
-          ref:
-            anyOf:
-              - $ref: '#/definitions/PromptReference'
-              - $ref: '#/definitions/ResourceTemplateReference'
-        required:
-          - argument
-          - ref
-        type: object
+        $ref: '#/$defs/CompleteRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
       - params
     type: object
-  CompleteResult:
-    description: The server's response to a completion/complete request
+  CompleteRequestParams:
+    description: Parameters for a `completion/complete` request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        $ref: '#/$defs/RequestMetaObject'
+      argument:
+        description: The argument's information
+        properties:
+          name:
+            description: The name of the argument
+            type: string
+          value:
+            description: The value of the argument to use for completion matching.
+            type: string
+        required:
+          - name
+          - value
         type: object
+      context:
+        description: Additional, optional context for completions
+        properties:
+          arguments:
+            additionalProperties:
+              type: string
+            description: Previously-resolved variables in a URI template or prompt.
+            type: object
+        type: object
+      ref:
+        anyOf:
+          - $ref: '#/$defs/PromptReference'
+          - $ref: '#/$defs/ResourceTemplateReference'
+    required:
+      - _meta
+      - argument
+      - ref
+    type: object
+  CompleteResult:
+    description: The result returned by the server for a {@link CompleteRequestcompletion/complete} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
       completion:
         properties:
           hasMore:
@@ -310,20 +448,47 @@ definitions:
             description: An array of completion values. Must not exceed 100 items.
             items:
               type: string
+            maxItems: 100
             type: array
         required:
           - values
         type: object
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
     required:
       - completion
+      - resultType
+    type: object
+  CompleteResultResponse:
+    description: A successful response from the server for a {@link CompleteRequestcompletion/complete} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/CompleteResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   ContentBlock:
     anyOf:
-      - $ref: '#/definitions/TextContent'
-      - $ref: '#/definitions/ImageContent'
-      - $ref: '#/definitions/AudioContent'
-      - $ref: '#/definitions/ResourceLink'
-      - $ref: '#/definitions/EmbeddedResource'
+      - $ref: '#/$defs/TextContent'
+      - $ref: '#/$defs/ImageContent'
+      - $ref: '#/$defs/AudioContent'
+      - $ref: '#/$defs/ResourceLink'
+      - $ref: '#/$defs/EmbeddedResource'
   CreateMessageRequest:
     description: A request from the server to sample an LLM via the client. The client has full discretion over which model to select. The client should also inform the user before beginning sampling, to allow them to inspect the request (human in the loop) and decide whether to approve it.
     properties:
@@ -331,65 +496,103 @@ definitions:
         const: sampling/createMessage
         type: string
       params:
-        properties:
-          includeContext:
-            description: A request to include context from one or more MCP servers (including the caller), to be attached to the prompt. The client MAY ignore this request.
-            enum:
-              - allServers
-              - none
-              - thisServer
-            type: string
-          maxTokens:
-            description: The maximum number of tokens to sample, as requested by the server. The client MAY choose to sample fewer tokens than requested.
-            type: integer
-          messages:
-            items:
-              $ref: '#/definitions/SamplingMessage'
-            type: array
-          metadata:
-            additionalProperties: true
-            description: Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.
-            properties: {}
-            type: object
-          modelPreferences:
-            $ref: '#/definitions/ModelPreferences'
-            description: The server's preferences for which model to select. The client MAY ignore these preferences.
-          stopSequences:
-            items:
-              type: string
-            type: array
-          systemPrompt:
-            description: An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.
-            type: string
-          temperature:
-            type: number
-        required:
-          - maxTokens
-          - messages
-        type: object
+        $ref: '#/$defs/CreateMessageRequestParams'
     required:
       - method
       - params
     type: object
+  CreateMessageRequestParams:
+    description: Parameters for a `sampling/createMessage` request.
+    properties:
+      includeContext:
+        description: |-
+          A request to include context from one or more MCP servers (including the caller), to be attached to the prompt.
+          The client MAY ignore this request.
+
+          Default is `"none"`. The values `"thisServer"` and `"allServers"` are deprecated (SEP-2596): servers SHOULD
+          omit this field or use `"none"`, and SHOULD only use the deprecated values if the client declares
+          {@link ClientCapabilities.sampling.context}.
+        enum:
+          - allServers
+          - none
+          - thisServer
+        type: string
+      maxTokens:
+        description: |-
+          The requested maximum number of tokens to sample (to prevent runaway completions).
+
+          The client MAY choose to sample fewer tokens than the requested maximum.
+        type: integer
+      messages:
+        items:
+          $ref: '#/$defs/SamplingMessage'
+        type: array
+      metadata:
+        $ref: '#/$defs/JSONObject'
+        description: Optional metadata to pass through to the LLM provider. The format of this metadata is provider-specific.
+      modelPreferences:
+        $ref: '#/$defs/ModelPreferences'
+        description: The server's preferences for which model to select. The client MAY ignore these preferences.
+      stopSequences:
+        items:
+          type: string
+        type: array
+      systemPrompt:
+        description: An optional system prompt the server wants to use for sampling. The client MAY modify or omit this prompt.
+        type: string
+      temperature:
+        type: number
+      toolChoice:
+        $ref: '#/$defs/ToolChoice'
+        description: |-
+          Controls how the model uses tools.
+          The client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.
+          Default is `{ mode: "auto" }`.
+      tools:
+        description: |-
+          Tools that the model may use during generation.
+          The client MUST return an error if this field is provided but {@link ClientCapabilities.sampling.tools} is not declared.
+        items:
+          $ref: '#/$defs/Tool'
+        type: array
+    required:
+      - maxTokens
+      - messages
+    type: object
   CreateMessageResult:
-    description: The client's response to a sampling/create_message request from the server. The client should inform the user before returning the sampled message, to allow them to inspect the response (human in the loop) and decide whether to allow the server to see it.
+    description: |-
+      The result returned by the client for a {@link CreateMessageRequestsampling/createMessage} request.
+      The client should inform the user before returning the sampled message, to allow them
+      to inspect the response (human in the loop) and decide whether to allow the server to see it.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       content:
         anyOf:
-          - $ref: '#/definitions/TextContent'
-          - $ref: '#/definitions/ImageContent'
-          - $ref: '#/definitions/AudioContent'
+          - $ref: '#/$defs/TextContent'
+          - $ref: '#/$defs/ImageContent'
+          - $ref: '#/$defs/AudioContent'
+          - $ref: '#/$defs/ToolUseContent'
+          - $ref: '#/$defs/ToolResultContent'
+          - items:
+              $ref: '#/$defs/SamplingMessageContentBlock'
+            type: array
       model:
         description: The name of the model that generated the message.
         type: string
       role:
-        $ref: '#/definitions/Role'
+        $ref: '#/$defs/Role'
       stopReason:
-        description: The reason why sampling stopped, if known.
+        description: |-
+          The reason why sampling stopped, if known.
+
+          Standard values:
+          - `"endTurn"`: Natural end of the assistant's turn
+          - `"stopSequence"`: A stop sequence was encountered
+          - `"maxTokens"`: Maximum token limit was reached
+          - `"toolUse"`: The model wants to use one or more tools
+
+          This field is an open string to allow for provider-specific stop reasons.
         type: string
     required:
       - content
@@ -399,6 +602,117 @@ definitions:
   Cursor:
     description: An opaque token used to represent a cursor for pagination.
     type: string
+  DiscoverRequest:
+    description: |-
+      A request from the client asking the server to advertise its supported
+      protocol versions, capabilities, and other metadata. Servers **MUST**
+      implement `server/discover`. Clients **MAY** call it but are not required
+      to — version negotiation can also happen inline via per-request `_meta`.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      method:
+        const: server/discover
+        type: string
+      params:
+        $ref: '#/$defs/RequestParams'
+    required:
+      - id
+      - jsonrpc
+      - method
+      - params
+    type: object
+  DiscoverResult:
+    description: The result returned by the server for a {@link DiscoverRequestserver/discover} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
+      capabilities:
+        $ref: '#/$defs/ServerCapabilities'
+        description: The capabilities of the server.
+      instructions:
+        description: |-
+          Natural-language guidance describing the server and its features.
+
+          This can be used by clients to improve an LLM's understanding of
+          available tools (e.g., by including it in a system prompt). It should
+          focus on information that helps the model use the server effectively
+          and should not duplicate information already in tool descriptions.
+        type: string
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      serverInfo:
+        $ref: '#/$defs/Implementation'
+        description: Information about the server software implementation.
+      supportedVersions:
+        description: |-
+          MCP Protocol Versions this server supports. The client should choose a
+          version from this list for use in subsequent requests.
+        items:
+          type: string
+        type: array
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
+    required:
+      - cacheScope
+      - capabilities
+      - resultType
+      - serverInfo
+      - supportedVersions
+      - ttlMs
+    type: object
+  DiscoverResultResponse:
+    description: A successful response from the server for a {@link DiscoverRequestserver/discover} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/DiscoverResult'
+    required:
+      - id
+      - jsonrpc
+      - result
+    type: object
   ElicitRequest:
     description: A request from the server to elicit additional information from the user via the client.
     properties:
@@ -406,51 +720,80 @@ definitions:
         const: elicitation/create
         type: string
       params:
-        properties:
-          message:
-            description: The message to present to the user.
-            type: string
-          requestedSchema:
-            description: |-
-              A restricted subset of JSON Schema.
-              Only top-level properties are allowed, without nesting.
-            properties:
-              properties:
-                additionalProperties:
-                  $ref: '#/definitions/PrimitiveSchemaDefinition'
-                type: object
-              required:
-                items:
-                  type: string
-                type: array
-              type:
-                const: object
-                type: string
-            required:
-              - properties
-              - type
-            type: object
-        required:
-          - message
-          - requestedSchema
-        type: object
+        $ref: '#/$defs/ElicitRequestParams'
     required:
       - method
       - params
     type: object
-  ElicitResult:
-    description: The client's response to an elicitation request.
+  ElicitRequestFormParams:
+    description: The parameters for a request to elicit non-sensitive information from the user via a form in the client.
     properties:
-      _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+      message:
+        description: The message to present to the user describing what information is being requested.
+        type: string
+      mode:
+        const: form
+        description: The elicitation mode.
+        type: string
+      requestedSchema:
+        description: |-
+          A restricted subset of JSON Schema.
+          Only top-level properties are allowed, without nesting.
+        properties:
+          $schema:
+            type: string
+          properties:
+            additionalProperties:
+              $ref: '#/$defs/PrimitiveSchemaDefinition'
+            type: object
+          required:
+            items:
+              type: string
+            type: array
+          type:
+            const: object
+            type: string
+        required:
+          - properties
+          - type
         type: object
+    required:
+      - message
+      - requestedSchema
+    type: object
+  ElicitRequestParams:
+    anyOf:
+      - $ref: '#/$defs/ElicitRequestFormParams'
+      - $ref: '#/$defs/ElicitRequestURLParams'
+    description: The parameters for a request to elicit additional information from the user via the client.
+  ElicitRequestURLParams:
+    description: The parameters for a request to elicit information from the user via a URL in the client.
+    properties:
+      message:
+        description: The message to present to the user explaining why the interaction is needed.
+        type: string
+      mode:
+        const: url
+        description: The elicitation mode.
+        type: string
+      url:
+        description: The URL that the user should navigate to.
+        format: uri
+        type: string
+    required:
+      - message
+      - mode
+      - url
+    type: object
+  ElicitResult:
+    description: The result returned by the client for an {@link ElicitRequestelicitation/create} request.
+    properties:
       action:
         description: |-
           The user action in response to the elicitation.
-          - "accept": User submitted the form/confirmed the action
-          - "decline": User explicitly decline the action
-          - "cancel": User dismissed without making an explicit choice
+          - `"accept"`: User submitted the form/confirmed the action
+          - `"decline"`: User explicitly declined the action
+          - `"cancel"`: User dismissed without making an explicit choice
         enum:
           - accept
           - cancel
@@ -458,13 +801,18 @@ definitions:
         type: string
       content:
         additionalProperties:
-          type:
-            - string
-            - integer
-            - boolean
+          anyOf:
+            - items:
+                type: string
+              type: array
+            - type:
+                - string
+                - integer
+                - boolean
         description: |-
-          The submitted form data, only present when action is "accept".
+          The submitted form data, only present when action is `"accept"` and mode was `"form"`.
           Contains values matching the requested schema.
+          Omitted for out-of-band mode responses.
         type: object
     required:
       - action
@@ -477,16 +825,14 @@ definitions:
       of the LLM and/or the user.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       resource:
         anyOf:
-          - $ref: '#/definitions/TextResourceContents'
-          - $ref: '#/definitions/BlobResourceContents'
+          - $ref: '#/$defs/TextResourceContents'
+          - $ref: '#/$defs/BlobResourceContents'
       type:
         const: resource
         type: string
@@ -495,77 +841,206 @@ definitions:
       - type
     type: object
   EmptyResult:
-    $ref: '#/definitions/Result'
+    $ref: '#/$defs/Result'
+    description: Common result fields.
   EnumSchema:
+    anyOf:
+      - $ref: '#/$defs/UntitledSingleSelectEnumSchema'
+      - $ref: '#/$defs/TitledSingleSelectEnumSchema'
+      - $ref: '#/$defs/UntitledMultiSelectEnumSchema'
+      - $ref: '#/$defs/TitledMultiSelectEnumSchema'
+      - $ref: '#/$defs/LegacyTitledEnumSchema'
+  Error:
     properties:
-      description:
-        type: string
-      enum:
-        items:
-          type: string
-        type: array
-      enumNames:
-        items:
-          type: string
-        type: array
-      title:
-        type: string
-      type:
-        const: string
+      code:
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
         type: string
     required:
-      - enum
-      - type
+      - code
+      - message
     type: object
   GetPromptRequest:
     description: Used by the client to get a prompt provided by the server.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: prompts/get
         type: string
       params:
-        properties:
-          arguments:
-            additionalProperties:
-              type: string
-            description: Arguments to use for templating the prompt.
-            type: object
-          name:
-            description: The name of the prompt or prompt template.
-            type: string
-        required:
-          - name
-        type: object
+        $ref: '#/$defs/GetPromptRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
       - params
     type: object
-  GetPromptResult:
-    description: The server's response to a prompts/get request from the client.
+  GetPromptRequestParams:
+    description: Parameters for a `prompts/get` request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
+        $ref: '#/$defs/RequestMetaObject'
+      arguments:
+        additionalProperties:
+          type: string
+        description: Arguments to use for templating the prompt.
         type: object
+      inputResponses:
+        $ref: '#/$defs/InputResponses'
+      name:
+        description: The name of the prompt or prompt template.
+        type: string
+      requestState:
+        type: string
+    required:
+      - _meta
+      - name
+    type: object
+  GetPromptResult:
+    description: The result returned by the server for a {@link GetPromptRequestprompts/get} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
       description:
         description: An optional description for the prompt.
         type: string
       messages:
         items:
-          $ref: '#/definitions/PromptMessage'
+          $ref: '#/$defs/PromptMessage'
         type: array
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
     required:
       - messages
+      - resultType
+    type: object
+  GetPromptResultResponse:
+    description: A successful response from the server for a {@link GetPromptRequestprompts/get} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        anyOf:
+          - $ref: '#/$defs/InputRequiredResult'
+          - $ref: '#/$defs/GetPromptResult'
+    required:
+      - id
+      - jsonrpc
+      - result
+    type: object
+  HeaderMismatchError:
+    description: |-
+      Returned when a server rejects a request because the values in the HTTP
+      headers do not match the corresponding values in the request body, or
+      because required headers are missing or malformed. For HTTP, the response
+      status code MUST be `400 Bad Request`.
+    properties:
+      error:
+        allOf:
+          - $ref: '#/$defs/Error'
+          - properties:
+              code:
+                const: -32020
+                type: integer
+            required:
+              - code
+            type: object
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+    required:
+      - error
+      - jsonrpc
+    type: object
+  Icon:
+    description: An optionally-sized icon that can be displayed in a user interface.
+    properties:
+      mimeType:
+        description: |-
+          Optional MIME type override if the source MIME type is missing or generic.
+          For example: `"image/png"`, `"image/jpeg"`, or `"image/svg+xml"`.
+        type: string
+      sizes:
+        description: |-
+          Optional array of strings that specify sizes at which the icon can be used.
+          Each string should be in WxH format (e.g., `"48x48"`, `"96x96"`) or `"any"` for scalable formats like SVG.
+
+          If not provided, the client should assume that the icon can be used at any size.
+        items:
+          type: string
+        type: array
+      src:
+        description: |-
+          A standard URI pointing to an icon resource. May be an HTTP/HTTPS URL or a
+          `data:` URI with Base64-encoded image data.
+
+          Consumers SHOULD take steps to ensure URLs serving icons are from the
+          same domain as the client/server or a trusted domain.
+
+          Consumers SHOULD take appropriate precautions when consuming SVGs as they can contain
+          executable JavaScript.
+        format: uri
+        type: string
+      theme:
+        description: |-
+          Optional specifier for the theme this icon is designed for. `"light"` indicates
+          the icon is designed to be used with a light background, and `"dark"` indicates
+          the icon is designed to be used with a dark background.
+
+          If not provided, the client should assume the icon can be used with any theme.
+        enum:
+          - dark
+          - light
+        type: string
+    required:
+      - src
+    type: object
+  Icons:
+    description: Base interface to add `icons` property.
+    properties:
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
     type: object
   ImageContent:
     description: An image provided to or from an LLM.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       data:
         description: The base64-encoded image data.
@@ -583,8 +1058,30 @@ definitions:
       - type
     type: object
   Implementation:
-    description: Describes the name and version of an MCP implementation, with an optional title for UI representation.
+    description: Describes the MCP implementation.
     properties:
+      description:
+        description: |-
+          An optional human-readable description of what this implementation does.
+
+          This can be used by clients or servers to provide context about their purpose
+          and capabilities. For example, a server might describe the types of resources
+          or tools it provides, while a client might describe its intended use case.
+        type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       name:
         description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
@@ -593,115 +1090,169 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
       version:
+        description: The version of this implementation.
+        type: string
+      websiteUrl:
+        description: An optional URL of the website for this implementation.
+        format: uri
         type: string
     required:
       - name
       - version
     type: object
-  InitializeRequest:
-    description: This request is sent from the client to the server when it first connects, asking it to begin initialization.
-    properties:
-      method:
-        const: initialize
-        type: string
-      params:
-        properties:
-          capabilities:
-            $ref: '#/definitions/ClientCapabilities'
-          clientInfo:
-            $ref: '#/definitions/Implementation'
-          protocolVersion:
-            description: The latest version of the Model Context Protocol that the client supports. The client MAY decide to support older versions as well.
-            type: string
-        required:
-          - capabilities
-          - clientInfo
-          - protocolVersion
-        type: object
-    required:
-      - method
-      - params
+  InputRequest:
+    anyOf:
+      - $ref: '#/$defs/CreateMessageRequest'
+      - $ref: '#/$defs/ListRootsRequest'
+      - $ref: '#/$defs/ElicitRequest'
+  InputRequests:
+    additionalProperties:
+      $ref: '#/$defs/InputRequest'
+    description: |-
+      A map of server-initiated requests that the client must fulfill.
+      Keys are server-assigned identifiers; values are the request objects.
     type: object
-  InitializeResult:
-    description: After receiving an initialize request from the client, the server sends this response.
+  InputRequiredResult:
+    description: |-
+      An InputRequiredResult sent by the server to indicate that additional input is needed
+      before the request can be completed.
+
+      At least one of `inputRequests` or `requestState` MUST be present.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
-      capabilities:
-        $ref: '#/definitions/ServerCapabilities'
-      instructions:
+        $ref: '#/$defs/MetaObject'
+      inputRequests:
+        $ref: '#/$defs/InputRequests'
+      requestState:
+        type: string
+      resultType:
         description: |-
-          Instructions describing how to use the server and its features.
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
 
-          This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a "hint" to the model. For example, this information MAY be added to the system prompt.
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
         type: string
-      protocolVersion:
-        description: The version of the Model Context Protocol that the server wants to use. This may not match the version that the client requested. If the client cannot support this version, it MUST disconnect.
-        type: string
-      serverInfo:
-        $ref: '#/definitions/Implementation'
     required:
-      - capabilities
-      - protocolVersion
-      - serverInfo
+      - resultType
     type: object
-  InitializedNotification:
-    description: This notification is sent from the client to the server after initialization has finished.
+  InputResponse:
+    anyOf:
+      - $ref: '#/$defs/CreateMessageResult'
+      - $ref: '#/$defs/ListRootsResult'
+      - $ref: '#/$defs/ElicitResult'
+  InputResponseRequestParams:
     properties:
-      method:
-        const: notifications/initialized
+      _meta:
+        $ref: '#/$defs/RequestMetaObject'
+      inputResponses:
+        $ref: '#/$defs/InputResponses'
+      requestState:
         type: string
-      params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
-        type: object
     required:
-      - method
+      - _meta
     type: object
-  JSONRPCError:
+  InputResponses:
+    additionalProperties:
+      $ref: '#/$defs/InputResponse'
+    description: |-
+      A map of client responses to server-initiated requests.
+      Keys correspond to the keys in the {@link InputRequests} map;
+      values are the client's result for each request.
+    type: object
+  InternalError:
+    description: A JSON-RPC error indicating that an internal error occurred on the receiver. This error is returned when the receiver encounters an unexpected condition that prevents it from fulfilling the request.
+    properties:
+      code:
+        const: -32603
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
+        type: string
+    required:
+      - code
+      - message
+    type: object
+  InvalidParamsError:
+    description: |-
+      A JSON-RPC error indicating that the method parameters are invalid or malformed.
+
+      In MCP, this error is returned in various contexts when request parameters fail validation:
+
+      - **Tools**: Unknown tool name or invalid tool arguments
+      - **Prompts**: Unknown prompt name or missing required arguments
+      - **Pagination**: Invalid or expired cursor values
+      - **Logging**: Invalid log level
+      - **Elicitation**: Server requests an elicitation mode not declared in client capabilities
+      - **Sampling**: Missing tool result or tool results mixed with other content
+    properties:
+      code:
+        const: -32602
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
+        type: string
+    required:
+      - code
+      - message
+    type: object
+  InvalidRequestError:
+    description: A JSON-RPC error indicating that the request is not a valid request object. This error is returned when the message structure does not conform to the JSON-RPC 2.0 specification requirements for a request (e.g., missing required fields like `jsonrpc` or `method`, or using invalid types for these fields).
+    properties:
+      code:
+        const: -32600
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
+        type: string
+    required:
+      - code
+      - message
+    type: object
+  JSONArray:
+    items:
+      $ref: '#/$defs/JSONValue'
+    type: array
+  JSONObject:
+    additionalProperties:
+      $ref: '#/$defs/JSONValue'
+    type: object
+  JSONRPCErrorResponse:
     description: A response to a request that indicates an error occurred.
     properties:
       error:
-        properties:
-          code:
-            description: The error type that occurred.
-            type: integer
-          data:
-            description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
-          message:
-            description: A short description of the error. The message SHOULD be limited to a concise single sentence.
-            type: string
-        required:
-          - code
-          - message
-        type: object
+        $ref: '#/$defs/Error'
       id:
-        $ref: '#/definitions/RequestId'
+        $ref: '#/$defs/RequestId'
       jsonrpc:
         const: '2.0'
         type: string
     required:
       - error
-      - id
       - jsonrpc
     type: object
   JSONRPCMessage:
     anyOf:
-      - $ref: '#/definitions/JSONRPCRequest'
-      - $ref: '#/definitions/JSONRPCNotification'
-      - $ref: '#/definitions/JSONRPCResponse'
-      - $ref: '#/definitions/JSONRPCError'
+      - $ref: '#/$defs/JSONRPCRequest'
+      - $ref: '#/$defs/JSONRPCNotification'
+      - $ref: '#/$defs/JSONRPCResultResponse'
+      - $ref: '#/$defs/JSONRPCErrorResponse'
     description: Refers to any valid JSON-RPC object that can be decoded off the wire, or encoded to be sent.
   JSONRPCNotification:
     description: A notification which does not expect a response.
@@ -713,11 +1264,6 @@ definitions:
         type: string
       params:
         additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
         type: object
     required:
       - jsonrpc
@@ -727,7 +1273,7 @@ definitions:
     description: A request that expects a response.
     properties:
       id:
-        $ref: '#/definitions/RequestId'
+        $ref: '#/$defs/RequestId'
       jsonrpc:
         const: '2.0'
         type: string
@@ -735,15 +1281,6 @@ definitions:
         type: string
       params:
         additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            properties:
-              progressToken:
-                $ref: '#/definitions/ProgressToken'
-                description: If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-            type: object
         type: object
     required:
       - id
@@ -751,44 +1288,104 @@ definitions:
       - method
     type: object
   JSONRPCResponse:
+    anyOf:
+      - $ref: '#/$defs/JSONRPCResultResponse'
+      - $ref: '#/$defs/JSONRPCErrorResponse'
+    description: A response to a request, containing either the result or error.
+  JSONRPCResultResponse:
     description: A successful (non-error) response to a request.
     properties:
       id:
-        $ref: '#/definitions/RequestId'
+        $ref: '#/$defs/RequestId'
       jsonrpc:
         const: '2.0'
         type: string
       result:
-        $ref: '#/definitions/Result'
+        $ref: '#/$defs/Result'
     required:
       - id
       - jsonrpc
       - result
     type: object
+  JSONValue:
+    anyOf:
+      - $ref: '#/$defs/JSONObject'
+      - items:
+          $ref: '#/$defs/JSONValue'
+        type: array
+      - type:
+          - string
+          - integer
+          - boolean
+  LegacyTitledEnumSchema:
+    description: |-
+      Use {@link TitledSingleSelectEnumSchema} instead.
+      This interface will be removed in a future version.
+    properties:
+      default:
+        type: string
+      description:
+        type: string
+      enum:
+        items:
+          type: string
+        type: array
+      enumNames:
+        description: |-
+          (Legacy) Display names for enum values.
+          Non-standard according to JSON schema 2020-12.
+        items:
+          type: string
+        type: array
+      title:
+        type: string
+      type:
+        const: string
+        type: string
+    required:
+      - enum
+      - type
+    type: object
   ListPromptsRequest:
     description: Sent from the client to request a list of prompts and prompt templates the server has.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: prompts/list
         type: string
       params:
-        properties:
-          cursor:
-            description: |-
-              An opaque token representing the current pagination position.
-              If provided, the server should return results starting after this cursor.
-            type: string
-        type: object
+        $ref: '#/$defs/PaginatedRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
+      - params
     type: object
   ListPromptsResult:
-    description: The server's response to a prompts/list request from the client.
+    description: The result returned by the server for a {@link ListPromptsRequestprompts/list} request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
       nextCursor:
         description: |-
           An opaque token representing the pagination position after the last returned result.
@@ -796,35 +1393,91 @@ definitions:
         type: string
       prompts:
         items:
-          $ref: '#/definitions/Prompt'
+          $ref: '#/$defs/Prompt'
         type: array
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
     required:
+      - cacheScope
       - prompts
+      - resultType
+      - ttlMs
+    type: object
+  ListPromptsResultResponse:
+    description: A successful response from the server for a {@link ListPromptsRequestprompts/list} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/ListPromptsResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   ListResourceTemplatesRequest:
     description: Sent from the client to request a list of resource templates the server has.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: resources/templates/list
         type: string
       params:
-        properties:
-          cursor:
-            description: |-
-              An opaque token representing the current pagination position.
-              If provided, the server should return results starting after this cursor.
-            type: string
-        type: object
+        $ref: '#/$defs/PaginatedRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
+      - params
     type: object
   ListResourceTemplatesResult:
-    description: The server's response to a resources/templates/list request from the client.
+    description: The result returned by the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
       nextCursor:
         description: |-
           An opaque token representing the pagination position after the last returned result.
@@ -832,35 +1485,91 @@ definitions:
         type: string
       resourceTemplates:
         items:
-          $ref: '#/definitions/ResourceTemplate'
+          $ref: '#/$defs/ResourceTemplate'
         type: array
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
     required:
+      - cacheScope
       - resourceTemplates
+      - resultType
+      - ttlMs
+    type: object
+  ListResourceTemplatesResultResponse:
+    description: A successful response from the server for a {@link ListResourceTemplatesRequestresources/templates/list} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/ListResourceTemplatesResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   ListResourcesRequest:
     description: Sent from the client to request a list of resources the server has.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: resources/list
         type: string
       params:
-        properties:
-          cursor:
-            description: |-
-              An opaque token representing the current pagination position.
-              If provided, the server should return results starting after this cursor.
-            type: string
-        type: object
+        $ref: '#/$defs/PaginatedRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
+      - params
     type: object
   ListResourcesResult:
-    description: The server's response to a resources/list request from the client.
+    description: The result returned by the server for a {@link ListResourcesRequestresources/list} request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
       nextCursor:
         description: |-
           An opaque token representing the pagination position after the last returned result.
@@ -868,10 +1577,50 @@ definitions:
         type: string
       resources:
         items:
-          $ref: '#/definitions/Resource'
+          $ref: '#/$defs/Resource'
         type: array
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
     required:
+      - cacheScope
       - resources
+      - resultType
+      - ttlMs
+    type: object
+  ListResourcesResultResponse:
+    description: A successful response from the server for a {@link ListResourcesRequestresources/list} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/ListResourcesResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   ListRootsRequest:
     description: |-
@@ -887,33 +1636,22 @@ definitions:
         const: roots/list
         type: string
       params:
-        additionalProperties: {}
         properties:
           _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            properties:
-              progressToken:
-                $ref: '#/definitions/ProgressToken'
-                description: If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-            type: object
+            $ref: '#/$defs/MetaObject'
         type: object
     required:
       - method
     type: object
   ListRootsResult:
     description: |-
-      The client's response to a roots/list request from the server.
-      This result contains an array of Root objects, each representing a root directory
+      The result returned by the client for a {@link ListRootsRequestroots/list} request.
+      This result contains an array of {@link Root} objects, each representing a root directory
       or file that the server can operate on.
     properties:
-      _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
       roots:
         items:
-          $ref: '#/definitions/Root'
+          $ref: '#/$defs/Root'
         type: array
     required:
       - roots
@@ -921,38 +1659,94 @@ definitions:
   ListToolsRequest:
     description: Sent from the client to request a list of tools the server has.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: tools/list
         type: string
       params:
-        properties:
-          cursor:
-            description: |-
-              An opaque token representing the current pagination position.
-              If provided, the server should return results starting after this cursor.
-            type: string
-        type: object
+        $ref: '#/$defs/PaginatedRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
+      - params
     type: object
   ListToolsResult:
-    description: The server's response to a tools/list request from the client.
+    description: The result returned by the server for a {@link ListToolsRequesttools/list} request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
       nextCursor:
         description: |-
           An opaque token representing the pagination position after the last returned result.
           If present, there may be more results available.
         type: string
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
       tools:
         items:
-          $ref: '#/definitions/Tool'
+          $ref: '#/$defs/Tool'
         type: array
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
     required:
+      - cacheScope
+      - resultType
       - tools
+      - ttlMs
+    type: object
+  ListToolsResultResponse:
+    description: A successful response from the server for a {@link ListToolsRequesttools/list} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        $ref: '#/$defs/ListToolsResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   LoggingLevel:
     description: |-
@@ -971,28 +1765,110 @@ definitions:
       - warning
     type: string
   LoggingMessageNotification:
-    description: Notification of a log message passed from server to client. If no logging/setLevel request has been sent from the client, the server MAY decide which messages to send automatically.
+    description: JSONRPCNotification of a log message passed from server to client. The client opts in by setting `"io.modelcontextprotocol/logLevel"` in a request's `_meta`.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/message
         type: string
       params:
-        properties:
-          data:
-            description: The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
-          level:
-            $ref: '#/definitions/LoggingLevel'
-            description: The severity of this log message.
-          logger:
-            description: An optional name of the logger issuing this message.
-            type: string
-        required:
-          - data
-          - level
-        type: object
+        $ref: '#/$defs/LoggingMessageNotificationParams'
     required:
+      - jsonrpc
       - method
       - params
+    type: object
+  LoggingMessageNotificationParams:
+    description: Parameters for a `notifications/message` notification.
+    properties:
+      _meta:
+        $ref: '#/$defs/NotificationMetaObject'
+      data:
+        description: The data to be logged, such as a string message or an object. Any JSON serializable type is allowed here.
+      level:
+        $ref: '#/$defs/LoggingLevel'
+        description: The severity of this log message.
+      logger:
+        description: An optional name of the logger issuing this message.
+        type: string
+    required:
+      - data
+      - level
+    type: object
+  MetaObject:
+    description: |-
+      Represents the contents of a `_meta` field, which clients and servers use to attach additional metadata to their interactions.
+
+      Certain key names are reserved by MCP for protocol-level metadata; implementations MUST NOT make assumptions about values at these keys. Additionally, specific schema definitions may reserve particular names for purpose-specific metadata, as declared in those definitions.
+
+      Valid keys have two segments:
+
+      **Prefix:**
+      - Optional — if specified, MUST be a series of _labels_ separated by dots (`.`), followed by a slash (`/`).
+      - Labels MUST start with a letter and end with a letter or digit. Interior characters may be letters, digits, or hyphens (`-`).
+      - Implementations SHOULD use reverse DNS notation (e.g., `com.example/` rather than `example.com/`).
+      - Any prefix where the second label is `modelcontextprotocol` or `mcp` is **reserved** for MCP use. For example: `io.modelcontextprotocol/`, `dev.mcp/`, `org.modelcontextprotocol.api/`, and `com.mcp.tools/` are all reserved. However, `com.example.mcp/` is NOT reserved, as the second label is `example`.
+
+      **Name:**
+      - Unless empty, MUST start and end with an alphanumeric character (`[a-z0-9A-Z]`).
+      - Interior characters may be alphanumeric, hyphens (`-`), underscores (`_`), or dots (`.`).
+    type: object
+  MethodNotFoundError:
+    description: |-
+      A JSON-RPC error indicating that the requested method does not exist or is not available.
+
+      In MCP, a server returns this error when a client invokes a method the server does not implement — either a genuinely unknown method, or one gated behind a server capability the server did not advertise (e.g., calling `prompts/list` when the `prompts` capability was not advertised).
+
+      A request that requires a client capability the client did not declare is signalled instead by {@link MissingRequiredClientCapabilityError} (`-32021`).
+    properties:
+      code:
+        const: -32601
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
+        type: string
+    required:
+      - code
+      - message
+    type: object
+  MissingRequiredClientCapabilityError:
+    description: |-
+      Returned when processing a request requires a capability the client did not
+      declare in `clientCapabilities`. For HTTP, the response status code MUST be
+      `400 Bad Request`.
+    properties:
+      error:
+        allOf:
+          - $ref: '#/$defs/Error'
+          - properties:
+              code:
+                const: -32021
+                type: integer
+              data:
+                properties:
+                  requiredCapabilities:
+                    $ref: '#/$defs/ClientCapabilities'
+                    description: The capabilities the server requires from the client to process this request.
+                required:
+                  - requiredCapabilities
+                type: object
+            required:
+              - code
+              - data
+            type: object
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+    required:
+      - error
+      - jsonrpc
     type: object
   ModelHint:
     description: |-
@@ -1046,7 +1922,7 @@ definitions:
           The client SHOULD prioritize these hints over the numeric priorities, but
           MAY still use the priorities to select from ambiguous matches.
         items:
-          $ref: '#/definitions/ModelHint'
+          $ref: '#/$defs/ModelHint'
         type: array
       intelligencePriority:
         description: |-
@@ -1065,29 +1941,53 @@ definitions:
         minimum: 0
         type: number
     type: object
+  MultiSelectEnumSchema:
+    anyOf:
+      - $ref: '#/$defs/UntitledMultiSelectEnumSchema'
+      - $ref: '#/$defs/TitledMultiSelectEnumSchema'
   Notification:
     properties:
       method:
         type: string
       params:
         additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
         type: object
     required:
       - method
     type: object
+  NotificationMetaObject:
+    description: Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.
+    properties:
+      io.modelcontextprotocol/subscriptionId:
+        $ref: '#/$defs/RequestId'
+        description: |-
+          Identifies the subscription stream a notification was delivered on. The
+          server MUST include this key on every notification delivered via a
+          {@link SubscriptionsListenRequestsubscriptions/listen} stream, so the
+          client can correlate the notification with the originating subscription.
+          The key is absent on notifications not delivered via a subscription
+          stream (e.g. progress notifications for an in-flight request), which is
+          why it is optional here.
+
+          The value is the JSON-RPC ID of the `subscriptions/listen` request that
+          opened the stream.
+    type: object
+  NotificationParams:
+    description: Common params for any notification.
+    properties:
+      _meta:
+        $ref: '#/$defs/NotificationMetaObject'
+    type: object
   NumberSchema:
     properties:
+      default:
+        type: number
       description:
         type: string
       maximum:
-        type: integer
+        type: number
       minimum:
-        type: integer
+        type: number
       title:
         type: string
       type:
@@ -1100,88 +2000,121 @@ definitions:
     type: object
   PaginatedRequest:
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         type: string
       params:
-        properties:
-          cursor:
-            description: |-
-              An opaque token representing the current pagination position.
-              If provided, the server should return results starting after this cursor.
-            type: string
-        type: object
+        $ref: '#/$defs/PaginatedRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
+      - params
+    type: object
+  PaginatedRequestParams:
+    description: Common params for paginated requests.
+    properties:
+      _meta:
+        $ref: '#/$defs/RequestMetaObject'
+      cursor:
+        description: |-
+          An opaque token representing the current pagination position.
+          If provided, the server should return results starting after this cursor.
+        type: string
+    required:
+      - _meta
     type: object
   PaginatedResult:
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       nextCursor:
         description: |-
           An opaque token representing the pagination position after the last returned result.
           If present, there may be more results available.
         type: string
-    type: object
-  PingRequest:
-    description: A ping, issued by either the server or the client, to check that the other party is still alive. The receiver must promptly respond, or else may be disconnected.
-    properties:
-      method:
-        const: ping
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
         type: string
-      params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            properties:
-              progressToken:
-                $ref: '#/definitions/ProgressToken'
-                description: If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-            type: object
-        type: object
     required:
-      - method
+      - resultType
+    type: object
+  ParseError:
+    description: A JSON-RPC error indicating that invalid JSON was received by the server. This error is returned when the server cannot parse the JSON text of a message.
+    properties:
+      code:
+        const: -32700
+        description: The error type that occurred.
+        type: integer
+      data:
+        description: Additional information about the error. The value of this member is defined by the sender (e.g. detailed error information, nested errors etc.).
+      message:
+        description: A short description of the error. The message SHOULD be limited to a concise single sentence.
+        type: string
+    required:
+      - code
+      - message
     type: object
   PrimitiveSchemaDefinition:
     anyOf:
-      - $ref: '#/definitions/StringSchema'
-      - $ref: '#/definitions/NumberSchema'
-      - $ref: '#/definitions/BooleanSchema'
-      - $ref: '#/definitions/EnumSchema'
+      - $ref: '#/$defs/StringSchema'
+      - $ref: '#/$defs/NumberSchema'
+      - $ref: '#/$defs/BooleanSchema'
+      - $ref: '#/$defs/UntitledSingleSelectEnumSchema'
+      - $ref: '#/$defs/TitledSingleSelectEnumSchema'
+      - $ref: '#/$defs/UntitledMultiSelectEnumSchema'
+      - $ref: '#/$defs/TitledMultiSelectEnumSchema'
+      - $ref: '#/$defs/LegacyTitledEnumSchema'
     description: |-
       Restricted schema definitions that only allow primitive types
       without nested objects or arrays.
   ProgressNotification:
     description: An out-of-band notification used to inform the receiver of a progress update for a long-running request.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/progress
         type: string
       params:
-        properties:
-          message:
-            description: An optional message describing the current progress.
-            type: string
-          progress:
-            description: The progress thus far. This should increase every time progress is made, even if the total is unknown.
-            type: number
-          progressToken:
-            $ref: '#/definitions/ProgressToken'
-            description: The progress token which was given in the initial request, used to associate this notification with the request that is proceeding.
-          total:
-            description: Total number of items to process (or total progress required), if known.
-            type: number
-        required:
-          - progress
-          - progressToken
-        type: object
+        $ref: '#/$defs/ProgressNotificationParams'
     required:
+      - jsonrpc
       - method
       - params
+    type: object
+  ProgressNotificationParams:
+    description: Parameters for a {@link ProgressNotificationnotifications/progress} notification.
+    properties:
+      _meta:
+        $ref: '#/$defs/NotificationMetaObject'
+      message:
+        description: An optional message describing the current progress.
+        type: string
+      progress:
+        description: The progress thus far. This should increase every time progress is made, even if the total is unknown.
+        type: number
+      progressToken:
+        $ref: '#/$defs/ProgressToken'
+        description: The progress token which was given in the initial request, used to associate this notification with the request that is proceeding.
+      total:
+        description: Total number of items to process (or total progress required), if known.
+        type: number
+    required:
+      - progress
+      - progressToken
     type: object
   ProgressToken:
     description: A progress token, used to associate progress notifications with the original request.
@@ -1192,17 +2125,29 @@ definitions:
     description: A prompt or prompt template that the server offers.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       arguments:
         description: A list of arguments to use for templating the prompt.
         items:
-          $ref: '#/definitions/PromptArgument'
+          $ref: '#/$defs/PromptArgument'
         type: array
       description:
         description: An optional description of what this prompt provides
         type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       name:
         description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
@@ -1211,7 +2156,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1235,7 +2180,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1243,33 +2188,31 @@ definitions:
       - name
     type: object
   PromptListChangedNotification:
-    description: An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
+    description: An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/prompts/list_changed
         type: string
       params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
-        type: object
+        $ref: '#/$defs/NotificationParams'
     required:
+      - jsonrpc
       - method
     type: object
   PromptMessage:
     description: |-
       Describes a message returned as part of a prompt.
 
-      This is similar to `SamplingMessage`, but also supports the embedding of
+      This is similar to {@link SamplingMessage}, but also supports the embedding of
       resources from the MCP server.
     properties:
       content:
-        $ref: '#/definitions/ContentBlock'
+        $ref: '#/$defs/ContentBlock'
       role:
-        $ref: '#/definitions/Role'
+        $ref: '#/$defs/Role'
     required:
       - content
       - role
@@ -1285,7 +2228,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1299,37 +2242,110 @@ definitions:
   ReadResourceRequest:
     description: Sent from the client to the server, to read a specific resource URI.
     properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: resources/read
         type: string
       params:
-        properties:
-          uri:
-            description: The URI of the resource to read. The URI can use any protocol; it is up to the server how to interpret it.
-            format: uri
-            type: string
-        required:
-          - uri
-        type: object
+        $ref: '#/$defs/ReadResourceRequestParams'
     required:
+      - id
+      - jsonrpc
       - method
       - params
     type: object
-  ReadResourceResult:
-    description: The server's response to a resources/read request from the client.
+  ReadResourceRequestParams:
+    description: Parameters for a `resources/read` request.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/RequestMetaObject'
+      inputResponses:
+        $ref: '#/$defs/InputResponses'
+      requestState:
+        type: string
+      uri:
+        description: The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.
+        format: uri
+        type: string
+    required:
+      - _meta
+      - uri
+    type: object
+  ReadResourceResult:
+    description: The result returned by the server for a {@link ReadResourceRequestresources/read} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
+      cacheScope:
+        description: |-
+          Indicates the intended scope of the cached response, analogous to HTTP
+          `Cache-Control: public` vs `Cache-Control: private`.
+
+          - `"public"`: The response does not contain user-specific data. Any
+            client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+            the response and serve it across authorization contexts.
+          - `"private"`: The response MAY be cached and reused only within the
+            same authorization context. Caches MUST NOT be shared across
+            authorization contexts (e.g., a different access token requires a
+            different cache).
+        enum:
+          - private
+          - public
+        type: string
       contents:
         items:
           anyOf:
-            - $ref: '#/definitions/TextResourceContents'
-            - $ref: '#/definitions/BlobResourceContents'
+            - $ref: '#/$defs/TextResourceContents'
+            - $ref: '#/$defs/BlobResourceContents'
         type: array
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+      ttlMs:
+        description: |-
+          A hint from the server indicating how long (in milliseconds) the
+          client MAY cache this response before re-fetching. Semantics are
+          analogous to HTTP Cache-Control max-age.
+
+          - If 0, The response SHOULD be considered immediately stale,
+            The client MAY re-fetch every time the result is needed.
+          - If positive, the client SHOULD consider the result fresh for this many
+            milliseconds after receiving the response.
+        minimum: 0
+        type: integer
     required:
+      - cacheScope
       - contents
+      - resultType
+      - ttlMs
+    type: object
+  ReadResourceResultResponse:
+    description: A successful response from the server for a {@link ReadResourceRequestresources/read} request.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      result:
+        anyOf:
+          - $ref: '#/$defs/InputRequiredResult'
+          - $ref: '#/$defs/ReadResourceResult'
+    required:
+      - id
+      - jsonrpc
+      - result
     type: object
   Request:
     properties:
@@ -1337,15 +2353,6 @@ definitions:
         type: string
       params:
         additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            properties:
-              progressToken:
-                $ref: '#/definitions/ProgressToken'
-                description: If specified, the caller is requesting out-of-band progress notifications for this request (as represented by notifications/progress). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
-            type: object
         type: object
     required:
       - method
@@ -1355,15 +2362,64 @@ definitions:
     type:
       - string
       - integer
+  RequestMetaObject:
+    description: Extends {@link MetaObject} with additional request-specific fields. All key naming rules from `MetaObject` apply.
+    properties:
+      io.modelcontextprotocol/clientCapabilities:
+        $ref: '#/$defs/ClientCapabilities'
+        description: |-
+          The client's capabilities for this specific request. Required.
+
+          Capabilities are declared per-request rather than once at initialization;
+          an empty object means the client supports no optional capabilities.
+          Servers MUST NOT infer capabilities from prior requests.
+      io.modelcontextprotocol/clientInfo:
+        $ref: '#/$defs/Implementation'
+        description: |-
+          Identifies the client software making the request. Required.
+
+          The {@link Implementation} schema requires `name` and `version`; other
+          fields are optional.
+      io.modelcontextprotocol/logLevel:
+        $ref: '#/$defs/LoggingLevel'
+        description: |-
+          The desired log level for this request. Optional.
+
+          If absent, the server MUST NOT send any {@link LoggingMessageNotificationnotifications/message}
+          notifications for this request. The client opts in to log messages by
+          explicitly setting a level. Replaces the former `logging/setLevel` RPC.
+      io.modelcontextprotocol/protocolVersion:
+        description: |-
+          The MCP Protocol Version being used for this request. Required.
+
+          For the HTTP transport, this value MUST match the `MCP-Protocol-Version`
+          header; otherwise the server MUST return a `400 Bad Request`. If the
+          server does not support the requested version, it MUST return an
+          {@link UnsupportedProtocolVersionError}.
+        type: string
+      progressToken:
+        $ref: '#/$defs/ProgressToken'
+        description: If specified, the caller is requesting out-of-band progress notifications for this request (as represented by {@link ProgressNotificationnotifications/progress}). The value of this parameter is an opaque token that will be attached to any subsequent notifications. The receiver is not obligated to provide these notifications.
+    required:
+      - io.modelcontextprotocol/clientCapabilities
+      - io.modelcontextprotocol/clientInfo
+      - io.modelcontextprotocol/protocolVersion
+    type: object
+  RequestParams:
+    description: Common params for any request.
+    properties:
+      _meta:
+        $ref: '#/$defs/RequestMetaObject'
+    required:
+      - _meta
+    type: object
   Resource:
     description: A known resource that the server is capable of reading.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       description:
         description: |-
@@ -1371,6 +2427,20 @@ definitions:
 
           This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
         type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1388,7 +2458,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1404,9 +2474,7 @@ definitions:
     description: The contents of a specific resource or sub-resource.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1421,14 +2489,12 @@ definitions:
     description: |-
       A resource that the server is capable of reading, included in a prompt or tool call result.
 
-      Note: resource links returned by tools are not guaranteed to appear in the results of `resources/list` requests.
+      Note: resource links returned by tools are not guaranteed to appear in the results of {@link ListResourcesRequestresources/list} requests.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       description:
         description: |-
@@ -1436,6 +2502,20 @@ definitions:
 
           This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
         type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1453,7 +2533,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1470,31 +2550,40 @@ definitions:
       - uri
     type: object
   ResourceListChangedNotification:
-    description: An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.
+    description: An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/resources/list_changed
         type: string
       params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
-        type: object
+        $ref: '#/$defs/NotificationParams'
     required:
+      - jsonrpc
       - method
+    type: object
+  ResourceRequestParams:
+    description: Common params for resource-related requests.
+    properties:
+      _meta:
+        $ref: '#/$defs/RequestMetaObject'
+      uri:
+        description: The URI of the resource. The URI can use any protocol; it is up to the server how to interpret it.
+        format: uri
+        type: string
+    required:
+      - _meta
+      - uri
     type: object
   ResourceTemplate:
     description: A template description for resources available on the server.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       description:
         description: |-
@@ -1502,6 +2591,20 @@ definitions:
 
           This can be used by clients to improve the LLM's understanding of available resources. It can be thought of like a "hint" to the model.
         type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       mimeType:
         description: The MIME type for all resources that match this template. This should only be included if all resources matching this template have the same type.
         type: string
@@ -1513,7 +2616,7 @@ definitions:
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1540,32 +2643,60 @@ definitions:
       - uri
     type: object
   ResourceUpdatedNotification:
-    description: A notification from the server to the client, informing it that a resource has changed and may need to be read again. This should only be sent if the client previously sent a resources/subscribe request.
+    description: A notification from the server to the client, informing it that a resource has changed and may need to be read again. This is only sent for resources the client opted in to via the `resourceSubscriptions` field of a {@link SubscriptionsListenRequestsubscriptions/listen} request.
     properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/resources/updated
         type: string
       params:
-        properties:
-          uri:
-            description: The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
-            format: uri
-            type: string
-        required:
-          - uri
-        type: object
+        $ref: '#/$defs/ResourceUpdatedNotificationParams'
     required:
+      - jsonrpc
       - method
       - params
     type: object
-  Result:
-    additionalProperties: {}
+  ResourceUpdatedNotificationParams:
+    description: Parameters for a `notifications/resources/updated` notification.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/NotificationMetaObject'
+      uri:
+        description: The URI of the resource that has been updated. This might be a sub-resource of the one that the client actually subscribed to.
+        format: uri
+        type: string
+    required:
+      - uri
     type: object
+  Result:
+    additionalProperties: {}
+    description: Common result fields.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+    required:
+      - resultType
+    type: object
+  ResultType:
+    description: |-
+      Indicates the type of a {@link Result} object, allowing the client to
+      determine how to parse the response.
+
+      complete - the request completed successfully and the result contains the final content.
+      input_required - the request requires additional input and the result contains an {@link InputRequiredResult} object with instructions for the client to provide additional input before retrying the original request.
+    type: string
   Role:
     description: The sender or recipient of messages and data in a conversation.
     enum:
@@ -1576,9 +2707,7 @@ definitions:
     description: Represents a root directory or file that the server can operate on.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       name:
         description: |-
           An optional name for the root. This can be used to provide a human-readable
@@ -1587,7 +2716,7 @@ definitions:
         type: string
       uri:
         description: |-
-          The URI identifying the root. This *must* start with file:// for now.
+          The URI identifying the root. This *must* start with `file://` for now.
           This restriction may be relaxed in future versions of the protocol to allow
           other URI schemes.
         format: uri
@@ -1595,60 +2724,59 @@ definitions:
     required:
       - uri
     type: object
-  RootsListChangedNotification:
-    description: |-
-      A notification from the client to the server, informing it that the list of roots has changed.
-      This notification should be sent whenever the client adds, removes, or modifies any root.
-      The server should then request an updated list of roots using the ListRootsRequest.
-    properties:
-      method:
-        const: notifications/roots/list_changed
-        type: string
-      params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
-        type: object
-    required:
-      - method
-    type: object
   SamplingMessage:
     description: Describes a message issued to or received from an LLM API.
     properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
       content:
         anyOf:
-          - $ref: '#/definitions/TextContent'
-          - $ref: '#/definitions/ImageContent'
-          - $ref: '#/definitions/AudioContent'
+          - $ref: '#/$defs/TextContent'
+          - $ref: '#/$defs/ImageContent'
+          - $ref: '#/$defs/AudioContent'
+          - $ref: '#/$defs/ToolUseContent'
+          - $ref: '#/$defs/ToolResultContent'
+          - items:
+              $ref: '#/$defs/SamplingMessageContentBlock'
+            type: array
       role:
-        $ref: '#/definitions/Role'
+        $ref: '#/$defs/Role'
     required:
       - content
       - role
     type: object
+  SamplingMessageContentBlock:
+    anyOf:
+      - $ref: '#/$defs/TextContent'
+      - $ref: '#/$defs/ImageContent'
+      - $ref: '#/$defs/AudioContent'
+      - $ref: '#/$defs/ToolUseContent'
+      - $ref: '#/$defs/ToolResultContent'
   ServerCapabilities:
     description: 'Capabilities that a server may support. Known capabilities are defined here, in this schema, but this is not a closed set: any server can define its own, additional capabilities.'
     properties:
       completions:
-        additionalProperties: true
+        $ref: '#/$defs/JSONObject'
         description: Present if the server supports argument autocompletion suggestions.
-        properties: {}
-        type: object
       experimental:
         additionalProperties:
-          additionalProperties: true
-          properties: {}
-          type: object
+          $ref: '#/$defs/JSONObject'
         description: Experimental, non-standard capabilities that the server supports.
         type: object
-      logging:
-        additionalProperties: true
-        description: Present if the server supports sending log messages to the client.
-        properties: {}
+      extensions:
+        additionalProperties:
+          $ref: '#/$defs/JSONObject'
+        description: |-
+          Optional MCP extensions that the server supports. Keys are extension identifiers
+          (e.g., "io.modelcontextprotocol/tasks"), and values are per-extension settings
+          objects. An empty object indicates support with no settings.
+
+          Keys MUST follow the {@link MetaObject`_meta` key naming rules}, with a
+          mandatory prefix.
         type: object
+      logging:
+        $ref: '#/$defs/JSONObject'
+        description: Present if the server supports sending log messages to the client.
       prompts:
         description: Present if the server offers any prompt templates.
         properties:
@@ -1676,51 +2804,36 @@ definitions:
     type: object
   ServerNotification:
     anyOf:
-      - $ref: '#/definitions/CancelledNotification'
-      - $ref: '#/definitions/ProgressNotification'
-      - $ref: '#/definitions/ResourceListChangedNotification'
-      - $ref: '#/definitions/ResourceUpdatedNotification'
-      - $ref: '#/definitions/PromptListChangedNotification'
-      - $ref: '#/definitions/ToolListChangedNotification'
-      - $ref: '#/definitions/LoggingMessageNotification'
-  ServerRequest:
-    anyOf:
-      - $ref: '#/definitions/PingRequest'
-      - $ref: '#/definitions/CreateMessageRequest'
-      - $ref: '#/definitions/ListRootsRequest'
-      - $ref: '#/definitions/ElicitRequest'
+      - $ref: '#/$defs/CancelledNotification'
+      - $ref: '#/$defs/ProgressNotification'
+      - $ref: '#/$defs/ResourceListChangedNotification'
+      - $ref: '#/$defs/SubscriptionsAcknowledgedNotification'
+      - $ref: '#/$defs/ResourceUpdatedNotification'
+      - $ref: '#/$defs/PromptListChangedNotification'
+      - $ref: '#/$defs/ToolListChangedNotification'
+      - $ref: '#/$defs/LoggingMessageNotification'
   ServerResult:
     anyOf:
-      - $ref: '#/definitions/Result'
-      - $ref: '#/definitions/InitializeResult'
-      - $ref: '#/definitions/ListResourcesResult'
-      - $ref: '#/definitions/ListResourceTemplatesResult'
-      - $ref: '#/definitions/ReadResourceResult'
-      - $ref: '#/definitions/ListPromptsResult'
-      - $ref: '#/definitions/GetPromptResult'
-      - $ref: '#/definitions/ListToolsResult'
-      - $ref: '#/definitions/CallToolResult'
-      - $ref: '#/definitions/CompleteResult'
-  SetLevelRequest:
-    description: A request from the client to the server, to enable or adjust logging.
-    properties:
-      method:
-        const: logging/setLevel
-        type: string
-      params:
-        properties:
-          level:
-            $ref: '#/definitions/LoggingLevel'
-            description: The level of logging that the client wants to receive from the server. The server should send all logs at this level and higher (i.e., more severe) to the client as notifications/message.
-        required:
-          - level
-        type: object
-    required:
-      - method
-      - params
-    type: object
+      - $ref: '#/$defs/Result'
+      - $ref: '#/$defs/InputRequiredResult'
+      - $ref: '#/$defs/DiscoverResult'
+      - $ref: '#/$defs/ListResourcesResult'
+      - $ref: '#/$defs/ListResourceTemplatesResult'
+      - $ref: '#/$defs/ReadResourceResult'
+      - $ref: '#/$defs/SubscriptionsListenResult'
+      - $ref: '#/$defs/ListPromptsResult'
+      - $ref: '#/$defs/GetPromptResult'
+      - $ref: '#/$defs/ListToolsResult'
+      - $ref: '#/$defs/CallToolResult'
+      - $ref: '#/$defs/CompleteResult'
+  SingleSelectEnumSchema:
+    anyOf:
+      - $ref: '#/$defs/UntitledSingleSelectEnumSchema'
+      - $ref: '#/$defs/TitledSingleSelectEnumSchema'
   StringSchema:
     properties:
+      default:
+        type: string
       description:
         type: string
       format:
@@ -1742,34 +2855,150 @@ definitions:
     required:
       - type
     type: object
-  SubscribeRequest:
-    description: Sent from the client to request resources/updated notifications from the server whenever a particular resource changes.
+  SubscriptionFilter:
+    description: |-
+      The set of notification types a client may opt in to on a
+      {@link SubscriptionsListenRequestsubscriptions/listen} request.
+
+      Each notification type is **opt-in**; the server **MUST NOT** send
+      notification types the client has not explicitly requested here.
     properties:
+      promptsListChanged:
+        description: If true, receive {@link PromptListChangedNotificationnotifications/prompts/list_changed}.
+        type: boolean
+      resourceSubscriptions:
+        description: |-
+          Subscribe to {@link ResourceUpdatedNotificationnotifications/resources/updated} for these resource URIs.
+          Replaces the former `resources/subscribe` RPC.
+        items:
+          type: string
+        type: array
+      resourcesListChanged:
+        description: If true, receive {@link ResourceListChangedNotificationnotifications/resources/list_changed}.
+        type: boolean
+      toolsListChanged:
+        description: If true, receive {@link ToolListChangedNotificationnotifications/tools/list_changed}.
+        type: boolean
+    type: object
+  SubscriptionsAcknowledgedNotification:
+    description: |-
+      Sent by the server as the first message on a
+      {@link SubscriptionsListenRequestsubscriptions/listen} stream to acknowledge
+      that the subscription has been established and to report which notification
+      types it agreed to honor.
+    properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
-        const: resources/subscribe
+        const: notifications/subscriptions/acknowledged
         type: string
       params:
-        properties:
-          uri:
-            description: The URI of the resource to subscribe to. The URI can use any protocol; it is up to the server how to interpret it.
-            format: uri
-            type: string
-        required:
-          - uri
-        type: object
+        $ref: '#/$defs/SubscriptionsAcknowledgedNotificationParams'
     required:
+      - jsonrpc
       - method
       - params
+    type: object
+  SubscriptionsAcknowledgedNotificationParams:
+    description: Parameters for a {@link SubscriptionsAcknowledgedNotificationnotifications/subscriptions/acknowledged} notification.
+    properties:
+      _meta:
+        $ref: '#/$defs/NotificationMetaObject'
+      notifications:
+        $ref: '#/$defs/SubscriptionFilter'
+        description: |-
+          The subset of requested notification types the server agreed to honor.
+          Only includes notification types the server actually supports; if the
+          client requested an unsupported type (e.g., `promptsListChanged` when
+          the server has no prompts), it is omitted from this set.
+    required:
+      - notifications
+    type: object
+  SubscriptionsListenRequest:
+    description: |-
+      Sent from the client to open a long-lived channel for receiving notifications
+      outside the context of a specific request. Replaces the previous HTTP GET
+      endpoint and ensures consistent behavior between HTTP and STDIO.
+    properties:
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+      method:
+        const: subscriptions/listen
+        type: string
+      params:
+        $ref: '#/$defs/SubscriptionsListenRequestParams'
+    required:
+      - id
+      - jsonrpc
+      - method
+      - params
+    type: object
+  SubscriptionsListenRequestParams:
+    description: Parameters for a {@link SubscriptionsListenRequestsubscriptions/listen} request.
+    properties:
+      _meta:
+        $ref: '#/$defs/RequestMetaObject'
+      notifications:
+        $ref: '#/$defs/SubscriptionFilter'
+        description: |-
+          The notifications the client opts in to on this stream. The server
+          **MUST NOT** send notification types the client has not explicitly
+          requested.
+    required:
+      - _meta
+      - notifications
+    type: object
+  SubscriptionsListenResult:
+    description: |-
+      The response to a {@link SubscriptionsListenRequestsubscriptions/listen}
+      request, signalling that the subscription has ended gracefully (for example,
+      during server shutdown). Because the listen stream is long-lived, this result
+      is sent only when the server tears the subscription down; an abrupt transport
+      close carries no response. The result body is otherwise empty.
+    properties:
+      _meta:
+        $ref: '#/$defs/SubscriptionsListenResultMeta'
+      resultType:
+        description: |-
+          Indicates the type of the result, which allows the client to determine
+          how to parse the result object.
+
+          Servers implementing this protocol version MUST include this field.
+          For backward compatibility, when a client receives a result from a
+          server implementing an earlier protocol version (which does not include
+          `resultType`), the client MUST treat the absent field as `"complete"`.
+        type: string
+    required:
+      - _meta
+      - resultType
+    type: object
+  SubscriptionsListenResultMeta:
+    description: |-
+      Extends {@link MetaObject} with the subscription-stream identifier carried by a
+      {@link SubscriptionsListenResult}. All key naming rules from `MetaObject` apply.
+    properties:
+      io.modelcontextprotocol/subscriptionId:
+        $ref: '#/$defs/RequestId'
+        description: |-
+          Identifies the subscription stream this response closes, so the client can
+          correlate it with the originating subscription — mirroring the same key on
+          the stream's notifications. The value is the JSON-RPC ID of the
+          `subscriptions/listen` request that opened the stream (and equals this
+          response's `id`).
+    required:
+      - io.modelcontextprotocol/subscriptionId
     type: object
   TextContent:
     description: Text provided to or from an LLM.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/Annotations'
+        $ref: '#/$defs/Annotations'
         description: Optional annotations for the client.
       text:
         description: The text content of the message.
@@ -1784,9 +3013,7 @@ definitions:
   TextResourceContents:
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       mimeType:
         description: The MIME type of this resource, if known.
         type: string
@@ -1801,38 +3028,139 @@ definitions:
       - text
       - uri
     type: object
+  TitledMultiSelectEnumSchema:
+    description: Schema for multiple-selection enumeration with display titles for each option.
+    properties:
+      default:
+        description: Optional default value.
+        items:
+          type: string
+        type: array
+      description:
+        description: Optional description for the enum field.
+        type: string
+      items:
+        description: Schema for array items with enum options and display labels.
+        properties:
+          anyOf:
+            description: Array of enum options with values and display labels.
+            items:
+              properties:
+                const:
+                  description: The constant enum value.
+                  type: string
+                title:
+                  description: Display title for this option.
+                  type: string
+              required:
+                - const
+                - title
+              type: object
+            type: array
+        required:
+          - anyOf
+        type: object
+      maxItems:
+        description: Maximum number of items to select.
+        type: integer
+      minItems:
+        description: Minimum number of items to select.
+        type: integer
+      title:
+        description: Optional title for the enum field.
+        type: string
+      type:
+        const: array
+        type: string
+    required:
+      - items
+      - type
+    type: object
+  TitledSingleSelectEnumSchema:
+    description: Schema for single-selection enumeration with display titles for each option.
+    properties:
+      default:
+        description: Optional default value.
+        type: string
+      description:
+        description: Optional description for the enum field.
+        type: string
+      oneOf:
+        description: Array of enum options with values and display labels.
+        items:
+          properties:
+            const:
+              description: The enum value.
+              type: string
+            title:
+              description: Display label for this option.
+              type: string
+          required:
+            - const
+            - title
+          type: object
+        type: array
+      title:
+        description: Optional title for the enum field.
+        type: string
+      type:
+        const: string
+        type: string
+    required:
+      - oneOf
+      - type
+    type: object
   Tool:
     description: Definition for a tool the client can call.
     properties:
       _meta:
-        additionalProperties: {}
-        description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-        type: object
+        $ref: '#/$defs/MetaObject'
       annotations:
-        $ref: '#/definitions/ToolAnnotations'
+        $ref: '#/$defs/ToolAnnotations'
         description: |-
           Optional additional tool information.
 
-          Display name precedence order is: title, annotations.title, then name.
+          Display name precedence order is: `title`, `annotations.title`, then `name`.
       description:
         description: |-
           A human-readable description of the tool.
 
           This can be used by clients to improve the LLM's understanding of available tools. It can be thought of like a "hint" to the model.
         type: string
+      icons:
+        description: |-
+          Optional set of sized icons that the client can display in a user interface.
+
+          Clients that support rendering icons MUST support at least the following MIME types:
+          - `image/png` - PNG images (safe, universal compatibility)
+          - `image/jpeg` (and `image/jpg`) - JPEG images (safe, universal compatibility)
+
+          Clients that support rendering icons SHOULD also support:
+          - `image/svg+xml` - SVG images (scalable but requires security precautions)
+          - `image/webp` - WebP images (modern, efficient format)
+        items:
+          $ref: '#/$defs/Icon'
+        type: array
       inputSchema:
-        description: A JSON Schema object defining the expected parameters for the tool.
+        additionalProperties: {}
+        description: |-
+          A JSON Schema object defining the expected parameters for the tool.
+
+          Tool arguments are always JSON objects, so `type: "object"` is required at the root.
+          Beyond that, any JSON Schema 2020-12 keyword may appear alongside `type` — including
+          composition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords
+          (`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other
+          standard validation or annotation keywords.
+
+          Property schemas may carry an `x-mcp-header` annotation to mirror the
+          argument value into an HTTP header on the Streamable HTTP transport. See
+          the Streamable HTTP transport specification for the validity and
+          extraction rules.
+
+          Defaults to JSON Schema 2020-12 when no explicit `$schema` is provided.
         properties:
-          properties:
-            additionalProperties:
-              additionalProperties: true
-              properties: {}
-              type: object
-            type: object
-          required:
-            items:
-              type: string
-            type: array
+          $schema:
+            type: string
           type:
             const: object
             type: string
@@ -1843,32 +3171,22 @@ definitions:
         description: Intended for programmatic or logical use, but used as a display name in past specs or fallback (if title isn't present).
         type: string
       outputSchema:
+        additionalProperties: {}
         description: |-
           An optional JSON Schema object defining the structure of the tool's output returned in
-          the structuredContent field of a CallToolResult.
+          the structuredContent field of a {@link CallToolResult}. This can be any valid JSON Schema 2020-12.
+
+          Defaults to JSON Schema 2020-12 when no explicit `$schema` is provided.
         properties:
-          properties:
-            additionalProperties:
-              additionalProperties: true
-              properties: {}
-              type: object
-            type: object
-          required:
-            items:
-              type: string
-            type: array
-          type:
-            const: object
+          $schema:
             type: string
-        required:
-          - type
         type: object
       title:
         description: |-
           Intended for UI and end-user contexts — optimized to be human-readable and easily understood,
           even by those unfamiliar with domain-specific terminology.
 
-          If not provided, the name should be used for display (except for Tool,
+          If not provided, the name should be used for display (except for {@link Tool},
           where `annotations.title` should be given precedence over using `name`,
           if present).
         type: string
@@ -1878,13 +3196,13 @@ definitions:
     type: object
   ToolAnnotations:
     description: |-
-      Additional properties describing a Tool to clients.
+      Additional properties describing a {@link Tool} to clients.
 
-      NOTE: all properties in ToolAnnotations are **hints**.
+      NOTE: all properties in `ToolAnnotations` are **hints**.
       They are not guaranteed to provide a faithful description of
       tool behavior (including descriptive properties like `title`).
 
-      Clients should never make tool use decisions based on ToolAnnotations
+      Clients should never make tool use decisions based on `ToolAnnotations`
       received from untrusted servers.
     properties:
       destructiveHint:
@@ -1899,7 +3217,7 @@ definitions:
       idempotentHint:
         description: |-
           If true, calling the tool repeatedly with the same arguments
-          will have no additional effect on the its environment.
+          will have no additional effect on its environment.
 
           (This property is meaningful only when `readOnlyHint == false`)
 
@@ -1924,39 +3242,216 @@ definitions:
         description: A human-readable title for the tool.
         type: string
     type: object
-  ToolListChangedNotification:
-    description: An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.
+  ToolChoice:
+    description: Controls tool selection behavior for sampling requests.
     properties:
+      mode:
+        description: |-
+          Controls the tool use ability of the model:
+          - `"auto"`: Model decides whether to use tools (default)
+          - `"required"`: Model MUST use at least one tool before completing
+          - `"none"`: Model MUST NOT use any tools
+        enum:
+          - auto
+          - none
+          - required
+        type: string
+    type: object
+  ToolListChangedNotification:
+    description: An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequestsubscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.
+    properties:
+      jsonrpc:
+        const: '2.0'
+        type: string
       method:
         const: notifications/tools/list_changed
         type: string
       params:
-        additionalProperties: {}
-        properties:
-          _meta:
-            additionalProperties: {}
-            description: See [specification/draft/basic/index#general-fields] for notes on _meta usage.
-            type: object
-        type: object
+        $ref: '#/$defs/NotificationParams'
     required:
+      - jsonrpc
       - method
     type: object
-  UnsubscribeRequest:
-    description: Sent from the client to request cancellation of resources/updated notifications from the server. This should follow a previous resources/subscribe request.
+  ToolResultContent:
+    description: The result of a tool use, provided by the user back to the assistant.
     properties:
-      method:
-        const: resources/unsubscribe
+      _meta:
+        $ref: '#/$defs/MetaObject'
+        description: |-
+          Optional metadata about the tool result. Clients SHOULD preserve this field when
+          including tool results in subsequent sampling requests to enable caching optimizations.
+      content:
+        description: |-
+          The unstructured result content of the tool use.
+
+          This has the same format as {@link CallToolResult.content} and can include text, images,
+          audio, resource links, and embedded resources.
+        items:
+          $ref: '#/$defs/ContentBlock'
+        type: array
+      isError:
+        description: |-
+          Whether the tool use resulted in an error.
+
+          If true, the content typically describes the error that occurred.
+          Default: false
+        type: boolean
+      structuredContent:
+        description: |-
+          An optional structured result value.
+
+          This can be any JSON value (object, array, string, number, boolean, or null).
+          If the tool defined an {@link Tool.outputSchema}, this SHOULD conform to that schema.
+      toolUseId:
+        description: |-
+          The ID of the tool use this result corresponds to.
+
+          This MUST match the ID from a previous {@link ToolUseContent}.
         type: string
-      params:
+      type:
+        const: tool_result
+        type: string
+    required:
+      - content
+      - toolUseId
+      - type
+    type: object
+  ToolUseContent:
+    description: A request from the assistant to call a tool.
+    properties:
+      _meta:
+        $ref: '#/$defs/MetaObject'
+        description: |-
+          Optional metadata about the tool use. Clients SHOULD preserve this field when
+          including tool uses in subsequent sampling requests to enable caching optimizations.
+      id:
+        description: |-
+          A unique identifier for this tool use.
+
+          This ID is used to match tool results to their corresponding tool uses.
+        type: string
+      input:
+        additionalProperties: {}
+        description: The arguments to pass to the tool, conforming to the tool's input schema.
+        type: object
+      name:
+        description: The name of the tool to call.
+        type: string
+      type:
+        const: tool_use
+        type: string
+    required:
+      - id
+      - input
+      - name
+      - type
+    type: object
+  UnsupportedProtocolVersionError:
+    description: |-
+      Returned when the request's protocol version is unknown to the server or
+      unsupported (e.g., a known experimental or draft version the server has
+      chosen not to implement). For HTTP, the response status code MUST be
+      `400 Bad Request`.
+    properties:
+      error:
+        allOf:
+          - $ref: '#/$defs/Error'
+          - properties:
+              code:
+                const: -32022
+                type: integer
+              data:
+                properties:
+                  requested:
+                    description: The protocol version that was requested by the client.
+                    type: string
+                  supported:
+                    description: |-
+                      Protocol versions the server supports. The client should choose a
+                      mutually supported version from this list and retry.
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - requested
+                  - supported
+                type: object
+            required:
+              - code
+              - data
+            type: object
+      id:
+        $ref: '#/$defs/RequestId'
+      jsonrpc:
+        const: '2.0'
+        type: string
+    required:
+      - error
+      - jsonrpc
+    type: object
+  UntitledMultiSelectEnumSchema:
+    description: Schema for multiple-selection enumeration without display titles for options.
+    properties:
+      default:
+        description: Optional default value.
+        items:
+          type: string
+        type: array
+      description:
+        description: Optional description for the enum field.
+        type: string
+      items:
+        description: Schema for the array items.
         properties:
-          uri:
-            description: The URI of the resource to unsubscribe from.
-            format: uri
+          enum:
+            description: Array of enum values to choose from.
+            items:
+              type: string
+            type: array
+          type:
+            const: string
             type: string
         required:
-          - uri
+          - enum
+          - type
         type: object
+      maxItems:
+        description: Maximum number of items to select.
+        type: integer
+      minItems:
+        description: Minimum number of items to select.
+        type: integer
+      title:
+        description: Optional title for the enum field.
+        type: string
+      type:
+        const: array
+        type: string
     required:
-      - method
-      - params
+      - items
+      - type
+    type: object
+  UntitledSingleSelectEnumSchema:
+    description: Schema for single-selection enumeration without display titles for options.
+    properties:
+      default:
+        description: Optional default value.
+        type: string
+      description:
+        description: Optional description for the enum field.
+        type: string
+      enum:
+        description: Array of enum values to choose from.
+        items:
+          type: string
+        type: array
+      title:
+        description: Optional title for the enum field.
+        type: string
+      type:
+        const: string
+        type: string
+    required:
+      - enum
+      - type
     type: object


### PR DESCRIPTION
## Summary

Re-syncs `internal/mcp/mcp-schema.{json,yaml}` from `schemas@main` (v0.4.0, includes inference-gateway/schemas#105) and regenerates `internal/mcp/generated_types.go`.

- Adds `SubscriptionsListenResult` / `SubscriptionsListenResultMeta` Go types (subscription lifecycle teardown, correlated via `io.modelcontextprotocol/subscriptionId`).
- Additive-only upstream sync; no gateway behavior change — nothing references the new types yet.
- Checks off the re-sync/regenerate task in #424; lifecycle handling in the MCP client/transport remains follow-up work tracked there.

Part of #424.

no docs ticket: schema/type sync only, no user-facing behavior change