### PR TITLE
fix(telemetry): append /v1/traces to path-less OTLP trace endpoints

### DIFF
--- a/otel/otel.go
+++ b/otel/otel.go
@@ -5,6 +5,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"net/url"
 
 	config "github.com/inference-gateway/inference-gateway/config"
 	logger "github.com/inference-gateway/inference-gateway/logger"
@@ -78,6 +79,22 @@ type OpenTelemetryImpl struct {
 	guardrailCounter        metric.Int64Counter     // inference_gateway.guardrails
 }
 
+// TracesEndpointURL appends the OTLP traces path to a path-less endpoint URL.
+// otel-go 1.45.0 stopped appending the default /v1/traces in WithEndpointURL,
+// so a bare TELEMETRY_TRACING_OTLP_ENDPOINT like http://localhost:4318 would
+// silently export to "/" instead.
+func TracesEndpointURL(endpoint string) string {
+	u, err := url.Parse(endpoint)
+	if err != nil || (u.Path != "" && u.Path != "/") {
+		return endpoint
+	}
+	joined, err := url.JoinPath(endpoint, "v1/traces")
+	if err != nil {
+		return endpoint
+	}
+	return joined
+}
+
 // Semconv-recommended bucket boundaries: durations in seconds, token counts in powers of 4.
 var (
 	durationBoundaries = []float64{0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92}
@@ -119,7 +136,7 @@ func (o *OpenTelemetryImpl) Init(cfg config.Config, log logger.Logger) error {
 
 	if cfg.Telemetry.TracingEnabled {
 		traceExporter, err := otlptracehttp.New(context.Background(),
-			otlptracehttp.WithEndpointURL(cfg.Telemetry.TracingOtlpEndpoint))
+			otlptracehttp.WithEndpointURL(TracesEndpointURL(cfg.Telemetry.TracingOtlpEndpoint)))
 		if err != nil {
 			o.logger.Error("failed to create otlp trace exporter", err)
 			return err

--- a/tests/tracing_test.go
+++ b/tests/tracing_test.go
@@ -28,6 +28,7 @@ import (
 	config "github.com/inference-gateway/inference-gateway/config"
 	mcp "github.com/inference-gateway/inference-gateway/internal/mcp"
 	logger "github.com/inference-gateway/inference-gateway/logger"
+	otel "github.com/inference-gateway/inference-gateway/otel"
 	client "github.com/inference-gateway/inference-gateway/providers/client"
 	constants "github.com/inference-gateway/inference-gateway/providers/constants"
 	registry "github.com/inference-gateway/inference-gateway/providers/registry"
@@ -306,4 +307,16 @@ func TestTracingProxyPropagation(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.NotEmpty(t, upstreamTraceparent, "proxied request must carry traceparent")
+}
+
+func TestTracingTracesEndpointURL(t *testing.T) {
+	cases := map[string]string{
+		"http://localhost:4318":           "http://localhost:4318/v1/traces",
+		"http://localhost:4318/":          "http://localhost:4318/v1/traces",
+		"http://collector:4318/v1/traces": "http://collector:4318/v1/traces",
+		"https://otlp.example.com/custom": "https://otlp.example.com/custom",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, otel.TracesEndpointURL(in))
+	}
 }


### PR DESCRIPTION
## Problem

Since v0.48.0, gateway spans no longer reach the OTLP collector — trace trees (e.g. the `infer traces` footer in infer-action runs) show only CLI-side spans.

## Root cause

#551 bumped `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp` from v1.44.0 to v1.45.0, which includes an upstream breaking change (open-telemetry/opentelemetry-go#8538): `WithEndpointURL` no longer appends the default `/v1/traces` path when the endpoint URL has no path — it posts to `/` instead.

The default `TELEMETRY_TRACING_OTLP_ENDPOINT=http://localhost:4318` has no path, so every trace export silently 404'd at the collector (batch exporter errors go to the otel global error handler, not the gateway logger).

## Fix

`TracesEndpointURL` appends `v1/traces` when the configured endpoint has no path (or only `/`), restoring pre-1.45 behavior. Endpoints that already carry an explicit path are passed through unchanged.

The metrics side is unaffected — it uses the Prometheus pull exporter, not `otlpmetrichttp`.

## Testing

- `TestTracingTracesEndpointURL` covers bare, trailing-slash, already-suffixed, and custom-path endpoints
- `go test ./...` passes

Closes the regression introduced in v0.48.0.