### PR TITLE
fix(providers): stream usage for ollama_cloud and dotted community-id matching

### DIFF
--- a/providers/core/community_pricing.go
+++ b/providers/core/community_pricing.go
@@ -47,7 +47,10 @@ func applyCommunityPricing(models []types.Model) {
 // communityLookupKeys returns candidate table keys for a gateway model ID in
 // preference order: exact, without Google's "models/" path prefix, without a
 // "-latest" alias suffix, and without a trailing "-YYYYMMDD" date pin, so
-// upstream listing IDs still match the dataset's canonical names.
+// upstream listing IDs still match the dataset's canonical names. Each
+// candidate containing dots also gets an underscored variant, because
+// models.dev file names replace dots in model ids (e.g. NIM's
+// "solar-10.7b-instruct" is committed as "solar-10_7b-instruct").
 func communityLookupKeys(id string) []string {
 	keys := []string{id}
 	provider, model, ok := strings.Cut(id, "/")
@@ -63,6 +66,11 @@ func communityLookupKeys(id string) []string {
 	}
 	if len(model) > 9 && model[len(model)-9] == '-' && isDigits(model[len(model)-8:]) {
 		keys = append(keys, provider+"/"+model[:len(model)-9])
+	}
+	for _, key := range keys {
+		if strings.Contains(key, ".") {
+			keys = append(keys, strings.ReplaceAll(key, ".", "_"))
+		}
 	}
 	return keys
 }

--- a/providers/core/community_pricing_test.go
+++ b/providers/core/community_pricing_test.go
@@ -12,11 +12,12 @@ func TestCommunityLookupKeys(t *testing.T) {
 		want []string
 	}{
 		{"plain", "openai/gpt-4o", []string{"openai/gpt-4o"}},
-		{"google models prefix", "google/models/gemini-2.0-flash", []string{"google/models/gemini-2.0-flash", "google/gemini-2.0-flash"}},
+		{"google models prefix", "google/models/gemini-2.0-flash", []string{"google/models/gemini-2.0-flash", "google/gemini-2.0-flash", "google/models/gemini-2_0-flash", "google/gemini-2_0-flash"}},
 		{"latest alias", "anthropic/claude-3-5-sonnet-latest", []string{"anthropic/claude-3-5-sonnet-latest", "anthropic/claude-3-5-sonnet"}},
 		{"date pin", "anthropic/claude-sonnet-4-5-20250929", []string{"anthropic/claude-sonnet-4-5-20250929", "anthropic/claude-sonnet-4-5"}},
-		{"not a date suffix", "groq/llama-3.3-70b", []string{"groq/llama-3.3-70b"}},
+		{"not a date suffix", "groq/llama-3.3-70b", []string{"groq/llama-3.3-70b", "groq/llama-3_3-70b"}},
 		{"no provider prefix", "gpt-4o", []string{"gpt-4o"}},
+		{"dotted nim id", "nvidia/upstage/solar-10.7b-instruct", []string{"nvidia/upstage/solar-10.7b-instruct", "nvidia/upstage/solar-10_7b-instruct"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/providers/core/provider.go
+++ b/providers/core/provider.go
@@ -85,11 +85,6 @@ func (p *ProviderImpl) prepareStreamingRequest(clientReq types.CreateChatComplet
 		IncludeUsage: true,
 	}
 
-	// Special case - cohere and mistral don't like stream_options, so we don't
-	// include it - probably they haven't implemented it yet in their OpenAI "compatible" API.
-	// ollama_cloud was excluded too (#207) but Ollama's OpenAI-compatible API now
-	// supports stream_options.include_usage, and without it streams carry no usage
-	// (and no prompt_tokens_details.cached_tokens) chunk.
 	if *p.GetID() == constants.CohereID || *p.GetID() == constants.MistralID {
 		clientReq.StreamOptions = nil
 	}

--- a/providers/core/provider.go
+++ b/providers/core/provider.go
@@ -85,9 +85,12 @@ func (p *ProviderImpl) prepareStreamingRequest(clientReq types.CreateChatComplet
 		IncludeUsage: true,
 	}
 
-	// Special case - cohere, mistral, and ollama_cloud don't like stream_options, so we don't
-	// include it - probably they haven't implemented it yet in their OpenAI "compatible" API
-	if *p.GetID() == constants.CohereID || *p.GetID() == constants.MistralID || *p.GetID() == constants.OllamaCloudID {
+	// Special case - cohere and mistral don't like stream_options, so we don't
+	// include it - probably they haven't implemented it yet in their OpenAI "compatible" API.
+	// ollama_cloud was excluded too (#207) but Ollama's OpenAI-compatible API now
+	// supports stream_options.include_usage, and without it streams carry no usage
+	// (and no prompt_tokens_details.cached_tokens) chunk.
+	if *p.GetID() == constants.CohereID || *p.GetID() == constants.MistralID {
 		clientReq.StreamOptions = nil
 	}
 


### PR DESCRIPTION
## Summary

Two fixes that make model usage and metadata actually reach clients:

- **Request stream usage from ollama_cloud.** The provider was added to the `stream_options` exception list in #207 when its OpenAI-compatible API ignored the parameter. Ollama now supports `stream_options.include_usage`; keeping the exception meant ollama_cloud streams carried no usage chunk at all, so clients (e.g. the CLI) never saw real token totals or `prompt_tokens_details.cached_tokens` and fell back to tokenizer estimates. Cohere and mistral stay excluded.
- **Match community metadata across dot/underscore id variants.** models.dev file names replace dots in model ids (NIM's `solar-10.7b-instruct` is committed as `solar-10_7b-instruct`), so the community pricing and context-window lookups silently missed those models. `communityLookupKeys` now also tries an underscored variant for every dotted candidate, recovering metadata for `dracarys-llama-3.1-70b-instruct`, `llama-3.1-nemotron-safety-guard-8b-v3`, `riva-translate-4b-instruct-v1.1`, and `solar-10.7b-instruct`.

## Verification

- `go test ./...` green; `TestCommunityLookupKeys` covers the new variant (existing dotted cases updated).
- ollama_cloud usage chunk should be confirmed against the live ollama.com API before release (one streamed request with `stream_options.include_usage: true`).

## Cross-repo impact

Consumed by inference-gateway/cli#941, which surfaces cached tokens (`C.<n>`, stats Cached column) and gateway-sourced context windows/pricing; for ollama_cloud those depend on the usage chunk this PR re-enables. No schema or SDK changes.