### PR TITLE
ci: install mockgen for schemas-sync codegen

### DIFF
--- a/.github/workflows/schemas-sync.yml
+++ b/.github/workflows/schemas-sync.yml
@@ -30,5 +30,7 @@ jobs:
       language: go
       ref: ${{ inputs.ref }}
       dry_run: ${{ inputs.dry_run }}
-      setup: npm install -g prettier
+      setup: |
+        npm install -g prettier
+        go install go.uber.org/mock/mockgen@v0.6.0
     secrets: inherit


### PR DESCRIPTION
The first schemas-sync run ([29833031253](https://github.com/inference-gateway/inference-gateway/actions/runs/29833031253)) failed at `go generate`: `mockgen: executable file not found in $PATH`. The `generate` task needs `mockgen` like the repo's own CI does (`ci.yml` installs `go.uber.org/mock/mockgen@v0.6.0`); add it to the schemas-sync caller's `setup` alongside prettier.

Impacted repos: inference-gateway only (per-repo caller config; the org reusable workflow is unchanged).