### PR TITLE
ci(sync-tables): use maintainer app and chore commit type

### DIFF
--- a/.github/workflows/sync-community-tables.yml
+++ b/.github/workflows/sync-community-tables.yml
@@ -16,8 +16,17 @@ jobs:
       - uses: actions/create-github-app-token@v3.2.0
         id: app-token
         with:
-          client-id: ${{ secrets.RELEASER_APP_ID }}
-          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.INFERENCE_GATEWAY_MAINTAINER_APP_ID }}
+          private-key: ${{ secrets.INFERENCE_GATEWAY_MAINTAINER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            inference-gateway
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout code
         uses: actions/checkout@v7.0.1
@@ -44,8 +53,10 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           branch: chore/sync-community-tables
           add-paths: providers/core/community_pricing.json,providers/core/community_context_windows.json
-          commit-message: 'fix: sync community pricing and context-window tables from models.dev'
-          title: 'fix: sync community pricing and context-window tables from models.dev'
+          committer: '${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          author: '${{ steps.app-token.outputs.app-slug }}[bot] <${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+          commit-message: 'chore: sync community pricing and context-window tables from models.dev'
+          title: 'chore: sync community pricing and context-window tables from models.dev'
           body: >-
             Automated weekly sync of `community_pricing.json` and
             `community_context_windows.json` from the


### PR DESCRIPTION
## What

Fixes the weekly `Sync Community Tables` workflow so its PR/commit come from the right identity and type:

- **Bot identity** — authenticate with `INFERENCE_GATEWAY_MAINTAINER_APP_*` instead of `RELEASER_APP_*`, so the sync PR is opened by the maintainer app rather than the releaser bot (which caused #500 to be authored by `inference-gateway-releaser`).
- **Commit author** — add the "Get GitHub App User ID" step and set `committer`/`author` on `peter-evans/create-pull-request`, so the commit is authored by the maintainer app bot instead of `github-actions[bot]`. Mirrors the pattern already in `release.yml`.
- **Commit type** — `fix:` → `chore:` so weekly data syncs stop landing under "🐛 Bug Fixes" in the changelog.

## Notes

Plain `chore:` still cuts a patch release per `.releaserc.yaml`, which is intended — the tables are `go:embed`-ed and only reach users via a release.

Only affects future runs; existing #500 is unaffected.