### PR TITLE
fix(providers): Regenerate with corrected Z.AI base URL

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -109,6 +109,6 @@
 | MOONSHOT_API_KEY | `""` | Moonshot API Key |
 | NVIDIA_API_URL | `https://integrate.api.nvidia.com/v1` | NVIDIA API URL |
 | NVIDIA_API_KEY | `""` | NVIDIA API Key |
-| ZAI_API_URL | `https://api.z.ai/v1` | ZAI API URL |
+| ZAI_API_URL | `https://api.z.ai/api/paas/v4` | ZAI API URL |
 | ZAI_API_KEY | `""` | ZAI API Key |
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -828,7 +828,7 @@ components:
               endpoint: '/chat/completions'
         zai:
           id: 'zai'
-          url: 'https://api.z.ai/v1'
+          url: 'https://api.z.ai/api/paas/v4'
           auth_type: 'bearer'
           supports_vision: true
           endpoints:
@@ -2871,7 +2871,7 @@ components:
                 - name: zai_api_url
                   env: 'ZAI_API_URL'
                   type: string
-                  default: 'https://api.z.ai/v1'
+                  default: 'https://api.z.ai/api/paas/v4'
                   description: 'ZAI API URL'
                 - name: zai_api_key
                   env: 'ZAI_API_KEY'

--- a/providers/constants/constants.go
+++ b/providers/constants/constants.go
@@ -29,7 +29,7 @@ const (
 	OllamaDefaultBaseURL      = "http://ollama:8080/v1"
 	OllamaCloudDefaultBaseURL = "https://ollama.com/v1"
 	OpenaiDefaultBaseURL      = "https://api.openai.com/v1"
-	ZaiDefaultBaseURL         = "https://api.z.ai/v1"
+	ZaiDefaultBaseURL         = "https://api.z.ai/api/paas/v4"
 )
 
 // The default endpoints of each provider


### PR DESCRIPTION
## Problem

`ZaiDefaultBaseURL` pointed at `https://api.z.ai/v1`, which does not exist on Z.AI's API (nginx 404), so `/proxy/zai/models` and all Z.AI requests failed. The correct OpenAI-compatible base is `https://api.z.ai/api/paas/v4`. Fixed at the source in inference-gateway/schemas#129 (released); this PR re-vendors the spec and regenerates.

## Changes

- `task openapi:download` — vendored the updated `openapi.yaml`
- `task generate` — regenerated `providers/constants/constants.go` (`ZaiDefaultBaseURL`) and `Configurations.md` (`ZAI_API_URL` default)

No hand-edits; all generated. `go build ./...` and provider/config tests pass.