### PR TITLE
fix: correct MiniMax M3 community pricing

### DIFF
--- a/providers/core/community_pricing.json
+++ b/providers/core/community_pricing.json
@@ -764,12 +764,12 @@
     "updated_at": "2026-07-20T22:04:30Z"
   },
   "minimax/MiniMax-M3": {
-    "cache_read_per_token": "0.00000006",
+    "cache_read_per_token": "0.00000012",
     "currency": "USD",
-    "input_per_token": "0.0000003",
-    "output_per_token": "0.0000012",
+    "input_per_token": "0.0000006",
+    "output_per_token": "0.0000024",
     "source": "community",
-    "updated_at": "2026-07-20T22:04:30Z"
+    "updated_at": "2026-08-16T06:15:34Z"
   },
   "mistral/codestral-latest": {
     "currency": "USD",

--- a/providers/core/community_pricing.overrides.json
+++ b/providers/core/community_pricing.overrides.json
@@ -1,1 +1,10 @@
-{}
+{
+  "minimax/MiniMax-M3": {
+    "cache_read_per_token": "0.00000012",
+    "currency": "USD",
+    "input_per_token": "0.0000006",
+    "output_per_token": "0.0000024",
+    "source": "community",
+    "updated_at": "2026-08-16T06:15:34Z"
+  }
+}

--- a/providers/core/community_pricing_test.go
+++ b/providers/core/community_pricing_test.go
@@ -1,8 +1,12 @@
 package core
 
 import (
+	"encoding/json"
+	"os"
 	"reflect"
 	"testing"
+
+	types "github.com/inference-gateway/inference-gateway/providers/types"
 )
 
 func TestCommunityLookupKeys(t *testing.T) {
@@ -25,5 +29,23 @@ func TestCommunityLookupKeys(t *testing.T) {
 				t.Fatalf("communityLookupKeys(%q) = %v, want %v", tt.id, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCommunityPricingOverridesMatchGeneratedTable(t *testing.T) {
+	data, err := os.ReadFile("community_pricing.overrides.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var overrides map[string]types.Pricing
+	if err := json.Unmarshal(data, &overrides); err != nil {
+		t.Fatal(err)
+	}
+
+	table := communityPricing()
+	for model, override := range overrides {
+		if got, ok := table[model]; !ok || !reflect.DeepEqual(got, override) {
+			t.Errorf("generated pricing for %q does not match its override", model)
+		}
 	}
 }


### PR DESCRIPTION
Reason: Correct MiniMax M3 community pricing to the current published rates.

- Update the committed community pricing table.
- Add a durable pricing override so future syncs preserve the correction.
- Verify that committed generated pricing matches every maintained override.

Checks:
- `go test -race ./providers/core ./internal/communitygen`
- `go test ./...`
- `golangci-lint run ./providers/core/... ./internal/communitygen/...`
- `git diff --check`
