### PR TITLE
fix: align pricing and context-window types with upstream openapi schema

### DIFF
--- a/.github/workflows/sync-community-tables.yml
+++ b/.github/workflows/sync-community-tables.yml
@@ -20,7 +20,7 @@ jobs:
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@v7.0.1
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -39,7 +39,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Open pull request if tables changed
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: chore/sync-community-tables

--- a/.github/workflows/sync-community-tables.yml
+++ b/.github/workflows/sync-community-tables.yml
@@ -1,0 +1,64 @@
+---
+name: Sync Community Tables
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/create-github-app-token@v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
+      - name: Get app user id
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout code
+        uses: actions/checkout@v7.0.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v7.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Sync tables from models.dev
+        run: |
+          gh api repos/sst/models.dev/tarball > /tmp/models.dev.tar.gz
+          go run cmd/generate/main.go -type CommunityPricing -input /tmp/models.dev.tar.gz -output providers/core/community_pricing.json
+          go run cmd/generate/main.go -type CommunityContextWindows -input /tmp/models.dev.tar.gz -output providers/core/community_context_windows.json
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Open pull request if tables changed
+        run: |
+          if git diff --quiet; then
+            echo "Community tables are up to date."
+            exit 0
+          fi
+          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
+          git checkout -B chore/sync-community-tables
+          git add providers/core/community_pricing.json providers/core/community_context_windows.json
+          git commit -m 'fix: sync community pricing and context-window tables from models.dev'
+          git push -f origin chore/sync-community-tables
+          gh pr create \
+            --title 'fix: sync community pricing and context-window tables from models.dev' \
+            --body 'Automated weekly sync of `community_pricing.json` and `community_context_windows.json` from the [models.dev](https://github.com/sst/models.dev) dataset. Only entries whose values changed carry a new `updated_at`.' \
+            || echo "PR already open; branch updated."
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sync-community-tables.yml
+++ b/.github/workflows/sync-community-tables.yml
@@ -3,7 +3,7 @@ name: Sync Community Tables
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # weekly, Monday 06:00 UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:
@@ -18,12 +18,6 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASER_APP_ID }}
           private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
-
-      - name: Get app user id
-        id: get-user-id
-        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout code
         uses: actions/checkout@v7.0.0
@@ -45,20 +39,16 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Open pull request if tables changed
-        run: |
-          if git diff --quiet; then
-            echo "Community tables are up to date."
-            exit 0
-          fi
-          git config user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
-          git config user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com'
-          git checkout -B chore/sync-community-tables
-          git add providers/core/community_pricing.json providers/core/community_context_windows.json
-          git commit -m 'fix: sync community pricing and context-window tables from models.dev'
-          git push -f origin chore/sync-community-tables
-          gh pr create \
-            --title 'fix: sync community pricing and context-window tables from models.dev' \
-            --body 'Automated weekly sync of `community_pricing.json` and `community_context_windows.json` from the [models.dev](https://github.com/sst/models.dev) dataset. Only entries whose values changed carry a new `updated_at`.' \
-            || echo "PR already open; branch updated."
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        uses: peter-evans/create-pull-request@v7.0.8
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: chore/sync-community-tables
+          add-paths: providers/core/community_pricing.json,providers/core/community_context_windows.json
+          commit-message: 'fix: sync community pricing and context-window tables from models.dev'
+          title: 'fix: sync community pricing and context-window tables from models.dev'
+          body: >-
+            Automated weekly sync of `community_pricing.json` and
+            `community_context_windows.json` from the
+            [models.dev](https://github.com/sst/models.dev) dataset. Only
+            entries whose values changed carry a new `updated_at`.
+          delete-branch: true

--- a/api/context_window.go
+++ b/api/context_window.go
@@ -52,8 +52,8 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 					return
 				}
 				for _, i := range indexes {
-					models[i].ContextWindow = &types.ModelContextWindow{
-						Tokens: tokens,
+					models[i].ContextWindow = &types.ContextWindow{
+						Tokens: int(tokens),
 						Source: types.ContextWindowSourceRuntime,
 					}
 				}
@@ -66,8 +66,8 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 						router.logger.Debug("failed to resolve runtime context window", "provider", providerID, "model", models[i].ID, "error", err)
 						return
 					}
-					models[i].ContextWindow = &types.ModelContextWindow{
-						Tokens: tokens,
+					models[i].ContextWindow = &types.ContextWindow{
+						Tokens: int(tokens),
 						Source: types.ContextWindowSourceRuntime,
 					}
 				})

--- a/api/context_window.go
+++ b/api/context_window.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -53,7 +54,7 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 				}
 				for _, i := range indexes {
 					models[i].ContextWindow = &types.ContextWindow{
-						Tokens: int(tokens),
+						Tokens: tokens,
 						Source: types.ContextWindowSourceRuntime,
 					}
 				}
@@ -66,13 +67,8 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 						router.logger.Debug("failed to resolve runtime context window", "provider", providerID, "model", models[i].ID, "error", err)
 						return
 					}
-					maxInt := int64(^uint(0) >> 1)
-					if tokens <= 0 || tokens > maxInt {
-						router.logger.Debug("invalid runtime context window", "provider", providerID, "model", models[i].ID, "tokens", tokens)
-						return
-					}
 					models[i].ContextWindow = &types.ContextWindow{
-						Tokens: int(tokens),
+						Tokens: tokens,
 						Source: types.ContextWindowSourceRuntime,
 					}
 				})
@@ -85,8 +81,9 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 // fetchLlamacppContextWindow reads the serving configuration from llama.cpp's
 // /props endpoint; default_generation_settings.n_ctx is the effective context
 // size the server was started with (--ctx-size), which can be smaller than the
-// model's theoretical maximum.
-func (router *RouterImpl) fetchLlamacppContextWindow(ctx context.Context, providerID types.Provider) (int64, error) {
+// model's theoretical maximum. Fetchers validate range and return int so call
+// sites never convert untrusted 64-bit values themselves.
+func (router *RouterImpl) fetchLlamacppContextWindow(ctx context.Context, providerID types.Provider) (int, error) {
 	var props struct {
 		DefaultGenerationSettings struct {
 			NCtx int64 `json:"n_ctx"`
@@ -95,16 +92,17 @@ func (router *RouterImpl) fetchLlamacppContextWindow(ctx context.Context, provid
 	if err := router.runtimeAPICall(ctx, providerID, http.MethodGet, "/props", nil, &props); err != nil {
 		return 0, err
 	}
-	if props.DefaultGenerationSettings.NCtx <= 0 {
-		return 0, fmt.Errorf("llama.cpp /props returned no context size")
+	tokens := props.DefaultGenerationSettings.NCtx
+	if tokens <= 0 || tokens > math.MaxInt {
+		return 0, fmt.Errorf("llama.cpp /props returned no usable context size (%d)", tokens)
 	}
-	return props.DefaultGenerationSettings.NCtx, nil
+	return int(tokens), nil
 }
 
 // fetchOllamaContextWindow reads per-model metadata from Ollama's show API: a
 // num_ctx entry in parameters when the modelfile overrides the context size,
 // falling back to the architecture's context_length in model_info.
-func (router *RouterImpl) fetchOllamaContextWindow(ctx context.Context, providerID types.Provider, modelID string) (int64, error) {
+func (router *RouterImpl) fetchOllamaContextWindow(ctx context.Context, providerID types.Provider, modelID string) (int, error) {
 	name := strings.TrimPrefix(modelID, string(providerID)+"/")
 	body, err := json.Marshal(map[string]string{"model": name})
 	if err != nil {
@@ -122,7 +120,7 @@ func (router *RouterImpl) fetchOllamaContextWindow(ctx context.Context, provider
 	for line := range strings.Lines(show.Parameters) {
 		fields := strings.Fields(line)
 		if len(fields) == 2 && fields[0] == "num_ctx" {
-			if tokens, err := strconv.ParseInt(fields[1], 10, 64); err == nil && tokens > 0 {
+			if tokens, err := strconv.Atoi(fields[1]); err == nil && tokens > 0 {
 				return tokens, nil
 			}
 		}
@@ -131,8 +129,8 @@ func (router *RouterImpl) fetchOllamaContextWindow(ctx context.Context, provider
 		if !strings.HasSuffix(key, ".context_length") {
 			continue
 		}
-		if tokens, ok := value.(float64); ok && tokens > 0 {
-			return int64(tokens), nil
+		if tokens, ok := value.(float64); ok && tokens > 0 && tokens < math.MaxInt {
+			return int(tokens), nil
 		}
 	}
 	return 0, fmt.Errorf("ollama show returned no context length for %s", name)

--- a/api/context_window.go
+++ b/api/context_window.go
@@ -66,6 +66,11 @@ func (router *RouterImpl) resolveContextWindows(ctx context.Context, models []ty
 						router.logger.Debug("failed to resolve runtime context window", "provider", providerID, "model", models[i].ID, "error", err)
 						return
 					}
+					maxInt := int64(^uint(0) >> 1)
+					if tokens <= 0 || tokens > maxInt {
+						router.logger.Debug("invalid runtime context window", "provider", providerID, "model", models[i].ID, "tokens", tokens)
+						return
+					}
 					models[i].ContextWindow = &types.ContextWindow{
 						Tokens: int(tokens),
 						Source: types.ContextWindowSourceRuntime,

--- a/api/routes.go
+++ b/api/routes.go
@@ -338,12 +338,12 @@ func parseIncludeParam(raw string) ([]string, error) {
 // is written unchanged so the default payload stays byte-for-byte
 // OpenAI-compatible.
 func (router *RouterImpl) renderModelsResponse(c *gin.Context, resp types.ListModelsResponse, includeKeys []string) {
-	if !slices.Contains(includeKeys, string(types.ContextWindow)) {
+	if !slices.Contains(includeKeys, string(types.ListModelsParamsIncludeContextWindow)) {
 		for i := range resp.Data {
 			resp.Data[i].ContextWindow = nil
 		}
 	}
-	if !slices.Contains(includeKeys, string(types.Pricing)) {
+	if !slices.Contains(includeKeys, string(types.ListModelsParamsIncludePricing)) {
 		for i := range resp.Data {
 			resp.Data[i].Pricing = nil
 		}
@@ -456,7 +456,7 @@ func (router *RouterImpl) ListModelsHandler(c *gin.Context) {
 
 		response.Data = routing.FilterModels(response.Data, router.cfg.AllowedModels, router.cfg.DisallowedModels)
 
-		if slices.Contains(includeKeys, string(types.ContextWindow)) {
+		if slices.Contains(includeKeys, string(types.ListModelsParamsIncludeContextWindow)) {
 			router.resolveContextWindows(ctx, response.Data)
 		}
 
@@ -512,7 +512,7 @@ func (router *RouterImpl) ListModelsHandler(c *gin.Context) {
 
 		allModels = routing.FilterModels(allModels, router.cfg.AllowedModels, router.cfg.DisallowedModels)
 
-		if slices.Contains(includeKeys, string(types.ContextWindow)) {
+		if slices.Contains(includeKeys, string(types.ListModelsParamsIncludeContextWindow)) {
 			router.resolveContextWindows(ctx, allModels)
 		}
 

--- a/internal/pricinggen/pricinggen.go
+++ b/internal/pricinggen/pricinggen.go
@@ -73,6 +73,10 @@ type contextWindowEntry struct {
 func Generate(output, tarballPath string) error {
 	table := make(map[string]types.Pricing)
 	syncedAt := time.Now().UTC().Truncate(time.Second)
+	prior := make(map[string]types.Pricing)
+	if data, err := os.ReadFile(output); err == nil {
+		_ = json.Unmarshal(data, &prior)
+	}
 	err := forEachModel(tarballPath, func(key string, model modelTOML) {
 		if model.Cost == nil {
 			return
@@ -82,7 +86,7 @@ func Generate(output, tarballPath string) error {
 		if input == nil || outputRate == nil {
 			return
 		}
-		table[key] = types.Pricing{
+		entry := types.Pricing{
 			Currency:           "USD",
 			InputPerToken:      *input,
 			OutputPerToken:     *outputRate,
@@ -91,6 +95,10 @@ func Generate(output, tarballPath string) error {
 			Source:             types.PricingSourceCommunity,
 			UpdatedAt:          syncedAt,
 		}
+		if old, ok := prior[key]; ok && sameRates(old, entry) {
+			entry.UpdatedAt = old.UpdatedAt
+		}
+		table[key] = entry
 	})
 	if err != nil {
 		return err
@@ -198,6 +206,22 @@ func tableKey(name string) (string, bool) {
 		return "", false
 	}
 	return provider + "/" + model, true
+}
+
+// sameRates reports whether two pricing entries carry identical rates,
+// ignoring UpdatedAt, so re-syncs keep the prior timestamp for unchanged
+// entries instead of rewriting the whole committed table.
+func sameRates(a, b types.Pricing) bool {
+	return a.Currency == b.Currency &&
+		a.InputPerToken == b.InputPerToken &&
+		a.OutputPerToken == b.OutputPerToken &&
+		a.Source == b.Source &&
+		eqRate(a.CacheReadPerToken, b.CacheReadPerToken) &&
+		eqRate(a.CacheWritePerToken, b.CacheWritePerToken)
+}
+
+func eqRate(a, b *string) bool {
+	return a == b || (a != nil && b != nil && *a == *b)
 }
 
 // freeOrRate maps an input/output rate from a present cost section: an

--- a/internal/pricinggen/pricinggen.go
+++ b/internal/pricinggen/pricinggen.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	toml "github.com/pelletier/go-toml/v2"
 
@@ -70,23 +71,25 @@ type contextWindowEntry struct {
 // `gh api repos/sst/models.dev/tarball`) and writes the community pricing
 // table keyed by "<provider>/<model>" to output.
 func Generate(output, tarballPath string) error {
-	table := make(map[string]types.ModelPricing)
+	table := make(map[string]types.Pricing)
+	syncedAt := time.Now().UTC().Truncate(time.Second)
 	err := forEachModel(tarballPath, func(key string, model modelTOML) {
 		if model.Cost == nil {
 			return
 		}
 		input := freeOrRate(model.Cost.Input)
 		outputRate := freeOrRate(model.Cost.Output)
-		if input == nil && outputRate == nil {
+		if input == nil || outputRate == nil {
 			return
 		}
-		table[key] = types.ModelPricing{
+		table[key] = types.Pricing{
 			Currency:           "USD",
-			InputPerToken:      input,
-			OutputPerToken:     outputRate,
+			InputPerToken:      *input,
+			OutputPerToken:     *outputRate,
 			CacheReadPerToken:  perMTokToPerToken(model.Cost.CacheRead),
 			CacheWritePerToken: perMTokToPerToken(model.Cost.CacheWrite),
 			Source:             types.PricingSourceCommunity,
+			UpdatedAt:          syncedAt,
 		}
 	})
 	if err != nil {

--- a/internal/pricinggen/pricinggen_test.go
+++ b/internal/pricinggen/pricinggen_test.go
@@ -136,6 +136,45 @@ func TestGenerate_FreeVsUnpublished(t *testing.T) {
 	}
 }
 
+// TestGenerate_PreservesTimestampsForUnchangedRates re-syncs over an existing
+// table: entries whose rates did not change keep their prior updated_at, while
+// changed entries get a fresh stamp.
+func TestGenerate_PreservesTimestampsForUnchangedRates(t *testing.T) {
+	tarball := writeTarball(t, map[string]string{
+		"sst-models.dev-abc/providers/openai/models/gpt-same.toml":    "[cost]\ninput = 3.0\noutput = 15.0\n",
+		"sst-models.dev-abc/providers/openai/models/gpt-changed.toml": "[cost]\ninput = 4.0\noutput = 15.0\n",
+	})
+
+	output := filepath.Join(t.TempDir(), "pricing.json")
+	prior := `{
+		"openai/gpt-same": {"currency":"USD","input_per_token":"0.000003","output_per_token":"0.000015","source":"community","updated_at":"2020-01-02T03:04:05Z"},
+		"openai/gpt-changed": {"currency":"USD","input_per_token":"0.000003","output_per_token":"0.000015","source":"community","updated_at":"2020-01-02T03:04:05Z"}
+	}`
+	if err := os.WriteFile(output, []byte(prior), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Generate(output, tarball); err != nil {
+		t.Fatalf("Generate() = %v", err)
+	}
+
+	data, err := os.ReadFile(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var table map[string]types.Pricing
+	if err := json.Unmarshal(data, &table); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := table["openai/gpt-same"].UpdatedAt.Format("2006-01-02T15:04:05Z"); got != "2020-01-02T03:04:05Z" {
+		t.Errorf("unchanged entry updated_at = %s, want prior timestamp preserved", got)
+	}
+	if got := table["openai/gpt-changed"].UpdatedAt.Year(); got == 2020 {
+		t.Error("changed entry must get a fresh updated_at, kept the prior one")
+	}
+}
+
 // TestGenerateContextWindows covers the limit states in models.dev files: a
 // published context limit emits an entry (with output tokens when present),
 // an absent limit section emits no entry, and unsupported providers are

--- a/internal/pricinggen/pricinggen_test.go
+++ b/internal/pricinggen/pricinggen_test.go
@@ -115,7 +115,7 @@ func TestGenerate_FreeVsUnpublished(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var table map[string]types.ModelPricing
+	var table map[string]types.Pricing
 	if err := json.Unmarshal(data, &table); err != nil {
 		t.Fatal(err)
 	}
@@ -124,14 +124,14 @@ func TestGenerate_FreeVsUnpublished(t *testing.T) {
 	if !ok {
 		t.Fatal("free-tier model with explicit zero cost missing from table")
 	}
-	if free.InputPerToken == nil || *free.InputPerToken != "0" || free.OutputPerToken == nil || *free.OutputPerToken != "0" {
+	if free.InputPerToken != "0" || free.OutputPerToken != "0" {
 		t.Errorf("free-tier rates = %v/%v, want \"0\"/\"0\"", free.InputPerToken, free.OutputPerToken)
 	}
 	if _, ok := table["ollama_cloud/kimi-sub"]; ok {
 		t.Error("model without a cost section must not get an entry")
 	}
 	paid, ok := table["openai/gpt-paid"]
-	if !ok || paid.InputPerToken == nil || *paid.InputPerToken != "0.000003" {
+	if !ok || paid.InputPerToken != "0.000003" {
 		t.Errorf("paid model entry = %+v, want input_per_token 0.000003", paid)
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -80,15 +80,10 @@ paths:
               enum:
                 - context_window
                 - pricing
-          description: >
-            Optional comma-separated list of additional per-model metadata
-            fields to include in the response. Supported keys: `context_window`,
-            `pricing`. Keys are trimmed and de-duplicated; an unknown key returns
-            400. When omitted, the response contains no metadata fields and stays
-            byte-for-byte OpenAI-compatible. A requested key that cannot be
-            resolved is returned as an explicit `null`, distinguishing "not
-            requested" (key absent) from "requested but unavailable" (key present,
-            value null).
+          description: |
+            Comma-separated list of metadata keys to include in the response.
+            Supported values: `pricing`, `context_window`.
+            When omitted, the response remains unchanged (backward compatible).
       responses:
         '200':
           description: List of available models
@@ -157,6 +152,99 @@ paths:
                         created: 1677649963
                         owned_by: 'openai'
                         served_by: 'openai'
+                includePricing:
+                  summary: Models with pricing metadata
+                  value:
+                    object: 'list'
+                    data:
+                      - id: 'openai/gpt-4o'
+                        object: 'model'
+                        created: 1686935002
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        pricing:
+                          currency: 'USD'
+                          input_per_token: '0.0000025'
+                          output_per_token: '0.00001'
+                          cache_read_per_token: '0.00000125'
+                          cache_write_per_token: '0.0000025'
+                          source: 'provider'
+                          updated_at: '2025-01-01T00:00:00Z'
+                      - id: 'openai/gpt-4-turbo'
+                        object: 'model'
+                        created: 1687882410
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        pricing:
+                          currency: 'USD'
+                          input_per_token: '0.00001'
+                          output_per_token: '0.00003'
+                          source: 'provider'
+                          updated_at: '2025-01-01T00:00:00Z'
+                includeContextWindow:
+                  summary: Models with context window metadata
+                  value:
+                    object: 'list'
+                    data:
+                      - id: 'openai/gpt-4o'
+                        object: 'model'
+                        created: 1686935002
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        context_window:
+                          tokens: 128000
+                          source: 'provider'
+                      - id: 'openai/gpt-4-turbo'
+                        object: 'model'
+                        created: 1687882410
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        context_window:
+                          tokens: 128000
+                          source: 'provider'
+                includePricingContextWindow:
+                  summary: Models with pricing and context window metadata
+                  value:
+                    object: 'list'
+                    data:
+                      - id: 'openai/gpt-4o'
+                        object: 'model'
+                        created: 1686935002
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        pricing:
+                          currency: 'USD'
+                          input_per_token: '0.0000025'
+                          output_per_token: '0.00001'
+                          cache_read_per_token: '0.00000125'
+                          cache_write_per_token: '0.0000025'
+                          source: 'provider'
+                          updated_at: '2025-01-01T00:00:00Z'
+                        context_window:
+                          tokens: 128000
+                          source: 'provider'
+                      - id: 'openai/gpt-4-turbo'
+                        object: 'model'
+                        created: 1687882410
+                        owned_by: 'openai'
+                        served_by: 'openai'
+                        pricing:
+                          currency: 'USD'
+                          input_per_token: '0.00001'
+                          output_per_token: '0.00003'
+                          source: 'provider'
+                          updated_at: '2025-01-01T00:00:00Z'
+                        context_window:
+                          tokens: 128000
+                          source: 'provider'
+        '400':
+          description: Bad request - unsupported include value
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                error: "Unsupported include value: 'unsupported'. Supported values: pricing, context_window"
         '401':
           $ref: '#/components/responses/Unauthorized'
         '500':
@@ -1043,6 +1131,65 @@ components:
           description: Image detail level for vision processing
       required:
         - url
+    ContextWindow:
+      type: object
+      description: Context window information for a model
+      properties:
+        tokens:
+          type: integer
+          description: Maximum number of tokens the model can process in a single request
+        source:
+          type: string
+          enum:
+            - runtime
+            - provider
+            - community
+          x-enum-varnames:
+            - ContextWindowSourceRuntime
+            - ContextWindowSourceProvider
+            - ContextWindowSourceCommunity
+          description: Source of the context window information
+      required:
+        - tokens
+        - source
+    Pricing:
+      type: object
+      description: Pricing information for a model
+      properties:
+        currency:
+          type: string
+          description: Currency code for the pricing (e.g. USD)
+        input_per_token:
+          type: string
+          description: Price per input token
+        output_per_token:
+          type: string
+          description: Price per output token
+        cache_read_per_token:
+          type: string
+          description: Price per cached input token read
+        cache_write_per_token:
+          type: string
+          description: Price per cached input token write
+        source:
+          type: string
+          enum:
+            - provider
+            - community
+          x-enum-varnames:
+            - PricingSourceProvider
+            - PricingSourceCommunity
+          description: Source of the pricing information
+        updated_at:
+          type: string
+          format: date-time
+          description: Timestamp when the pricing was last updated
+      required:
+        - currency
+        - input_per_token
+        - output_per_token
+        - source
+        - updated_at
     Model:
       type: object
       description: Common model information
@@ -1059,97 +1206,21 @@ components:
         served_by:
           $ref: '#/components/schemas/Provider'
         context_window:
-          $ref: '#/components/schemas/ModelContextWindow'
+          oneOf:
+            - $ref: '#/components/schemas/ContextWindow'
+            - type: 'null'
+          description: Context window information for the model (included when `include=context_window`)
         pricing:
-          $ref: '#/components/schemas/ModelPricing'
+          oneOf:
+            - $ref: '#/components/schemas/Pricing'
+            - type: 'null'
+          description: Pricing information for the model (included when `include=pricing`)
       required:
         - id
         - object
         - created
         - owned_by
         - served_by
-    ModelContextWindow:
-      type: object
-      description: >
-        Effective context window a client may safely use for the model. Present
-        only when requested via `include=context_window`; `null` when requested
-        but the window could not be resolved. The value reflects what the
-        serving runtime is actually configured with when available, which can be
-        smaller than the model's theoretical maximum.
-      properties:
-        tokens:
-          type: integer
-          format: int64
-          description: Effective context window size in tokens.
-        source:
-          type: string
-          description: >
-            Where the value was resolved from. `runtime` means the serving
-            runtime reported its configured window (e.g. llama.cpp `/props`,
-            Ollama's show API); `provider` means the upstream provider published
-            the window in its model listing; `community` means it was synced
-            from the community-maintained models.dev dataset.
-          enum:
-            - runtime
-            - provider
-            - community
-          x-enum-varnames:
-            - ContextWindowSourceRuntime
-            - ContextWindowSourceProvider
-            - ContextWindowSourceCommunity
-      required:
-        - tokens
-        - source
-    ModelPricing:
-      type: object
-      description: >
-        Normalized public per-token pricing for the model. Present only when
-        requested via `include=pricing`; `null` when requested but the model
-        has no public per-token cost (subscription-based providers, locally
-        hosted models, or providers that publish no pricing). Monetary values
-        are decimal strings to avoid floating-point precision loss. Rates the
-        provider does not publish are omitted entirely, never `0` or `null`.
-      properties:
-        currency:
-          type: string
-          description: ISO 4217 currency code the rates are denominated in.
-        input_per_token:
-          type: string
-          description: Cost per input (prompt) token, as a decimal string.
-        output_per_token:
-          type: string
-          description: Cost per output (completion) token, as a decimal string.
-        cache_read_per_token:
-          type: string
-          description: >
-            Cost per token read from the provider's prompt cache, as a decimal
-            string. Present only when the provider publishes a cached-input
-            rate.
-        cache_write_per_token:
-          type: string
-          description: >
-            Cost per token written to the provider's prompt cache, as a decimal
-            string. Present only when the provider publishes a cache-creation
-            rate.
-        source:
-          type: string
-          description: >
-            Where the rates were resolved from. `provider` means the upstream
-            provider published them in its model listing; `community` means
-            they were synced from the community-maintained models.dev dataset.
-          enum:
-            - provider
-            - community
-          x-enum-varnames:
-            - PricingSourceProvider
-            - PricingSourceCommunity
-        updated_at:
-          type: string
-          format: date-time
-          description: When the rates were last refreshed, if known.
-      required:
-        - currency
-        - source
     ListModelsResponse:
       type: object
       description: Response structure for listing models

--- a/providers/core/community_context_window.go
+++ b/providers/core/community_context_window.go
@@ -45,8 +45,8 @@ func applyCommunityContextWindows(models []types.Model) {
 		}
 		for _, key := range communityLookupKeys(models[i].ID) {
 			if entry, ok := table[key]; ok {
-				models[i].ContextWindow = &types.ModelContextWindow{
-					Tokens: entry.Context,
+				models[i].ContextWindow = &types.ContextWindow{
+					Tokens: int(entry.Context),
 					Source: types.ContextWindowSourceCommunity,
 				}
 				break

--- a/providers/core/community_context_window.go
+++ b/providers/core/community_context_window.go
@@ -3,6 +3,7 @@ package core
 import (
 	_ "embed"
 	"encoding/json"
+	"math"
 	"sync"
 
 	types "github.com/inference-gateway/inference-gateway/providers/types"
@@ -44,7 +45,7 @@ func applyCommunityContextWindows(models []types.Model) {
 			continue
 		}
 		for _, key := range communityLookupKeys(models[i].ID) {
-			if entry, ok := table[key]; ok {
+			if entry, ok := table[key]; ok && entry.Context > 0 && entry.Context <= math.MaxInt {
 				models[i].ContextWindow = &types.ContextWindow{
 					Tokens: int(entry.Context),
 					Source: types.ContextWindowSourceCommunity,

--- a/providers/core/community_context_window_test.go
+++ b/providers/core/community_context_window_test.go
@@ -12,7 +12,7 @@ import (
 // the table stay nil.
 func TestApplyCommunityContextWindows(t *testing.T) {
 	models := []types.Model{
-		{ID: "openai/gpt-4", ContextWindow: &types.ModelContextWindow{Tokens: 4096, Source: types.ContextWindowSourceProvider}},
+		{ID: "openai/gpt-4", ContextWindow: &types.ContextWindow{Tokens: 4096, Source: types.ContextWindowSourceProvider}},
 		{ID: "openai/gpt-4"},
 		{ID: "anthropic/claude-sonnet-4-5-19990101"},
 		{ID: "openai/gpt-nonexistent"},

--- a/providers/core/community_pricing.go
+++ b/providers/core/community_pricing.go
@@ -19,8 +19,8 @@ var communityPricingJSON []byte
 // communityPricing lazily parses the embedded table once. The file is
 // generated and committed, so a parse failure is a build defect, not a
 // runtime condition; it degrades to an empty table (pricing stays null).
-var communityPricing = sync.OnceValue(func() map[string]types.ModelPricing {
-	table := make(map[string]types.ModelPricing)
+var communityPricing = sync.OnceValue(func() map[string]types.Pricing {
+	table := make(map[string]types.Pricing)
 	_ = json.Unmarshal(communityPricingJSON, &table)
 	return table
 })

--- a/providers/core/community_pricing.json
+++ b/providers/core/community_pricing.json
@@ -5,7 +5,8 @@
     "currency": "USD",
     "input_per_token": "0.00001",
     "output_per_token": "0.00005",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-haiku-4-5": {
     "cache_read_per_token": "0.0000001",
@@ -13,7 +14,8 @@
     "currency": "USD",
     "input_per_token": "0.000001",
     "output_per_token": "0.000005",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-haiku-4-5-20251001": {
     "cache_read_per_token": "0.0000001",
@@ -21,7 +23,8 @@
     "currency": "USD",
     "input_per_token": "0.000001",
     "output_per_token": "0.000005",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-1": {
     "cache_read_per_token": "0.0000015",
@@ -29,7 +32,8 @@
     "currency": "USD",
     "input_per_token": "0.000015",
     "output_per_token": "0.000075",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-1-20250805": {
     "cache_read_per_token": "0.0000015",
@@ -37,7 +41,8 @@
     "currency": "USD",
     "input_per_token": "0.000015",
     "output_per_token": "0.000075",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-5": {
     "cache_read_per_token": "0.0000005",
@@ -45,7 +50,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-5-20251101": {
     "cache_read_per_token": "0.0000005",
@@ -53,7 +59,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-6": {
     "cache_read_per_token": "0.0000005",
@@ -61,7 +68,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-7": {
     "cache_read_per_token": "0.0000005",
@@ -69,7 +77,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-opus-4-8": {
     "cache_read_per_token": "0.0000005",
@@ -77,7 +86,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-sonnet-4-5": {
     "cache_read_per_token": "0.0000003",
@@ -85,7 +95,8 @@
     "currency": "USD",
     "input_per_token": "0.000003",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-sonnet-4-5-20250929": {
     "cache_read_per_token": "0.0000003",
@@ -93,7 +104,8 @@
     "currency": "USD",
     "input_per_token": "0.000003",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-sonnet-4-6": {
     "cache_read_per_token": "0.0000003",
@@ -101,7 +113,8 @@
     "currency": "USD",
     "input_per_token": "0.000003",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "anthropic/claude-sonnet-5": {
     "cache_read_per_token": "0.0000002",
@@ -109,438 +122,507 @@
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
     "currency": "USD",
     "input_per_token": "0.000000351",
     "output_per_token": "0.000000555",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
     "currency": "USD",
     "input_per_token": "0.000000497",
     "output_per_token": "0.000004881",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/google/gemma-4-26b-a4b-it": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
     "currency": "USD",
     "input_per_token": "0.000000017",
     "output_per_token": "0.000000112",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": {
     "currency": "USD",
     "input_per_token": "0.000000152",
     "output_per_token": "0.000000287",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-3.2-11b-vision-instruct": {
     "currency": "USD",
     "input_per_token": "0.0000000485",
     "output_per_token": "0.000000676",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-3.2-1b-instruct": {
     "currency": "USD",
     "input_per_token": "0.000000027",
     "output_per_token": "0.000000201",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-3.2-3b-instruct": {
     "currency": "USD",
     "input_per_token": "0.0000000509",
     "output_per_token": "0.000000335",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
     "currency": "USD",
     "input_per_token": "0.000000293",
     "output_per_token": "0.000002253",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-4-scout-17b-16e-instruct": {
     "currency": "USD",
     "input_per_token": "0.00000027",
     "output_per_token": "0.00000085",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/meta/llama-guard-3-8b": {
     "currency": "USD",
     "input_per_token": "0.000000484",
     "output_per_token": "0.00000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
     "currency": "USD",
     "input_per_token": "0.000000351",
     "output_per_token": "0.000000555",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/moonshotai/kimi-k2.6": {
     "cache_read_per_token": "0.00000016",
     "currency": "USD",
     "input_per_token": "0.00000095",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/moonshotai/kimi-k2.7-code": {
     "cache_read_per_token": "0.00000019",
     "currency": "USD",
     "input_per_token": "0.00000095",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/openai/gpt-oss-120b": {
     "currency": "USD",
     "input_per_token": "0.00000035",
     "output_per_token": "0.00000075",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/openai/gpt-oss-20b": {
     "currency": "USD",
     "input_per_token": "0.0000002",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
     "currency": "USD",
     "input_per_token": "0.00000066",
     "output_per_token": "0.000001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
     "currency": "USD",
     "input_per_token": "0.0000000509",
     "output_per_token": "0.000000335",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/qwen/qwq-32b": {
     "currency": "USD",
     "input_per_token": "0.00000066",
     "output_per_token": "0.000001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/zai-org/glm-4.7-flash": {
     "currency": "USD",
     "input_per_token": "0.0000000605",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cloudflare/@cf/zai-org/glm-5.2": {
     "cache_read_per_token": "0.00000026",
     "currency": "USD",
     "input_per_token": "0.0000014",
     "output_per_token": "0.0000044",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-a-03-2025": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-a-plus-05-2026": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-a-reasoning-08-2025": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-a-translate-08-2025": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-a-vision-07-2025": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-r-08-2024": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.0000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-r-plus-08-2024": {
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-r7b-12-2024": {
     "currency": "USD",
     "input_per_token": "0.0000000375",
     "output_per_token": "0.00000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/command-r7b-arabic-02-2025": {
     "currency": "USD",
     "input_per_token": "0.0000000375",
     "output_per_token": "0.00000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "cohere/north-mini-code-1-0": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "deepseek/deepseek-chat": {
     "cache_read_per_token": "0.0000000028",
     "currency": "USD",
     "input_per_token": "0.00000014",
     "output_per_token": "0.00000028",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "deepseek/deepseek-reasoner": {
     "cache_read_per_token": "0.0000000028",
     "currency": "USD",
     "input_per_token": "0.00000014",
     "output_per_token": "0.00000028",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "deepseek/deepseek-v4-flash": {
     "cache_read_per_token": "0.0000000028",
     "currency": "USD",
     "input_per_token": "0.00000014",
     "output_per_token": "0.00000028",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "deepseek/deepseek-v4-pro": {
     "cache_read_per_token": "0.000000003625",
     "currency": "USD",
     "input_per_token": "0.000000435",
     "output_per_token": "0.00000087",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.0-flash": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.0-flash-lite": {
     "currency": "USD",
     "input_per_token": "0.000000075",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-flash": {
     "cache_read_per_token": "0.00000003",
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-flash-image": {
     "cache_read_per_token": "0.000000075",
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-flash-lite": {
     "cache_read_per_token": "0.00000001",
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-flash-preview-tts": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-pro": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-2.5-pro-preview-tts": {
     "currency": "USD",
     "input_per_token": "0.000001",
     "output_per_token": "0.00002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3-flash-preview": {
     "cache_read_per_token": "0.00000005",
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3-pro-image-preview": {
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.00012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3-pro-preview": {
     "cache_read_per_token": "0.0000002",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.1-flash-image-preview": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.00006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.1-flash-lite": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.1-flash-lite-preview": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.1-pro-preview": {
     "cache_read_per_token": "0.0000002",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.1-pro-preview-customtools": {
     "cache_read_per_token": "0.0000002",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-3.5-flash": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000015",
     "output_per_token": "0.000009",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-embedding-001": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-flash-latest": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000015",
     "output_per_token": "0.000009",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-flash-lite-latest": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "google/gemini-omni-flash-preview": {
     "currency": "USD",
     "input_per_token": "0.0000015",
     "output_per_token": "0.0000175",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/llama-3.1-8b-instant": {
     "currency": "USD",
     "input_per_token": "0.00000005",
     "output_per_token": "0.00000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/llama-3.3-70b-versatile": {
     "currency": "USD",
     "input_per_token": "0.00000059",
     "output_per_token": "0.00000079",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
     "currency": "USD",
     "input_per_token": "0.00000011",
     "output_per_token": "0.00000034",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/meta-llama/llama-prompt-guard-2-22m": {
     "currency": "USD",
     "input_per_token": "0.00000003",
     "output_per_token": "0.00000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/meta-llama/llama-prompt-guard-2-86m": {
     "currency": "USD",
     "input_per_token": "0.00000004",
     "output_per_token": "0.00000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/openai/gpt-oss-120b": {
     "cache_read_per_token": "0.000000075",
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.0000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/openai/gpt-oss-20b": {
     "cache_read_per_token": "0.0000000375",
     "currency": "USD",
     "input_per_token": "0.000000075",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/openai/gpt-oss-safeguard-20b": {
     "currency": "USD",
     "input_per_token": "0.000000075",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "groq/qwen/qwen3-32b": {
     "currency": "USD",
     "input_per_token": "0.00000029",
     "output_per_token": "0.00000059",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2": {
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2.1": {
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2.5": {
     "cache_read_per_token": "0.00000003",
@@ -548,7 +630,8 @@
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2.5-highspeed": {
     "cache_read_per_token": "0.00000006",
@@ -556,7 +639,8 @@
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000024",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2.7": {
     "cache_read_per_token": "0.00000006",
@@ -564,7 +648,8 @@
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M2.7-highspeed": {
     "cache_read_per_token": "0.00000006",
@@ -572,1008 +657,1169 @@
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000024",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M3": {
     "cache_read_per_token": "0.00000006",
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/codestral-latest": {
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000009",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-2512": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-latest": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-medium-2507": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-medium-latest": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-small-2505": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/devstral-small-2507": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/labs-devstral-small-2512": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/magistral-medium-latest": {
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000005",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/magistral-small": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/ministral-3b-latest": {
     "currency": "USD",
     "input_per_token": "0.00000004",
     "output_per_token": "0.00000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/ministral-8b-latest": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-embed": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-large-2411": {
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-large-2512": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-large-latest": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-medium-2505": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-medium-2508": {
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-medium-2604": {
     "currency": "USD",
     "input_per_token": "0.0000015",
     "output_per_token": "0.0000075",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-medium-latest": {
     "currency": "USD",
     "input_per_token": "0.0000015",
     "output_per_token": "0.0000075",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-nemo": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.00000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-small-2506": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-small-2603": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.0000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/mistral-small-latest": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.0000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/open-mistral-7b": {
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.00000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/open-mistral-nemo": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.00000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/open-mixtral-8x22b": {
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/open-mixtral-8x7b": {
     "currency": "USD",
     "input_per_token": "0.0000007",
     "output_per_token": "0.0000007",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/pixtral-12b": {
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.00000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "mistral/pixtral-large-latest": {
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2-0711-preview": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2-0905-preview": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2-thinking": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2-thinking-turbo": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.00000115",
     "output_per_token": "0.000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2-turbo-preview": {
     "cache_read_per_token": "0.0000006",
     "currency": "USD",
     "input_per_token": "0.0000024",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2.5": {
     "cache_read_per_token": "0.0000001",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.000003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2.6": {
     "cache_read_per_token": "0.00000016",
     "currency": "USD",
     "input_per_token": "0.00000095",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2.7-code": {
     "cache_read_per_token": "0.00000019",
     "currency": "USD",
     "input_per_token": "0.00000095",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k2.7-code-highspeed": {
     "cache_read_per_token": "0.00000038",
     "currency": "USD",
     "input_per_token": "0.0000019",
     "output_per_token": "0.000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "moonshot/kimi-k3": {
     "cache_read_per_token": "0.0000003",
     "currency": "USD",
     "input_per_token": "0.000003",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/abacusai/dracarys-llama-3_1-70b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/baai/bge-m3": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/black-forest-labs/flux.1-dev": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/black-forest-labs/flux_1-kontext-dev": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/black-forest-labs/flux_1-schnell": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/black-forest-labs/flux_2-klein-4b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/bytedance/seed-oss-36b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/deepseek-ai/deepseek-v4-flash": {
     "cache_read_per_token": "0.0000000028",
     "currency": "USD",
     "input_per_token": "0.00000014",
     "output_per_token": "0.00000028",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/deepseek-ai/deepseek-v4-pro": {
     "cache_read_per_token": "0.000000003625",
     "currency": "USD",
     "input_per_token": "0.000000435",
     "output_per_token": "0.00000087",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/google/gemma-2-2b-it": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/google/gemma-3n-e2b-it": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/google/gemma-3n-e4b-it": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/google/gemma-4-31b-it": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/google/google-paligemma": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/esm2-650m": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/esmfold": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.1-70b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.1-8b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.2-11b-vision-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.2-1b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.2-3b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.2-90b-vision-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-3.3-70b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-4-maverick-17b-128e-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/meta/llama-guard-4-12b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/microsoft/phi-4-mini-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/microsoft/phi-4-multimodal-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/minimaxai/minimax-m2.7": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/minimaxai/minimax-m3": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/magistral-small-2506": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mistral-7b-instruct-v03": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mistral-large-3-675b-instruct-2512": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mistral-medium-3-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mistral-nemotron": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mistral-small-4-119b-2603": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mixtral-8x22b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/mistralai/mixtral-8x7b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/moonshotai/kimi-k2-instruct-0905": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/moonshotai/kimi-k2.6": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/active-speaker-detection": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/bevformer": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/cosmos-predict1-5b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/cosmos-transfer1-7b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/cosmos-transfer2_5-2b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/gliner-pii": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/llama-3_1-nemotron-safety-guard-8b-v3": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/llama-nemotron-embed-vl-1b-v2": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/llama-nemotron-rerank-vl-1b-v2": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/magpie-tts-zeroshot": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-3-content-safety": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-3-nano-30b-a3b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-3-super-120b-a12b": {
     "currency": "USD",
     "input_per_token": "0.0000002",
     "output_per_token": "0.0000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-3-ultra-550b-a55b": {
     "cache_read_per_token": "0.00000015",
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000025",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-content-safety-reasoning-4b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-mini-4b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nemotron-voicechat": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nv-embed-v1": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nv-embedcode-7b-v1": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/nvidia-nemotron-nano-9b-v2": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/rerank-qa-mistral-4b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/riva-translate-4b-instruct-v1_1": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/sparsedrive": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/streampetr": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/studiovoice": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/synthetic-video-detector": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/usdcode": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/nvidia/usdvalidate": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/openai/gpt-oss-120b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/openai/gpt-oss-20b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/openai/whisper-large-v3": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen-image": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen-image-edit": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen2.5-coder-32b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen3-coder-480b-a35b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen3-next-80b-a3b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen3.5-122b-a10b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/qwen/qwen3.5-397b-a17b": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/sarvamai/sarvam-m": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/stepfun-ai/step-3.5-flash": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/stepfun-ai/step-3.7-flash": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/upstage/solar-10_7b-instruct": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "nvidia/z-ai/glm-5.2": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-3.5-turbo": {
     "currency": "USD",
     "input_per_token": "0.0000005",
     "output_per_token": "0.0000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4": {
     "currency": "USD",
     "input_per_token": "0.00003",
     "output_per_token": "0.00006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4-turbo": {
     "currency": "USD",
     "input_per_token": "0.00001",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4.1": {
     "cache_read_per_token": "0.0000005",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4.1-mini": {
     "cache_read_per_token": "0.0000001",
     "currency": "USD",
     "input_per_token": "0.0000004",
     "output_per_token": "0.0000016",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4.1-nano": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4o": {
     "cache_read_per_token": "0.00000125",
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4o-2024-05-13": {
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4o-2024-08-06": {
     "cache_read_per_token": "0.00000125",
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4o-2024-11-20": {
     "cache_read_per_token": "0.00000125",
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-4o-mini": {
     "cache_read_per_token": "0.000000075",
     "currency": "USD",
     "input_per_token": "0.00000015",
     "output_per_token": "0.0000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5-chat-latest": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5-codex": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5-mini": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5-nano": {
     "cache_read_per_token": "0.000000005",
     "currency": "USD",
     "input_per_token": "0.00000005",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5-pro": {
     "currency": "USD",
     "input_per_token": "0.000015",
     "output_per_token": "0.00012",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.1": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.1-chat-latest": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.1-codex": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.1-codex-max": {
     "cache_read_per_token": "0.000000125",
     "currency": "USD",
     "input_per_token": "0.00000125",
     "output_per_token": "0.00001",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.1-codex-mini": {
     "cache_read_per_token": "0.000000025",
     "currency": "USD",
     "input_per_token": "0.00000025",
     "output_per_token": "0.000002",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.2": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.2-chat-latest": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.2-codex": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.2-pro": {
     "currency": "USD",
     "input_per_token": "0.000021",
     "output_per_token": "0.000168",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.3-chat-latest": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.3-codex": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.3-codex-spark": {
     "cache_read_per_token": "0.000000175",
     "currency": "USD",
     "input_per_token": "0.00000175",
     "output_per_token": "0.000014",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.4": {
     "cache_read_per_token": "0.00000025",
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.4-mini": {
     "cache_read_per_token": "0.000000075",
     "currency": "USD",
     "input_per_token": "0.00000075",
     "output_per_token": "0.0000045",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.4-nano": {
     "cache_read_per_token": "0.00000002",
     "currency": "USD",
     "input_per_token": "0.0000002",
     "output_per_token": "0.00000125",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.4-pro": {
     "currency": "USD",
     "input_per_token": "0.00003",
     "output_per_token": "0.00018",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.5": {
     "cache_read_per_token": "0.0000005",
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.5-pro": {
     "currency": "USD",
     "input_per_token": "0.00003",
     "output_per_token": "0.00018",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.6": {
     "cache_read_per_token": "0.0000005",
@@ -1581,7 +1827,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.6-luna": {
     "cache_read_per_token": "0.0000001",
@@ -1589,7 +1836,8 @@
     "currency": "USD",
     "input_per_token": "0.000001",
     "output_per_token": "0.000006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.6-sol": {
     "cache_read_per_token": "0.0000005",
@@ -1597,7 +1845,8 @@
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-5.6-terra": {
     "cache_read_per_token": "0.00000025",
@@ -1605,186 +1854,214 @@
     "currency": "USD",
     "input_per_token": "0.0000025",
     "output_per_token": "0.000015",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-image-2": {
     "cache_read_per_token": "0.00000125",
     "currency": "USD",
     "input_per_token": "0.000005",
     "output_per_token": "0.00003",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/gpt-realtime-2.1": {
     "cache_read_per_token": "0.0000004",
     "currency": "USD",
     "input_per_token": "0.000004",
     "output_per_token": "0.000024",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o1": {
     "cache_read_per_token": "0.0000075",
     "currency": "USD",
     "input_per_token": "0.000015",
     "output_per_token": "0.00006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o1-pro": {
     "currency": "USD",
     "input_per_token": "0.00015",
     "output_per_token": "0.0006",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o3": {
     "cache_read_per_token": "0.0000005",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o3-deep-research": {
     "cache_read_per_token": "0.0000025",
     "currency": "USD",
     "input_per_token": "0.00001",
     "output_per_token": "0.00004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o3-mini": {
     "cache_read_per_token": "0.00000055",
     "currency": "USD",
     "input_per_token": "0.0000011",
     "output_per_token": "0.0000044",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o3-pro": {
     "currency": "USD",
     "input_per_token": "0.00002",
     "output_per_token": "0.00008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o4-mini": {
     "cache_read_per_token": "0.000000275",
     "currency": "USD",
     "input_per_token": "0.0000011",
     "output_per_token": "0.0000044",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/o4-mini-deep-research": {
     "cache_read_per_token": "0.0000005",
     "currency": "USD",
     "input_per_token": "0.000002",
     "output_per_token": "0.000008",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/text-embedding-3-large": {
     "currency": "USD",
     "input_per_token": "0.00000013",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/text-embedding-3-small": {
     "currency": "USD",
     "input_per_token": "0.00000002",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "openai/text-embedding-ada-002": {
     "currency": "USD",
     "input_per_token": "0.0000001",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.5": {
     "cache_read_per_token": "0.00000011",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000022",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.5-air": {
     "cache_read_per_token": "0.00000003",
     "currency": "USD",
     "input_per_token": "0.0000002",
     "output_per_token": "0.0000011",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.5-flash": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.5v": {
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000018",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.6": {
     "cache_read_per_token": "0.00000011",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000022",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.6v": {
     "currency": "USD",
     "input_per_token": "0.0000003",
     "output_per_token": "0.0000009",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.7": {
     "cache_read_per_token": "0.00000011",
     "currency": "USD",
     "input_per_token": "0.0000006",
     "output_per_token": "0.0000022",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.7-flash": {
     "currency": "USD",
     "input_per_token": "0",
     "output_per_token": "0",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-4.7-flashx": {
     "cache_read_per_token": "0.00000001",
     "currency": "USD",
     "input_per_token": "0.00000007",
     "output_per_token": "0.0000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-5": {
     "cache_read_per_token": "0.0000002",
     "currency": "USD",
     "input_per_token": "0.000001",
     "output_per_token": "0.0000032",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-5-turbo": {
     "cache_read_per_token": "0.00000024",
     "currency": "USD",
     "input_per_token": "0.0000012",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-5.1": {
     "cache_read_per_token": "0.00000026",
     "currency": "USD",
     "input_per_token": "0.0000014",
     "output_per_token": "0.0000044",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-5.2": {
     "cache_read_per_token": "0.00000026",
     "currency": "USD",
     "input_per_token": "0.0000014",
     "output_per_token": "0.0000044",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   },
   "zai/glm-5v-turbo": {
     "cache_read_per_token": "0.00000024",
     "currency": "USD",
     "input_per_token": "0.0000012",
     "output_per_token": "0.000004",
-    "source": "community"
+    "source": "community",
+    "updated_at": "2026-07-20T22:04:30Z"
   }
 }

--- a/providers/core/context_window.go
+++ b/providers/core/context_window.go
@@ -46,8 +46,8 @@ func applyProviderContextWindows(raw []byte, models []types.Model) {
 			if !ok || tokens <= 0 {
 				continue
 			}
-			models[i].ContextWindow = &types.ModelContextWindow{
-				Tokens: int64(tokens),
+			models[i].ContextWindow = &types.ContextWindow{
+				Tokens: int(tokens),
 				Source: types.ContextWindowSourceProvider,
 			}
 			break

--- a/providers/core/context_window.go
+++ b/providers/core/context_window.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"encoding/json"
+	"math"
 
 	types "github.com/inference-gateway/inference-gateway/providers/types"
 )
@@ -43,7 +44,7 @@ func applyProviderContextWindows(raw []byte, models []types.Model) {
 		}
 		for _, key := range providerContextWindowKeys {
 			tokens, ok := entry[key].(float64)
-			if !ok || tokens <= 0 {
+			if !ok || tokens <= 0 || tokens >= math.MaxInt {
 				continue
 			}
 			models[i].ContextWindow = &types.ContextWindow{

--- a/providers/core/pricing.go
+++ b/providers/core/pricing.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"strconv"
+	"time"
 
 	types "github.com/inference-gateway/inference-gateway/providers/types"
 )
@@ -27,16 +28,17 @@ func applyProviderPricing(raw []byte, models []types.Model) {
 
 		input := pricingRate(pricing, "input_per_token", "prompt", "input")
 		output := pricingRate(pricing, "output_per_token", "completion", "output")
-		if input == nil && output == nil {
+		if input == nil || output == nil {
 			continue
 		}
-		models[i].Pricing = &types.ModelPricing{
+		models[i].Pricing = &types.Pricing{
 			Currency:           "USD",
-			InputPerToken:      input,
-			OutputPerToken:     output,
+			InputPerToken:      *input,
+			OutputPerToken:     *output,
 			CacheReadPerToken:  pricingRate(pricing, "cache_read_per_token", "input_cache_read", "cached"),
 			CacheWritePerToken: pricingRate(pricing, "cache_write_per_token", "input_cache_write", "cache_creation"),
 			Source:             types.PricingSourceProvider,
+			UpdatedAt:          time.Now().UTC(),
 		}
 	}
 }

--- a/providers/core/pricing.go
+++ b/providers/core/pricing.go
@@ -38,7 +38,7 @@ func applyProviderPricing(raw []byte, models []types.Model) {
 			CacheReadPerToken:  pricingRate(pricing, "cache_read_per_token", "input_cache_read", "cached"),
 			CacheWritePerToken: pricingRate(pricing, "cache_write_per_token", "input_cache_write", "cache_creation"),
 			Source:             types.PricingSourceProvider,
-			UpdatedAt:          time.Now().UTC(),
+			UpdatedAt:          time.Now().UTC().Truncate(time.Second),
 		}
 	}
 }

--- a/providers/types/common_types.go
+++ b/providers/types/common_types.go
@@ -47,6 +47,27 @@ func (e ChatCompletionToolType) Valid() bool {
 	}
 }
 
+// Defines values for ContextWindowSource.
+const (
+	ContextWindowSourceCommunity ContextWindowSource = "community"
+	ContextWindowSourceProvider  ContextWindowSource = "provider"
+	ContextWindowSourceRuntime   ContextWindowSource = "runtime"
+)
+
+// Valid indicates whether the value is a known member of the ContextWindowSource enum.
+func (e ContextWindowSource) Valid() bool {
+	switch e {
+	case ContextWindowSourceCommunity:
+		return true
+	case ContextWindowSourceProvider:
+		return true
+	case ContextWindowSourceRuntime:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CreateChatCompletionRequestReasoningEffort.
 const (
 	High    CreateChatCompletionRequestReasoningEffort = "high"
@@ -158,35 +179,14 @@ func (e MessageRole) Valid() bool {
 	}
 }
 
-// Defines values for ModelContextWindowSource.
+// Defines values for PricingSource.
 const (
-	ContextWindowSourceCommunity ModelContextWindowSource = "community"
-	ContextWindowSourceProvider  ModelContextWindowSource = "provider"
-	ContextWindowSourceRuntime   ModelContextWindowSource = "runtime"
+	PricingSourceCommunity PricingSource = "community"
+	PricingSourceProvider  PricingSource = "provider"
 )
 
-// Valid indicates whether the value is a known member of the ModelContextWindowSource enum.
-func (e ModelContextWindowSource) Valid() bool {
-	switch e {
-	case ContextWindowSourceCommunity:
-		return true
-	case ContextWindowSourceProvider:
-		return true
-	case ContextWindowSourceRuntime:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for ModelPricingSource.
-const (
-	PricingSourceCommunity ModelPricingSource = "community"
-	PricingSourceProvider  ModelPricingSource = "provider"
-)
-
-// Valid indicates whether the value is a known member of the ModelPricingSource enum.
-func (e ModelPricingSource) Valid() bool {
+// Valid indicates whether the value is a known member of the PricingSource enum.
+func (e PricingSource) Valid() bool {
 	switch e {
 	case PricingSourceCommunity:
 		return true
@@ -763,16 +763,16 @@ func (e TextContentPartType) Valid() bool {
 
 // Defines values for ListModelsParamsInclude.
 const (
-	ContextWindow ListModelsParamsInclude = "context_window"
-	Pricing       ListModelsParamsInclude = "pricing"
+	ListModelsParamsIncludeContextWindow ListModelsParamsInclude = "context_window"
+	ListModelsParamsIncludePricing       ListModelsParamsInclude = "pricing"
 )
 
 // Valid indicates whether the value is a known member of the ListModelsParamsInclude enum.
 func (e ListModelsParamsInclude) Valid() bool {
 	switch e {
-	case ContextWindow:
+	case ListModelsParamsIncludeContextWindow:
 		return true
-	case Pricing:
+	case ListModelsParamsIncludePricing:
 		return true
 	default:
 		return false
@@ -998,6 +998,18 @@ type Config = any
 type ContentPart struct {
 	union json.RawMessage
 }
+
+// ContextWindow Context window information for a model
+type ContextWindow struct {
+	// Source Source of the context window information
+	Source ContextWindowSource `json:"source"`
+
+	// Tokens Maximum number of tokens the model can process in a single request
+	Tokens int `json:"tokens"`
+}
+
+// ContextWindowSource Source of the context window information
+type ContextWindowSource string
 
 // CreateChatCompletionRequest defines model for CreateChatCompletionRequest.
 type CreateChatCompletionRequest struct {
@@ -1325,56 +1337,44 @@ type MessageRole string
 
 // Model Common model information
 type Model struct {
-	// ContextWindow Effective context window a client may safely use for the model. Present only when requested via `include=context_window`; `null` when requested but the window could not be resolved. The value reflects what the serving runtime is actually configured with when available, which can be smaller than the model's theoretical maximum.
-	ContextWindow *ModelContextWindow `json:"context_window,omitempty"`
-	Created       int64               `json:"created"`
-	ID            string              `json:"id"`
-	Object        string              `json:"object"`
-	OwnedBy       string              `json:"owned_by"`
+	// ContextWindow Context window information for the model (included when `include=context_window`)
+	ContextWindow *ContextWindow `json:"context_window,omitempty"`
+	Created       int64          `json:"created"`
+	ID            string         `json:"id"`
+	Object        string         `json:"object"`
+	OwnedBy       string         `json:"owned_by"`
 
-	// Pricing Normalized public per-token pricing for the model. Present only when requested via `include=pricing`; `null` when requested but the model has no public per-token cost (subscription-based providers, locally hosted models, or providers that publish no pricing). Monetary values are decimal strings to avoid floating-point precision loss. Rates the provider does not publish are omitted entirely, never `0` or `null`.
-	Pricing  *ModelPricing `json:"pricing,omitempty"`
-	ServedBy Provider      `json:"served_by"`
+	// Pricing Pricing information for the model (included when `include=pricing`)
+	Pricing  *Pricing `json:"pricing,omitempty"`
+	ServedBy Provider `json:"served_by"`
 }
 
-// ModelContextWindow Effective context window a client may safely use for the model. Present only when requested via `include=context_window`; `null` when requested but the window could not be resolved. The value reflects what the serving runtime is actually configured with when available, which can be smaller than the model's theoretical maximum.
-type ModelContextWindow struct {
-	// Source Where the value was resolved from. `runtime` means the serving runtime reported its configured window (e.g. llama.cpp `/props`, Ollama's show API); `provider` means the upstream provider published the window in its model listing; `community` means it was synced from the community-maintained models.dev dataset.
-	Source ModelContextWindowSource `json:"source"`
-
-	// Tokens Effective context window size in tokens.
-	Tokens int64 `json:"tokens"`
-}
-
-// ModelContextWindowSource Where the value was resolved from. `runtime` means the serving runtime reported its configured window (e.g. llama.cpp `/props`, Ollama's show API); `provider` means the upstream provider published the window in its model listing; `community` means it was synced from the community-maintained models.dev dataset.
-type ModelContextWindowSource string
-
-// ModelPricing Normalized public per-token pricing for the model. Present only when requested via `include=pricing`; `null` when requested but the model has no public per-token cost (subscription-based providers, locally hosted models, or providers that publish no pricing). Monetary values are decimal strings to avoid floating-point precision loss. Rates the provider does not publish are omitted entirely, never `0` or `null`.
-type ModelPricing struct {
-	// CacheReadPerToken Cost per token read from the provider's prompt cache, as a decimal string. Present only when the provider publishes a cached-input rate.
+// Pricing Pricing information for a model
+type Pricing struct {
+	// CacheReadPerToken Price per cached input token read
 	CacheReadPerToken *string `json:"cache_read_per_token,omitempty"`
 
-	// CacheWritePerToken Cost per token written to the provider's prompt cache, as a decimal string. Present only when the provider publishes a cache-creation rate.
+	// CacheWritePerToken Price per cached input token write
 	CacheWritePerToken *string `json:"cache_write_per_token,omitempty"`
 
-	// Currency ISO 4217 currency code the rates are denominated in.
+	// Currency Currency code for the pricing (e.g. USD)
 	Currency string `json:"currency"`
 
-	// InputPerToken Cost per input (prompt) token, as a decimal string.
-	InputPerToken *string `json:"input_per_token,omitempty"`
+	// InputPerToken Price per input token
+	InputPerToken string `json:"input_per_token"`
 
-	// OutputPerToken Cost per output (completion) token, as a decimal string.
-	OutputPerToken *string `json:"output_per_token,omitempty"`
+	// OutputPerToken Price per output token
+	OutputPerToken string `json:"output_per_token"`
 
-	// Source Where the rates were resolved from. `provider` means the upstream provider published them in its model listing; `community` means they were synced from the community-maintained models.dev dataset.
-	Source ModelPricingSource `json:"source"`
+	// Source Source of the pricing information
+	Source PricingSource `json:"source"`
 
-	// UpdatedAt When the rates were last refreshed, if known.
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	// UpdatedAt Timestamp when the pricing was last updated
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ModelPricingSource Where the rates were resolved from. `provider` means the upstream provider published them in its model listing; `community` means they were synced from the community-maintained models.dev dataset.
-type ModelPricingSource string
+// PricingSource Source of the pricing information
+type PricingSource string
 
 // Provider defines model for Provider.
 type Provider string
@@ -1978,7 +1978,9 @@ type ListModelsParams struct {
 	// Provider Specific provider to query (optional)
 	Provider *Provider `form:"provider,omitempty" json:"provider,omitempty"`
 
-	// Include Optional comma-separated list of additional per-model metadata fields to include in the response. Supported keys: `context_window`, `pricing`. Keys are trimmed and de-duplicated; an unknown key returns 400. When omitted, the response contains no metadata fields and stays byte-for-byte OpenAI-compatible. A requested key that cannot be resolved is returned as an explicit `null`, distinguishing "not requested" (key absent) from "requested but unavailable" (key present, value null).
+	// Include Comma-separated list of metadata keys to include in the response.
+	// Supported values: `pricing`, `context_window`.
+	// When omitted, the response remains unchanged (backward compatible).
 	Include *[]ListModelsParamsInclude `form:"include,omitempty" json:"include,omitempty"`
 }
 

--- a/tests/api_pricing_test.go
+++ b/tests/api_pricing_test.go
@@ -56,8 +56,10 @@ func TestListModelsHandler_PricingResolution(t *testing.T) {
 		models := modelsByID(t, w.Body.Bytes())
 		require.Len(t, models, 6)
 
-		full, exists := models["deepseek/deepseek-chat"]["pricing"]
-		require.True(t, exists)
+		full, ok := models["deepseek/deepseek-chat"]["pricing"].(map[string]any)
+		require.True(t, ok)
+		assert.NotEmpty(t, full["updated_at"], "required updated_at must be stamped")
+		delete(full, "updated_at")
 		assert.Equal(t, map[string]any{
 			"currency":              "USD",
 			"input_per_token":       "0.00000027",


### PR DESCRIPTION
## Summary

Syncing `openapi.yaml` from the central schemas repo broke `task generate`: the spec renamed `ModelPricing` → `Pricing` and `ModelContextWindow` → `ContextWindow`, made `input_per_token`, `output_per_token`, and `updated_at` required, and changed `ContextWindow.tokens` to `int`. Hand-written code still referenced the old generated names and pointer fields.

## Changes

- Rename type references across `api/`, `providers/core/`, and `internal/pricinggen/`; `routes.go` now uses the `ListModelsParamsInclude*` enum constants since `types.Pricing` / `types.ContextWindow` are struct types now.
- `applyProviderPricing` and the community pricing sync require both rates (schema-required) and stamp the required `updated_at` in UTC so serialized output is machine-independent.
- Resynced `community_pricing.json` from models.dev so every entry carries `updated_at`.
- Updated tests asserting the old pointer fields / exact response map.

## Behavior note

A provider publishing only one of the two rates now gets no provider-sourced pricing entry (falls back to the community table or `null`) instead of a partial entry — forced by both rates being schema-required.

## Testing

- `task generate` passes with a clean tree
- `go test ./...` green