### PR TITLE
feat: restructure model modalities into nested input/output and resolve models.dev base_model inheritance

### DIFF
--- a/internal/communitygen/communitygen.go
+++ b/internal/communitygen/communitygen.go
@@ -199,8 +199,6 @@ func forEachModel(tarballPath string, visit func(key string, model modelTOML)) e
 	}
 	defer gz.Close()
 
-	// One streaming pass buffers both file kinds — tar order is not guaranteed —
-	// then base_model inheritance is resolved before visiting.
 	type entry struct {
 		key   string
 		model modelTOML

--- a/internal/communitygen/communitygen.go
+++ b/internal/communitygen/communitygen.go
@@ -83,6 +83,10 @@ type modelTOML struct {
 		Input  []string `toml:"input"`
 		Output []string `toml:"output"`
 	} `toml:"modalities"`
+	// BaseModel references a canonical "models/<lab>/<model>.toml" definition
+	// ("<lab>/<model>") whose sections fill in anything this provider file
+	// omits (models.dev's base_model inheritance).
+	BaseModel string `toml:"base_model"`
 }
 
 // contextWindowEntry is one row of the community context-window table: the
@@ -142,17 +146,21 @@ func GenerateContextWindows(output, tarballPath string) error {
 
 // GenerateModalities reads a models.dev repository tarball and writes the
 // community modalities table keyed by "<provider>/<model>" to output. It maps
-// each model's input modalities to the gateway's ModelModalities enum, dropping
-// values the enum does not carry (e.g. models.dev's "pdf"). Models with no
-// recognized input modality get no entry and render as explicit nulls.
+// each model's input and output modalities to the gateway's Modality enum,
+// dropping values the enum does not carry (e.g. models.dev's "pdf"). Models
+// with no recognized input or output modality get no entry and render as
+// explicit nulls.
 func GenerateModalities(output, tarballPath string) error {
-	table := make(map[string][]types.ModelModalities)
+	table := make(map[string]types.ModelModalities)
 	err := forEachModel(tarballPath, func(key string, model modelTOML) {
-		mods := enumModalities(model.Modalities.Input)
-		if len(mods) == 0 {
+		entry := types.ModelModalities{
+			Input:  enumModalities(model.Modalities.Input),
+			Output: enumModalities(model.Modalities.Output),
+		}
+		if len(entry.Input) == 0 || len(entry.Output) == 0 {
 			return
 		}
-		table[key] = mods
+		table[key] = entry
 	})
 	if err != nil {
 		return err
@@ -161,12 +169,12 @@ func GenerateModalities(output, tarballPath string) error {
 }
 
 // enumModalities keeps only the values that are members of the gateway's
-// ModelModalities enum, in first-seen order without duplicates.
-func enumModalities(values []string) []types.ModelModalities {
-	var out []types.ModelModalities
-	seen := make(map[types.ModelModalities]bool)
+// Modality enum, in first-seen order without duplicates.
+func enumModalities(values []string) []types.Modality {
+	var out []types.Modality
+	seen := make(map[types.Modality]bool)
 	for _, v := range values {
-		m := types.ModelModalities(v)
+		m := types.Modality(v)
 		if !m.Valid() || seen[m] {
 			continue
 		}
@@ -191,6 +199,15 @@ func forEachModel(tarballPath string, visit func(key string, model modelTOML)) e
 	}
 	defer gz.Close()
 
+	// One streaming pass buffers both file kinds — tar order is not guaranteed —
+	// then base_model inheritance is resolved before visiting.
+	type entry struct {
+		key   string
+		model modelTOML
+	}
+	bases := make(map[string]modelTOML)
+	var entries []entry
+
 	tr := tar.NewReader(gz)
 	for {
 		hdr, err := tr.Next()
@@ -204,7 +221,8 @@ func forEachModel(tarballPath string, visit func(key string, model modelTOML)) e
 			continue
 		}
 		key, ok := tableKey(hdr.Name)
-		if !ok {
+		baseKey, isBase := canonicalModelKey(hdr.Name)
+		if !ok && !isBase {
 			continue
 		}
 		data, err := io.ReadAll(tr)
@@ -215,9 +233,54 @@ func forEachModel(tarballPath string, visit func(key string, model modelTOML)) e
 		if err := toml.Unmarshal(data, &model); err != nil {
 			return fmt.Errorf("parsing %s: %w", hdr.Name, err)
 		}
-		visit(key, model)
+		if isBase {
+			bases[baseKey] = model
+			continue
+		}
+		entries = append(entries, entry{key, model})
+	}
+
+	for _, e := range entries {
+		if base, ok := bases[e.model.BaseModel]; ok {
+			e.model = mergeBase(e.model, base)
+		}
+		visit(e.key, e.model)
 	}
 	return nil
+}
+
+// canonicalModelKey maps a tarball entry like
+// "sst-models.dev-abc123/models/openai/gpt-image-2.toml" to its base-model key
+// "openai/gpt-image-2". These canonical files are the inheritance targets of
+// provider files' base_model references, not table entries themselves.
+func canonicalModelKey(name string) (string, bool) {
+	if strings.Contains(name, "/providers/") {
+		return "", false
+	}
+	_, rest, ok := strings.Cut(name, "/models/")
+	if !ok {
+		return "", false
+	}
+	key, ok := strings.CutSuffix(rest, ".toml")
+	if !ok || key == "" {
+		return "", false
+	}
+	return key, true
+}
+
+// mergeBase fills the sections a provider model file omits from its canonical
+// base model: provider-published values always win, section by section.
+func mergeBase(m, base modelTOML) modelTOML {
+	if m.Cost == nil {
+		m.Cost = base.Cost
+	}
+	if m.Limit.Context == 0 && m.Limit.Output == 0 {
+		m.Limit = base.Limit
+	}
+	if len(m.Modalities.Input) == 0 && len(m.Modalities.Output) == 0 {
+		m.Modalities = base.Modalities
+	}
+	return m
 }
 
 // writeTable merges the hand-maintained overrides over the synced table and

--- a/internal/communitygen/communitygen_test.go
+++ b/internal/communitygen/communitygen_test.go
@@ -295,15 +295,15 @@ func TestGenerateContextWindows(t *testing.T) {
 	}
 }
 
-// TestEnumModalities keeps only known ModelModalities members, in first-seen
+// TestEnumModalities keeps only known Modality members, in first-seen
 // order without duplicates, dropping values the enum does not carry (e.g.
 // models.dev's "pdf").
 func TestEnumModalities(t *testing.T) {
 	got := enumModalities([]string{"text", "pdf", "image", "text", "bogus", "audio"})
-	want := []types.ModelModalities{
-		types.ModelModalitiesText,
-		types.ModelModalitiesImage,
-		types.ModelModalitiesAudio,
+	want := []types.Modality{
+		types.ModalityText,
+		types.ModalityImage,
+		types.ModalityAudio,
 	}
 	if !slices.Equal(got, want) {
 		t.Errorf("enumModalities() = %v, want %v", got, want)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -256,16 +256,22 @@ paths:
                         owned_by: 'openai'
                         served_by: 'openai'
                         modalities:
-                          - text
-                          - image
-                      - id: 'openai/gpt-4-turbo'
+                          input:
+                            - text
+                            - image
+                          output:
+                            - text
+                      - id: 'openai/gpt-image-2'
                         object: 'model'
                         created: 1687882410
                         owned_by: 'openai'
                         served_by: 'openai'
                         modalities:
-                          - text
-                          - image
+                          input:
+                            - text
+                            - image
+                          output:
+                            - image
         '400':
           description: Bad request - unsupported include value
           content:
@@ -1630,16 +1636,9 @@ components:
           $ref: '#/components/schemas/Provider'
         modalities:
           oneOf:
-            - type: array
-              items:
-                type: string
-                enum:
-                  - text
-                  - image
-                  - audio
-                  - video
+            - $ref: '#/components/schemas/ModelModalities'
             - type: 'null'
-          description: The modalities the model supports natively (included when `include=modalities`)
+          description: The input and output modalities of the model (included when `include=modalities`)
         context_window:
           oneOf:
             - $ref: '#/components/schemas/ContextWindow'
@@ -1656,6 +1655,33 @@ components:
         - created
         - owned_by
         - served_by
+    Modality:
+      type: string
+      description: A single input or output modality
+      enum:
+        - text
+        - image
+        - audio
+        - video
+    ModelModalities:
+      type: object
+      description: >-
+        The input and output modalities of a model, mirroring the models.dev dataset shape.
+        Vision models accept `image` in `input`; image-generation models list `image` in
+        `output` — when `output` carries `image` but not `text`, the model only generates
+        images and cannot chat.
+      properties:
+        input:
+          type: array
+          items:
+            $ref: '#/components/schemas/Modality'
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/Modality'
+      required:
+        - input
+        - output
     ListModelsResponse:
       type: object
       description: Response structure for listing models

--- a/providers/core/community_context_windows.json
+++ b/providers/core/community_context_windows.json
@@ -3,13 +3,25 @@
     "context": 1000000,
     "output": 128000
   },
+  "anthropic/claude-haiku-4-5": {
+    "context": 200000,
+    "output": 64000
+  },
   "anthropic/claude-haiku-4-5-20251001": {
     "context": 200000,
     "output": 64000
   },
+  "anthropic/claude-opus-4-1": {
+    "context": 200000,
+    "output": 32000
+  },
   "anthropic/claude-opus-4-1-20250805": {
     "context": 200000,
     "output": 32000
+  },
+  "anthropic/claude-opus-4-5": {
+    "context": 200000,
+    "output": 64000
   },
   "anthropic/claude-opus-4-5-20251101": {
     "context": 200000,
@@ -93,6 +105,10 @@
     "context": 128000,
     "output": 128000
   },
+  "cloudflare/@cf/moonshotai/kimi-k2.7-code": {
+    "context": 262144,
+    "output": 262144
+  },
   "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
     "context": 256000,
     "output": 256000
@@ -124,6 +140,62 @@
   "cloudflare/@cf/zai-org/glm-5.2": {
     "context": 262144,
     "output": 262144
+  },
+  "cohere/c4ai-aya-expanse-32b": {
+    "context": 128000,
+    "output": 4000
+  },
+  "cohere/c4ai-aya-expanse-8b": {
+    "context": 8000,
+    "output": 4000
+  },
+  "cohere/c4ai-aya-vision-32b": {
+    "context": 16000,
+    "output": 4000
+  },
+  "cohere/c4ai-aya-vision-8b": {
+    "context": 16000,
+    "output": 4000
+  },
+  "cohere/command-a-03-2025": {
+    "context": 256000,
+    "output": 8000
+  },
+  "cohere/command-a-plus-05-2026": {
+    "context": 128000,
+    "output": 64000
+  },
+  "cohere/command-a-reasoning-08-2025": {
+    "context": 256000,
+    "output": 32000
+  },
+  "cohere/command-a-translate-08-2025": {
+    "context": 8000,
+    "output": 8000
+  },
+  "cohere/command-a-vision-07-2025": {
+    "context": 128000,
+    "output": 8000
+  },
+  "cohere/command-r-08-2024": {
+    "context": 128000,
+    "output": 4000
+  },
+  "cohere/command-r-plus-08-2024": {
+    "context": 128000,
+    "output": 4000
+  },
+  "cohere/command-r7b-12-2024": {
+    "context": 128000,
+    "output": 4000
+  },
+  "cohere/command-r7b-arabic-02-2025": {
+    "context": 128000,
+    "output": 4000
+  },
+  "cohere/north-mini-code-1-0": {
+    "context": 256000,
+    "output": 64000
   },
   "deepseek/deepseek-chat": {
     "context": 1000000,
@@ -159,6 +231,14 @@
     "context": 131072,
     "output": 65536
   },
+  "google/gemini-2.5-flash": {
+    "context": 1048576,
+    "output": 65536
+  },
+  "google/gemini-2.5-flash-image": {
+    "context": 32768,
+    "output": 32768
+  },
   "google/gemini-2.5-flash-lite": {
     "context": 1048576,
     "output": 65536
@@ -166,6 +246,10 @@
   "google/gemini-2.5-flash-preview-tts": {
     "context": 8192,
     "output": 16384
+  },
+  "google/gemini-2.5-pro": {
+    "context": 1048576,
+    "output": 65536
   },
   "google/gemini-2.5-pro-preview-tts": {
     "context": 8192,
@@ -201,6 +285,14 @@
     "context": 1048576,
     "output": 65536
   },
+  "google/gemini-3.1-flash-live-preview": {
+    "context": 131072,
+    "output": 65536
+  },
+  "google/gemini-3.1-flash-tts-preview": {
+    "context": 8192,
+    "output": 16384
+  },
   "google/gemini-3.1-pro-preview": {
     "context": 1048576,
     "output": 65536
@@ -213,9 +305,17 @@
     "context": 1048576,
     "output": 65536
   },
+  "google/gemini-3.5-flash-lite": {
+    "context": 1048576,
+    "output": 65536
+  },
   "google/gemini-3.5-live-translate-preview": {
     "context": 16384,
     "output": 32768
+  },
+  "google/gemini-3.6-flash": {
+    "context": 1048576,
+    "output": 65536
   },
   "google/gemini-embedding-001": {
     "context": 2048,
@@ -230,6 +330,10 @@
     "output": 65536
   },
   "google/gemini-omni-flash-preview": {
+    "context": 131072,
+    "output": 65536
+  },
+  "google/gemini-robotics-er-1.6-preview": {
     "context": 131072,
     "output": 65536
   },
@@ -260,6 +364,10 @@
     "context": 480,
     "output": 8192
   },
+  "groq/allam-2-7b": {
+    "context": 4096,
+    "output": 4096
+  },
   "groq/canopylabs/orpheus-arabic-saudi": {
     "context": 4000,
     "output": 50000
@@ -284,10 +392,6 @@
     "context": 131072,
     "output": 32768
   },
-  "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
-    "context": 131072,
-    "output": 8192
-  },
   "groq/meta-llama/llama-prompt-guard-2-22m": {
     "context": 512,
     "output": 512
@@ -304,9 +408,9 @@
     "context": 131072,
     "output": 65536
   },
-  "groq/qwen/qwen3-32b": {
+  "groq/qwen/qwen3.6-27b": {
     "context": 131072,
-    "output": 40960
+    "output": 16384
   },
   "minimax/MiniMax-M2": {
     "context": 196608,
@@ -412,6 +516,10 @@
     "context": 262144,
     "output": 262144
   },
+  "mistral/mistral-medium-latest": {
+    "context": 262144,
+    "output": 262144
+  },
   "mistral/mistral-nemo": {
     "context": 128000,
     "output": 128000
@@ -483,6 +591,18 @@
   "moonshot/kimi-k2.6": {
     "context": 262144,
     "output": 262144
+  },
+  "moonshot/kimi-k2.7-code": {
+    "context": 262144,
+    "output": 262144
+  },
+  "moonshot/kimi-k2.7-code-highspeed": {
+    "context": 262144,
+    "output": 262144
+  },
+  "moonshot/kimi-k3": {
+    "context": 1048576,
+    "output": 131072
   },
   "nvidia/abacusai/dracarys-llama-3.1-70b-instruct": {
     "context": 128000,
@@ -662,6 +782,10 @@
     "context": 128000,
     "output": 4096
   },
+  "nvidia/nvidia/llama-3.1-nemotron-70b-instruct": {
+    "context": 128000,
+    "output": 8192
+  },
   "nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1": {
     "context": 131072,
     "output": 16384
@@ -713,6 +837,10 @@
   "nvidia/nvidia/nemotron-mini-4b-instruct": {
     "context": 128000,
     "output": 8192
+  },
+  "nvidia/nvidia/nemotron-nano-12b-v2-vl": {
+    "context": 128000,
+    "output": 128000
   },
   "nvidia/nvidia/nemotron-voicechat": {
     "context": 128000,
@@ -798,7 +926,15 @@
     "context": 128000,
     "output": 8192
   },
+  "nvidia/z-ai/glm-5.2": {
+    "context": 1000000,
+    "output": 131072
+  },
   "ollama_cloud/deepseek-v4-flash": {
+    "context": 1048576,
+    "output": 1048576
+  },
+  "ollama_cloud/deepseek-v4-flash:0731": {
     "context": 1048576,
     "output": 1048576
   },
@@ -832,6 +968,14 @@
   "ollama_cloud/kimi-k2.6": {
     "context": 262144,
     "output": 262144
+  },
+  "ollama_cloud/kimi-k2.7-code": {
+    "context": 262144,
+    "output": 262144
+  },
+  "ollama_cloud/kimi-k3": {
+    "context": 1048576,
+    "output": 131072
   },
   "ollama_cloud/minimax-m2.5": {
     "context": 204800,
@@ -908,6 +1052,10 @@
     "context": 128000,
     "output": 16384
   },
+  "openai/gpt-5": {
+    "context": 400000,
+    "output": 128000
+  },
   "openai/gpt-5-mini": {
     "context": 400000,
     "output": 128000
@@ -971,6 +1119,26 @@
   "openai/gpt-5.5-pro": {
     "context": 1050000,
     "output": 128000
+  },
+  "openai/gpt-5.6": {
+    "context": 1050000,
+    "output": 128000
+  },
+  "openai/gpt-5.6-luna": {
+    "context": 1050000,
+    "output": 128000
+  },
+  "openai/gpt-5.6-sol": {
+    "context": 1050000,
+    "output": 128000
+  },
+  "openai/gpt-5.6-terra": {
+    "context": 1050000,
+    "output": 128000
+  },
+  "openai/gpt-realtime-2.1": {
+    "context": 128000,
+    "output": 32000
   },
   "openai/o1": {
     "context": 200000,
@@ -1044,8 +1212,20 @@
     "context": 200000,
     "output": 131072
   },
+  "zai/glm-5": {
+    "context": 204800,
+    "output": 131072
+  },
   "zai/glm-5-turbo": {
     "context": 200000,
+    "output": 131072
+  },
+  "zai/glm-5.1": {
+    "context": 200000,
+    "output": 131072
+  },
+  "zai/glm-5.2": {
+    "context": 1000000,
     "output": 131072
   },
   "zai/glm-5v-turbo": {

--- a/providers/core/community_modalities.go
+++ b/providers/core/community_modalities.go
@@ -19,8 +19,8 @@ var communityModalitiesJSON []byte
 // communityModalities lazily parses the embedded table once. The file is
 // generated and committed, so a parse failure is a build defect, not a runtime
 // condition; it degrades to an empty table (modalities stay null).
-var communityModalities = sync.OnceValue(func() map[string][]types.ModelModalities {
-	table := make(map[string][]types.ModelModalities)
+var communityModalities = sync.OnceValue(func() map[string]types.ModelModalities {
+	table := make(map[string]types.ModelModalities)
 	_ = json.Unmarshal(communityModalitiesJSON, &table)
 	return table
 })
@@ -28,7 +28,7 @@ var communityModalities = sync.OnceValue(func() map[string][]types.ModelModaliti
 // applyCommunityModalities fills Modalities from the community table for models
 // the provider listing did not resolve, so provider-published modalities always
 // win. Models absent from the table keep a nil Modalities and render as explicit
-// nulls when requested. The stored slice is cloned so a caller mutating one
+// nulls when requested. The stored slices are cloned so a caller mutating one
 // model's modalities can never corrupt the shared embedded table.
 func applyCommunityModalities(models []types.Model) {
 	table := communityModalities()
@@ -37,8 +37,11 @@ func applyCommunityModalities(models []types.Model) {
 			continue
 		}
 		for _, key := range communityLookupKeys(models[i].ID) {
-			if mods, ok := table[key]; ok && len(mods) > 0 {
-				clone := slices.Clone(mods)
+			if mods, ok := table[key]; ok {
+				clone := types.ModelModalities{
+					Input:  slices.Clone(mods.Input),
+					Output: slices.Clone(mods.Output),
+				}
 				models[i].Modalities = &clone
 				break
 			}

--- a/providers/core/community_modalities.json
+++ b/providers/core/community_modalities.json
@@ -1,924 +1,2948 @@
 {
-  "anthropic/claude-fable-5": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-haiku-4-5-20251001": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-opus-4-1-20250805": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-opus-4-5-20251101": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-opus-4-6": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-opus-4-7": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-opus-4-8": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-sonnet-4-5-20250929": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-sonnet-4-6": [
-    "text",
-    "image"
-  ],
-  "anthropic/claude-sonnet-5": [
-    "text",
-    "image"
-  ],
-  "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": [
-    "text"
-  ],
-  "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": [
-    "text"
-  ],
-  "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": [
-    "text"
-  ],
-  "cloudflare/@cf/meta/llama-3.2-11b-vision-instruct": [
-    "text",
-    "image"
-  ],
-  "cloudflare/@cf/meta/llama-3.2-1b-instruct": [
-    "text"
-  ],
-  "cloudflare/@cf/meta/llama-3.2-3b-instruct": [
-    "text"
-  ],
-  "cloudflare/@cf/meta/llama-guard-3-8b": [
-    "text"
-  ],
-  "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": [
-    "text"
-  ],
-  "cloudflare/@cf/moonshotai/kimi-k2.6": [
-    "text",
-    "image"
-  ],
-  "cloudflare/@cf/moonshotai/kimi-k2.7-code": [
-    "text",
-    "image"
-  ],
-  "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": [
-    "text"
-  ],
-  "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": [
-    "text"
-  ],
-  "cloudflare/@cf/qwen/qwq-32b": [
-    "text"
-  ],
-  "cloudflare/@cf/zai-org/glm-4.7-flash": [
-    "text"
-  ],
-  "deepseek/deepseek-chat": [
-    "text"
-  ],
-  "deepseek/deepseek-reasoner": [
-    "text"
-  ],
-  "deepseek/deepseek-v4-pro": [
-    "text"
-  ],
-  "google/gemini-2.0-flash": [
-    "text",
-    "image",
-    "audio",
-    "video"
-  ],
-  "google/gemini-2.0-flash-lite": [
-    "text",
-    "image",
-    "audio",
-    "video"
-  ],
-  "google/gemini-2.5-flash-lite": [
-    "text",
-    "image",
-    "audio",
-    "video"
-  ],
-  "google/gemini-2.5-flash-preview-tts": [
-    "text"
-  ],
-  "google/gemini-2.5-pro-preview-tts": [
-    "text"
-  ],
-  "google/gemini-3-flash-preview": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3-pro-preview": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3.1-flash-image-preview": [
-    "text",
-    "image"
-  ],
-  "google/gemini-3.1-flash-lite": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3.1-flash-lite-preview": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3.1-pro-preview": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3.1-pro-preview-customtools": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-3.5-flash": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-embedding-001": [
-    "text"
-  ],
-  "google/gemini-flash-latest": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemini-flash-lite-latest": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "google/gemma-4-26b-a4b-it": [
-    "text",
-    "image"
-  ],
-  "google/gemma-4-31b-it": [
-    "text",
-    "image"
-  ],
-  "groq/canopylabs/orpheus-arabic-saudi": [
-    "text"
-  ],
-  "groq/canopylabs/orpheus-v1-english": [
-    "text"
-  ],
-  "groq/groq/compound": [
-    "text"
-  ],
-  "groq/groq/compound-mini": [
-    "text"
-  ],
-  "groq/llama-3.1-8b-instant": [
-    "text"
-  ],
-  "groq/llama-3.3-70b-versatile": [
-    "text"
-  ],
-  "groq/meta-llama/llama-prompt-guard-2-22m": [
-    "text"
-  ],
-  "groq/meta-llama/llama-prompt-guard-2-86m": [
-    "text"
-  ],
-  "groq/openai/gpt-oss-20b": [
-    "text"
-  ],
-  "groq/openai/gpt-oss-safeguard-20b": [
-    "text"
-  ],
-  "groq/qwen/qwen3.6-27b": [
-    "text",
-    "image"
-  ],
-  "groq/whisper-large-v3": [
-    "audio"
-  ],
-  "groq/whisper-large-v3-turbo": [
-    "audio"
-  ],
-  "minimax/MiniMax-M2": [
-    "text"
-  ],
-  "minimax/MiniMax-M2.1": [
-    "text"
-  ],
-  "minimax/MiniMax-M2.5": [
-    "text"
-  ],
-  "minimax/MiniMax-M2.5-highspeed": [
-    "text"
-  ],
-  "minimax/MiniMax-M2.7": [
-    "text"
-  ],
-  "minimax/MiniMax-M2.7-highspeed": [
-    "text"
-  ],
-  "minimax/MiniMax-M3": [
-    "text",
-    "image",
-    "video"
-  ],
-  "mistral/codestral-latest": [
-    "text"
-  ],
-  "mistral/devstral-2512": [
-    "text"
-  ],
-  "mistral/devstral-latest": [
-    "text"
-  ],
-  "mistral/devstral-medium-2507": [
-    "text"
-  ],
-  "mistral/devstral-medium-latest": [
-    "text"
-  ],
-  "mistral/devstral-small-2505": [
-    "text"
-  ],
-  "mistral/devstral-small-2507": [
-    "text"
-  ],
-  "mistral/labs-devstral-small-2512": [
-    "text",
-    "image"
-  ],
-  "mistral/magistral-medium-latest": [
-    "text"
-  ],
-  "mistral/magistral-small": [
-    "text"
-  ],
-  "mistral/ministral-3b-latest": [
-    "text"
-  ],
-  "mistral/ministral-8b-latest": [
-    "text"
-  ],
-  "mistral/mistral-embed": [
-    "text"
-  ],
-  "mistral/mistral-large-2411": [
-    "text"
-  ],
-  "mistral/mistral-large-2512": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-large-latest": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-medium-2505": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-medium-2508": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-medium-2604": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-nemo": [
-    "text"
-  ],
-  "mistral/mistral-small-2506": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-small-2603": [
-    "text",
-    "image"
-  ],
-  "mistral/mistral-small-latest": [
-    "text",
-    "image"
-  ],
-  "mistral/open-mistral-7b": [
-    "text"
-  ],
-  "mistral/open-mistral-nemo": [
-    "text"
-  ],
-  "mistral/open-mixtral-8x22b": [
-    "text"
-  ],
-  "mistral/open-mixtral-8x7b": [
-    "text"
-  ],
-  "mistral/pixtral-12b": [
-    "text",
-    "image"
-  ],
-  "mistral/pixtral-large-latest": [
-    "text",
-    "image"
-  ],
-  "mistral/voxtral-mini-latest": [
-    "audio"
-  ],
-  "mistral/voxtral-mini-tts-latest": [
-    "text"
-  ],
-  "mistral/voxtral-small-latest": [
-    "text",
-    "audio"
-  ],
-  "moonshot/kimi-k2-0711-preview": [
-    "text"
-  ],
-  "moonshot/kimi-k2-0905-preview": [
-    "text"
-  ],
-  "moonshot/kimi-k2-thinking": [
-    "text"
-  ],
-  "moonshot/kimi-k2-thinking-turbo": [
-    "text"
-  ],
-  "moonshot/kimi-k2-turbo-preview": [
-    "text"
-  ],
-  "moonshot/kimi-k2.5": [
-    "text",
-    "image",
-    "video"
-  ],
-  "moonshot/kimi-k2.6": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/abacusai/dracarys-llama-3.1-70b-instruct": [
-    "text"
-  ],
-  "nvidia/baai/bge-m3": [
-    "text"
-  ],
-  "nvidia/black-forest-labs/flux.1-dev": [
-    "text"
-  ],
-  "nvidia/black-forest-labs/flux_1-kontext-dev": [
-    "text",
-    "image"
-  ],
-  "nvidia/black-forest-labs/flux_1-schnell": [
-    "text"
-  ],
-  "nvidia/black-forest-labs/flux_2-klein-4b": [
-    "image",
-    "text"
-  ],
-  "nvidia/bytedance/seed-oss-36b-instruct": [
-    "text"
-  ],
-  "nvidia/google/gemma-2-2b-it": [
-    "text"
-  ],
-  "nvidia/google/gemma-3-12b-it": [
-    "text",
-    "image"
-  ],
-  "nvidia/google/gemma-3-4b-it": [
-    "text",
-    "image"
-  ],
-  "nvidia/google/gemma-3n-e2b-it": [
-    "text",
-    "image"
-  ],
-  "nvidia/google/gemma-3n-e4b-it": [
-    "text",
-    "image"
-  ],
-  "nvidia/google/gemma-4-31b-it": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/google/google-paligemma": [
-    "text",
-    "image"
-  ],
-  "nvidia/meta/esm2-650m": [
-    "text"
-  ],
-  "nvidia/meta/esmfold": [
-    "text"
-  ],
-  "nvidia/meta/llama-3.1-70b-instruct": [
-    "text"
-  ],
-  "nvidia/meta/llama-3.1-8b-instruct": [
-    "text"
-  ],
-  "nvidia/meta/llama-3.2-11b-vision-instruct": [
-    "text",
-    "image"
-  ],
-  "nvidia/meta/llama-3.2-1b-instruct": [
-    "text"
-  ],
-  "nvidia/meta/llama-3.2-3b-instruct": [
-    "text"
-  ],
-  "nvidia/meta/llama-3.2-90b-vision-instruct": [
-    "text",
-    "image"
-  ],
-  "nvidia/meta/llama-3.3-70b-instruct": [
-    "text"
-  ],
-  "nvidia/meta/llama-4-maverick-17b-128e-instruct": [
-    "text",
-    "image"
-  ],
-  "nvidia/meta/llama-guard-4-12b": [
-    "text",
-    "image"
-  ],
-  "nvidia/microsoft/phi-4-mini-instruct": [
-    "text"
-  ],
-  "nvidia/microsoft/phi-4-multimodal-instruct": [
-    "text"
-  ],
-  "nvidia/minimaxai/minimax-m2.7": [
-    "text"
-  ],
-  "nvidia/mistralai/magistral-small-2506": [
-    "text"
-  ],
-  "nvidia/mistralai/ministral-14b-instruct-2512": [
-    "text",
-    "image"
-  ],
-  "nvidia/mistralai/mistral-7b-instruct-v0.3": [
-    "text"
-  ],
-  "nvidia/mistralai/mistral-large-3-675b-instruct-2512": [
-    "text",
-    "image"
-  ],
-  "nvidia/mistralai/mistral-medium-3-instruct": [
-    "text",
-    "image"
-  ],
-  "nvidia/mistralai/mistral-nemotron": [
-    "text"
-  ],
-  "nvidia/mistralai/mistral-small-4-119b-2603": [
-    "text",
-    "image"
-  ],
-  "nvidia/mistralai/mixtral-8x22b-instruct": [
-    "text"
-  ],
-  "nvidia/mistralai/mixtral-8x7b-instruct": [
-    "text"
-  ],
-  "nvidia/moonshotai/kimi-k2-instruct-0905": [
-    "text"
-  ],
-  "nvidia/moonshotai/kimi-k2.6": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/nvidia/active-speaker-detection": [
-    "video"
-  ],
-  "nvidia/nvidia/bevformer": [
-    "video"
-  ],
-  "nvidia/nvidia/cosmos-predict1-5b": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/nvidia/cosmos-reason2-8b": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/nvidia/cosmos-transfer1-7b": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/nvidia/cosmos-transfer2_5-2b": [
-    "text",
-    "image",
-    "video"
-  ],
-  "nvidia/nvidia/gliner-pii": [
-    "text"
-  ],
-  "nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1": [
-    "text"
-  ],
-  "nvidia/nvidia/llama-3.1-nemotron-nano-vl-8b-v1": [
-    "text",
-    "image"
-  ],
-  "nvidia/nvidia/llama-3.1-nemotron-safety-guard-8b-v3": [
-    "text"
-  ],
-  "nvidia/nvidia/llama-3_2-nemoretriever-300m-embed-v1": [
-    "text"
-  ],
-  "nvidia/nvidia/llama-nemotron-embed-vl-1b-v2": [
-    "text",
-    "image"
-  ],
-  "nvidia/nvidia/llama-nemotron-rerank-vl-1b-v2": [
-    "text",
-    "image"
-  ],
-  "nvidia/nvidia/magpie-tts-zeroshot": [
-    "text",
-    "audio"
-  ],
-  "nvidia/nvidia/nemotron-3-content-safety": [
-    "text"
-  ],
-  "nvidia/nvidia/nemotron-3-nano-30b-a3b": [
-    "text"
-  ],
-  "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "nvidia/nvidia/nemotron-3-super-120b-a12b": [
-    "text"
-  ],
-  "nvidia/nvidia/nemotron-content-safety-reasoning-4b": [
-    "text"
-  ],
-  "nvidia/nvidia/nemotron-mini-4b-instruct": [
-    "text"
-  ],
-  "nvidia/nvidia/nemotron-voicechat": [
-    "text",
-    "audio"
-  ],
-  "nvidia/nvidia/nv-embed-v1": [
-    "text"
-  ],
-  "nvidia/nvidia/nv-embedcode-7b-v1": [
-    "text"
-  ],
-  "nvidia/nvidia/nvidia-nemotron-nano-9b-v2": [
-    "text"
-  ],
-  "nvidia/nvidia/rerank-qa-mistral-4b": [
-    "text"
-  ],
-  "nvidia/nvidia/riva-translate-4b-instruct-v1.1": [
-    "text"
-  ],
-  "nvidia/nvidia/sparsedrive": [
-    "video"
-  ],
-  "nvidia/nvidia/streampetr": [
-    "video"
-  ],
-  "nvidia/nvidia/studiovoice": [
-    "text"
-  ],
-  "nvidia/nvidia/synthetic-video-detector": [
-    "video"
-  ],
-  "nvidia/nvidia/usdcode": [
-    "text"
-  ],
-  "nvidia/nvidia/usdvalidate": [
-    "text"
-  ],
-  "nvidia/openai/gpt-oss-20b": [
-    "text"
-  ],
-  "nvidia/openai/whisper-large-v3": [
-    "audio"
-  ],
-  "nvidia/qwen/qwen-image": [
-    "text",
-    "image"
-  ],
-  "nvidia/qwen/qwen-image-edit": [
-    "text",
-    "image"
-  ],
-  "nvidia/qwen/qwen2.5-coder-32b-instruct": [
-    "text"
-  ],
-  "nvidia/qwen/qwen3-coder-480b-a35b-instruct": [
-    "text"
-  ],
-  "nvidia/qwen/qwen3-next-80b-a3b-instruct": [
-    "text"
-  ],
-  "nvidia/qwen/qwen3.5-122b-a10b": [
-    "text",
-    "image",
-    "video",
-    "audio"
-  ],
-  "nvidia/qwen/qwen3.5-397b-a17b": [
-    "text",
-    "image"
-  ],
-  "nvidia/sarvamai/sarvam-m": [
-    "text"
-  ],
-  "nvidia/stepfun-ai/step-3.5-flash": [
-    "text"
-  ],
-  "nvidia/stepfun-ai/step-3.7-flash": [
-    "text",
-    "image"
-  ],
-  "nvidia/upstage/solar-10.7b-instruct": [
-    "text"
-  ],
-  "ollama_cloud/deepseek-v4-flash": [
-    "text"
-  ],
-  "ollama_cloud/deepseek-v4-pro": [
-    "text"
-  ],
-  "ollama_cloud/gemma4:31b": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/glm-5.1": [
-    "text"
-  ],
-  "ollama_cloud/gpt-oss:120b": [
-    "text"
-  ],
-  "ollama_cloud/gpt-oss:20b": [
-    "text"
-  ],
-  "ollama_cloud/kimi-k2.5": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/kimi-k2.6": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/kimi-k2.7-code": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/kimi-k3": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/minimax-m2.5": [
-    "text"
-  ],
-  "ollama_cloud/minimax-m2.7": [
-    "text"
-  ],
-  "ollama_cloud/minimax-m3": [
-    "text",
-    "image",
-    "video"
-  ],
-  "ollama_cloud/mistral-large-3:675b": [
-    "text",
-    "image"
-  ],
-  "ollama_cloud/nemotron-3-nano:30b": [
-    "text"
-  ],
-  "ollama_cloud/nemotron-3-super": [
-    "text"
-  ],
-  "ollama_cloud/qwen3.5:397b": [
-    "text",
-    "image"
-  ],
-  "openai/chatgpt-image-latest": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-3.5-turbo": [
-    "text"
-  ],
-  "openai/gpt-4": [
-    "text"
-  ],
-  "openai/gpt-4-turbo": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4.1": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4.1-mini": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4.1-nano": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4o": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4o-2024-05-13": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4o-2024-08-06": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4o-2024-11-20": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-4o-mini": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5-mini": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5-nano": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5-pro": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.1": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.2": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.2-chat-latest": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.2-pro": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.3-chat-latest": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.3-codex": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.3-codex-spark": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.4": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.4-mini": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.4-nano": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.4-pro": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.5": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-5.5-pro": [
-    "text",
-    "image"
-  ],
-  "openai/gpt-image-1-mini": [
-    "text",
-    "image"
-  ],
-  "openai/o1": [
-    "text",
-    "image"
-  ],
-  "openai/o1-pro": [
-    "text",
-    "image"
-  ],
-  "openai/o3": [
-    "text",
-    "image"
-  ],
-  "openai/o3-mini": [
-    "text"
-  ],
-  "openai/o3-pro": [
-    "text",
-    "image"
-  ],
-  "openai/o4-mini": [
-    "text",
-    "image"
-  ],
-  "openai/text-embedding-3-large": [
-    "text"
-  ],
-  "openai/text-embedding-3-small": [
-    "text"
-  ],
-  "openai/text-embedding-ada-002": [
-    "text"
-  ],
-  "zai/glm-4.5": [
-    "text"
-  ],
-  "zai/glm-4.5-air": [
-    "text"
-  ],
-  "zai/glm-4.5-flash": [
-    "text"
-  ],
-  "zai/glm-4.5v": [
-    "text",
-    "image",
-    "video"
-  ],
-  "zai/glm-4.6": [
-    "text"
-  ],
-  "zai/glm-4.6v": [
-    "text",
-    "image",
-    "video"
-  ],
-  "zai/glm-4.7": [
-    "text"
-  ],
-  "zai/glm-4.7-flash": [
-    "text"
-  ],
-  "zai/glm-4.7-flashx": [
-    "text"
-  ],
-  "zai/glm-5-turbo": [
-    "text"
-  ],
-  "zai/glm-5v-turbo": [
-    "text",
-    "image",
-    "video"
-  ]
+  "anthropic/claude-fable-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-haiku-4-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-haiku-4-5-20251001": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-1-20250805": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-5-20251101": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-6": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-7": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-4-8": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-opus-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-sonnet-4-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-sonnet-4-5-20250929": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-sonnet-4-6": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "anthropic/claude-sonnet-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/aisingapore/gemma-sea-lion-v4-27b-it": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/deepseek-ai/deepseek-r1-distill-qwen-32b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/google/gemma-4-26b-a4b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/ibm-granite/granite-4.0-h-micro": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-3.1-8b-instruct-fp8": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-3.2-11b-vision-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-3.2-1b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-3.2-3b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-3.3-70b-instruct-fp8-fast": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-4-scout-17b-16e-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/meta/llama-guard-3-8b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/mistralai/mistral-small-3.1-24b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/nvidia/nemotron-3-120b-a12b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/openai/gpt-oss-120b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/openai/gpt-oss-20b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/qwen/qwen2.5-coder-32b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/qwen/qwen3-30b-a3b-fp8": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/qwen/qwq-32b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/zai-org/glm-4.7-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/zai-org/glm-5.2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/c4ai-aya-expanse-32b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/c4ai-aya-expanse-8b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/c4ai-aya-vision-32b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/c4ai-aya-vision-8b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-a-03-2025": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-a-plus-05-2026": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-a-reasoning-08-2025": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-a-translate-08-2025": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-a-vision-07-2025": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-r-08-2024": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-r-plus-08-2024": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-r7b-12-2024": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/command-r7b-arabic-02-2025": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cohere/north-mini-code-1-0": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "deepseek/deepseek-chat": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "deepseek/deepseek-reasoner": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "deepseek/deepseek-v4-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "deepseek/deepseek-v4-pro": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/deep-research-max-preview-04-2026": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/deep-research-preview-04-2026": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-2.0-flash": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.0-flash-lite": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.5-computer-use-preview-10-2025": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.5-flash": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.5-flash-image": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-2.5-flash-lite": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.5-flash-preview-tts": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "google/gemini-2.5-pro": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-2.5-pro-preview-tts": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "google/gemini-3-flash-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3-pro-image": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-3-pro-image-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-3-pro-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.1-flash-image": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-3.1-flash-image-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-3.1-flash-lite": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.1-flash-lite-image": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "google/gemini-3.1-flash-lite-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.1-flash-live-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "google/gemini-3.1-flash-tts-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "google/gemini-3.1-pro-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.1-pro-preview-customtools": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.5-flash": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.5-flash-lite": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.5-live-translate-preview": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "audio",
+      "text"
+    ]
+  },
+  "google/gemini-3.6-flash": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-embedding-001": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-embedding-2": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-flash-latest": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-flash-lite-latest": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-omni-flash-preview": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "google/gemini-robotics-er-1.6-preview": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemma-4-26b-a4b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemma-4-31b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/lyria-3-clip-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "google/lyria-3-pro-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "google/veo-3.1-fast-generate-preview": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "google/veo-3.1-generate-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "google/veo-3.1-lite-generate-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "groq/allam-2-7b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/canopylabs/orpheus-arabic-saudi": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "groq/canopylabs/orpheus-v1-english": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "groq/groq/compound": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/groq/compound-mini": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/llama-3.1-8b-instant": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/llama-3.3-70b-versatile": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/meta-llama/llama-prompt-guard-2-22m": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/meta-llama/llama-prompt-guard-2-86m": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/openai/gpt-oss-120b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/openai/gpt-oss-20b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/openai/gpt-oss-safeguard-20b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/qwen/qwen3.6-27b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/whisper-large-v3": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "groq/whisper-large-v3-turbo": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2.5": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2.5-highspeed": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2.7": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M2.7-highspeed": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "minimax/MiniMax-M3": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/codestral-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-2512": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-medium-2507": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-medium-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-small-2505": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/devstral-small-2507": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/labs-devstral-small-2512": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/magistral-medium-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/magistral-small": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/ministral-3b-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/ministral-8b-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-embed": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-large-2411": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-large-2512": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-large-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-medium-2505": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-medium-2508": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-medium-2604": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-medium-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-nemo": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-small-2506": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-small-2603": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/mistral-small-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/open-mistral-7b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/open-mistral-nemo": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/open-mixtral-8x22b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/open-mixtral-8x7b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/pixtral-12b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/pixtral-large-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/voxtral-mini-latest": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "mistral/voxtral-mini-tts-latest": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "mistral/voxtral-small-latest": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2-0711-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2-0905-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2-thinking": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2-thinking-turbo": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2-turbo-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2.5": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2.6": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2.7-code": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k2.7-code-highspeed": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "moonshot/kimi-k3": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/abacusai/dracarys-llama-3.1-70b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/baai/bge-m3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/black-forest-labs/flux.1-dev": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/black-forest-labs/flux_1-kontext-dev": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/black-forest-labs/flux_1-schnell": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/black-forest-labs/flux_2-klein-4b": {
+    "input": [
+      "image",
+      "text"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/bytedance/seed-oss-36b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/deepseek-ai/deepseek-v4-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/deepseek-ai/deepseek-v4-pro": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-2-2b-it": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-3-12b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-3-4b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-3n-e2b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-3n-e4b-it": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-4-31b-it": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/google-paligemma": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/esm2-650m": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/esmfold": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.1-70b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.1-8b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.2-11b-vision-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.2-1b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.2-3b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.2-90b-vision-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-3.3-70b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-4-maverick-17b-128e-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/llama-guard-4-12b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/microsoft/phi-4-mini-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/microsoft/phi-4-multimodal-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/minimaxai/minimax-m2.7": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/minimaxai/minimax-m3": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/magistral-small-2506": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/ministral-14b-instruct-2512": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-7b-instruct-v0.3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-large-3-675b-instruct-2512": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-medium-3-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-medium-3.5-128b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-nemotron": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-small-4-119b-2603": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mixtral-8x22b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mixtral-8x7b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/moonshotai/kimi-k2-instruct-0905": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/moonshotai/kimi-k2.6": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/active-speaker-detection": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/bevformer": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/cosmos-predict1-5b": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "nvidia/nvidia/cosmos-reason2-8b": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/cosmos-transfer1-7b": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "nvidia/nvidia/cosmos-transfer2_5-2b": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "nvidia/nvidia/gliner-pii": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-70b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-nano-8b-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-nano-vl-8b-v1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-safety-guard-8b-v3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.3-nemotron-super-49b-v1.5": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3_2-nemoretriever-300m-embed-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-nemotron-embed-vl-1b-v2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-nemotron-rerank-vl-1b-v2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/magpie-tts-zeroshot": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-content-safety": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-nano-30b-a3b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-super-120b-a12b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-ultra-550b-a55b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-content-safety-reasoning-4b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-mini-4b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-nano-12b-v2-vl": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-voicechat": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nv-embed-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nv-embedcode-7b-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nvidia-nemotron-nano-9b-v2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/rerank-qa-mistral-4b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/riva-translate-4b-instruct-v1.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/sparsedrive": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/streampetr": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/studiovoice": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/synthetic-video-detector": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/usdcode": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/usdvalidate": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/openai/gpt-oss-120b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/openai/gpt-oss-20b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/openai/whisper-large-v3": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/poolside/laguna-xs-2.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/qwen/qwen-image": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/qwen/qwen-image-edit": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "nvidia/qwen/qwen2.5-coder-32b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/qwen/qwen3-coder-480b-a35b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/qwen/qwen3-next-80b-a3b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/qwen/qwen3.5-122b-a10b": {
+    "input": [
+      "text",
+      "image",
+      "video",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/qwen/qwen3.5-397b-a17b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/sarvamai/sarvam-m": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/stepfun-ai/step-3.5-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/stepfun-ai/step-3.7-flash": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/thinkingmachines/inkling": {
+    "input": [
+      "text",
+      "image",
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/upstage/solar-10.7b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/z-ai/glm-5.2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/deepseek-v4-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/deepseek-v4-flash:0731": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/deepseek-v4-pro": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/gemma4:31b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/glm-5.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/glm-5.2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/gpt-oss:120b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/gpt-oss:20b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/kimi-k2.5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/kimi-k2.6": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/kimi-k2.7-code": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/minimax-m2.5": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/minimax-m2.7": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/minimax-m3": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/mistral-large-3:675b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/nemotron-3-nano:30b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/nemotron-3-super": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/nemotron-3-ultra": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/qwen3.5:397b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/chatgpt-image-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "openai/gpt-3.5-turbo": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4-turbo": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4.1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4.1-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4.1-nano": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-2024-05-13": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-2024-08-06": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-2024-11-20": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5-nano": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.2-chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.2-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.3-chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.3-codex": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.3-codex-spark": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.4": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.4-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.4-nano": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.4-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.5-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.6": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.6-luna": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.6-sol": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.6-terra": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-image-1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "openai/gpt-image-1-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "openai/gpt-image-1.5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
+    ]
+  },
+  "openai/gpt-image-2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "image"
+    ]
+  },
+  "openai/gpt-realtime-2.1": {
+    "input": [
+      "text",
+      "audio",
+      "image"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/o1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/o1-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/o3": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/o3-mini": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/o3-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/o4-mini": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/text-embedding-3-large": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/text-embedding-3-small": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/text-embedding-ada-002": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.5": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.5-air": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.5-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.5v": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.6": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.6v": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.7": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.7-flash": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-4.7-flashx": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5-turbo": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5.2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5v-turbo": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  }
 }

--- a/providers/core/community_modalities_test.go
+++ b/providers/core/community_modalities_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"slices"
 	"testing"
 
 	types "github.com/inference-gateway/inference-gateway/providers/types"
@@ -11,7 +12,10 @@ import (
 // (including ID variants like date pins), and models absent from the table stay
 // nil.
 func TestApplyCommunityModalities(t *testing.T) {
-	provided := []types.ModelModalities{types.ModelModalitiesText}
+	provided := types.ModelModalities{
+		Input:  []types.Modality{types.ModalityText},
+		Output: []types.Modality{types.ModalityText},
+	}
 	models := []types.Model{
 		{ID: "openai/gpt-4o", Modalities: &provided},
 		{ID: "openai/gpt-4o"},
@@ -21,16 +25,40 @@ func TestApplyCommunityModalities(t *testing.T) {
 
 	applyCommunityModalities(models)
 
-	if got := models[0].Modalities; got == nil || len(*got) != 1 || (*got)[0] != types.ModelModalitiesText {
+	if got := models[0].Modalities; got == nil || len(got.Input) != 1 || got.Input[0] != types.ModalityText {
 		t.Errorf("provider-resolved modalities overwritten: %+v", got)
 	}
-	if got := models[1].Modalities; got == nil || len(*got) == 0 {
+	if got := models[1].Modalities; got == nil || len(got.Input) == 0 || len(got.Output) == 0 {
 		t.Errorf("unresolved model did not fall back to community table: %+v", got)
 	}
-	if got := models[2].Modalities; got == nil || len(*got) == 0 {
+	if got := models[2].Modalities; got == nil || len(got.Input) == 0 {
 		t.Errorf("date-pinned ID variant did not resolve in community table: %+v", got)
 	}
 	if got := models[3].Modalities; got != nil {
 		t.Errorf("model absent from the table must keep nil modalities, got %+v", got)
+	}
+}
+
+// TestCommunityModalitiesTableDistinguishesImageGen verifies the embedded
+// table carries the output side: gpt-image-2 must be image-out without
+// text-out (image-generation), while gpt-4o outputs text (chat).
+func TestCommunityModalitiesTableDistinguishesImageGen(t *testing.T) {
+	models := []types.Model{
+		{ID: "openai/gpt-image-2"},
+		{ID: "openai/gpt-4o"},
+	}
+
+	applyCommunityModalities(models)
+
+	imageGen := models[0].Modalities
+	if imageGen == nil {
+		t.Fatal("gpt-image-2 missing from community table")
+	}
+	if len(imageGen.Output) == 0 || slices.Contains(imageGen.Output, types.ModalityText) {
+		t.Errorf("gpt-image-2 output must be image-only, got %+v", imageGen.Output)
+	}
+	chat := models[1].Modalities
+	if chat == nil || !slices.Contains(chat.Output, types.ModalityText) {
+		t.Errorf("gpt-4o must output text, got %+v", chat)
 	}
 }

--- a/providers/core/community_pricing.json
+++ b/providers/core/community_pricing.json
@@ -663,6 +663,13 @@
     "source": "community",
     "updated_at": "2026-07-27T09:42:20Z"
   },
+  "groq/allam-2-7b": {
+    "currency": "USD",
+    "input_per_token": "0",
+    "output_per_token": "0",
+    "source": "community",
+    "updated_at": "2026-08-05T16:53:50Z"
+  },
   "groq/llama-3.1-8b-instant": {
     "currency": "USD",
     "input_per_token": "0.00000005",
@@ -674,13 +681,6 @@
     "currency": "USD",
     "input_per_token": "0.00000059",
     "output_per_token": "0.00000079",
-    "source": "community",
-    "updated_at": "2026-07-20T22:04:30Z"
-  },
-  "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
-    "currency": "USD",
-    "input_per_token": "0.00000011",
-    "output_per_token": "0.00000034",
     "source": "community",
     "updated_at": "2026-07-20T22:04:30Z"
   },
@@ -721,12 +721,13 @@
     "source": "community",
     "updated_at": "2026-07-20T22:04:30Z"
   },
-  "groq/qwen/qwen3-32b": {
+  "groq/qwen/qwen3.6-27b": {
+    "cache_read_per_token": "0.0000003",
     "currency": "USD",
-    "input_per_token": "0.00000029",
-    "output_per_token": "0.00000059",
+    "input_per_token": "0.0000006",
+    "output_per_token": "0.000003",
     "source": "community",
-    "updated_at": "2026-07-20T22:04:30Z"
+    "updated_at": "2026-08-05T16:53:50Z"
   },
   "minimax/MiniMax-M2": {
     "currency": "USD",

--- a/providers/types/common_types.go
+++ b/providers/types/common_types.go
@@ -624,24 +624,24 @@ func (e MessagesToolUseBlockType) Valid() bool {
 	}
 }
 
-// Defines values for ModelModalities.
+// Defines values for Modality.
 const (
-	ModelModalitiesAudio ModelModalities = "audio"
-	ModelModalitiesImage ModelModalities = "image"
-	ModelModalitiesText  ModelModalities = "text"
-	ModelModalitiesVideo ModelModalities = "video"
+	ModalityAudio Modality = "audio"
+	ModalityImage Modality = "image"
+	ModalityText  Modality = "text"
+	ModalityVideo Modality = "video"
 )
 
-// Valid indicates whether the value is a known member of the ModelModalities enum.
-func (e ModelModalities) Valid() bool {
+// Valid indicates whether the value is a known member of the Modality enum.
+func (e Modality) Valid() bool {
 	switch e {
-	case ModelModalitiesAudio:
+	case ModalityAudio:
 		return true
-	case ModelModalitiesImage:
+	case ModalityImage:
 		return true
-	case ModelModalitiesText:
+	case ModalityText:
 		return true
-	case ModelModalitiesVideo:
+	case ModalityVideo:
 		return true
 	default:
 		return false
@@ -2444,6 +2444,9 @@ type MessagesUsage struct {
 	OutputTokens int64 `json:"output_tokens"`
 }
 
+// Modality A single input or output modality
+type Modality string
+
 // Model Common model information
 type Model struct {
 	// ContextWindow Context window information for the model (included when `include=context_window`)
@@ -2451,18 +2454,21 @@ type Model struct {
 	Created       int64          `json:"created"`
 	ID            string         `json:"id"`
 
-	// Modalities The modalities the model supports natively (included when `include=modalities`)
-	Modalities *[]ModelModalities `json:"modalities,omitempty"`
-	Object     string             `json:"object"`
-	OwnedBy    string             `json:"owned_by"`
+	// Modalities The input and output modalities of the model (included when `include=modalities`)
+	Modalities *ModelModalities `json:"modalities,omitempty"`
+	Object     string           `json:"object"`
+	OwnedBy    string           `json:"owned_by"`
 
 	// Pricing Pricing information for the model (included when `include=pricing`)
 	Pricing  *Pricing `json:"pricing,omitempty"`
 	ServedBy Provider `json:"served_by"`
 }
 
-// ModelModalities defines model for Model.Modalities.
-type ModelModalities string
+// ModelModalities The input and output modalities of a model, mirroring the models.dev dataset shape. Vision models accept `image` in `input`; image-generation models list `image` in `output` — when `output` carries `image` but not `text`, the model only generates images and cannot chat.
+type ModelModalities struct {
+	Input  []Modality `json:"input"`
+	Output []Modality `json:"output"`
+}
 
 // Pricing Pricing information for a model
 type Pricing struct {


### PR DESCRIPTION
Completes the downstream sync of schemas v0.22 (nested `ModelModalities`) that the automated sync workflow could not finish ([failed run](https://github.com/inference-gateway/inference-gateway/actions/runs/31026938909/job/92377714031)) — the regenerated types turned `ModelModalities` from a string enum into a `{input, output}` struct, and `communitygen`/`providers/core` still consumed it as an enum.

## Changes

- **Vendored `openapi.yaml` + regenerated types**: `Model.modalities` is now `ModelModalities {input, output []Modality}`. `/v1/models?include=modalities` reports both sides — image-generation models are the ones with `image` in `output` but no `text` (e.g. `gpt-image-2`: `{input: [text, image], output: [image]}`), distinguishable from vision chat models for the first time. Endpoint and query param unchanged.
- **`communitygen`**: adapted to the struct shape, and fixed a second latent bug — models.dev introduced `base_model` inheritance (provider files reference canonical `models/<lab>/<model>.toml` definitions and omit their own sections). The walker read only provider files, silently dropping every inheriting model. `forEachModel` now buffers canonical definitions and merges them section-by-section (provider-published values win) before visiting, which benefits all three community tables.
- **Fresh table sync**: modalities 254 → **337** entries — now covering `gpt-image-2`, `deepseek/deepseek-v4-flash`, the `nvidia/deepseek-ai/*` catalog, and ollama tagged variants (`:0731`). Pricing and context-window tables refreshed through the same inheritance fix.

## Cross-repo impact

- `sdk` (Go) and other SDKs must regenerate against schemas v0.22 (breaking type change).
- `cli` consumes the new shape for model-picker labels and image-gen filtering (inference-gateway/cli#1031 follow-up).
- `docs`: models endpoint reference needs the nested example.
