### PR TITLE
fix(flox): restrict claude-code to systems with catalog builds

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -6,7 +6,12 @@
       "claude-code": {
         "pkg-path": "claude-code",
         "pkg-group": "claude-code",
-        "version": "^2.1.201"
+        "version": "^2.1.201",
+        "systems": [
+          "aarch64-darwin",
+          "aarch64-linux",
+          "x86_64-linux"
+        ]
       },
       "codex": {
         "pkg-path": "codex",
@@ -178,35 +183,6 @@
         "out": "/nix/store/fm203s00j5ignfgr4f05p2fc7ppmhfy0-claude-code-2.1.201"
       },
       "system": "aarch64-linux",
-      "group": "claude-code",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-code",
-      "broken": false,
-      "derivation": "/nix/store/94k99z7q71qjfhf0h1524c9i14b5a8jm-claude-code-2.1.201.drv",
-      "description": "Agentic coding tool that lives in your terminal, understands your codebase, and helps you code faster",
-      "install_id": "claude-code",
-      "license": "Unfree",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=d407951447dcd00442e97087bf374aad70c04cea",
-      "name": "claude-code-2.1.201",
-      "pname": "claude-code",
-      "rev": "d407951447dcd00442e97087bf374aad70c04cea",
-      "rev_count": 1027867,
-      "rev_date": "2026-07-05T04:06:12Z",
-      "scrape_date": "2026-07-06T04:09:00.518525Z",
-      "stabilities": [
-        "unstable"
-      ],
-      "unfree": true,
-      "version": "2.1.201",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/23hm04zk9nn86835a2985p7a5pfd62bb-claude-code-2.1.201"
-      },
-      "system": "x86_64-darwin",
       "group": "claude-code",
       "priority": 5
     },

--- a/.flox/env/manifest.toml
+++ b/.flox/env/manifest.toml
@@ -57,6 +57,7 @@ infer.flake = "github:inference-gateway/cli/v0.164.0"
 claude-code.pkg-path = "claude-code"
 claude-code.version = "^2.1.201"
 claude-code.pkg-group = "claude-code"
+claude-code.systems = ["aarch64-darwin", "aarch64-linux", "x86_64-linux"]
 codex.pkg-path = "codex"
 codex.version = "^0.142.3"
 codex.pkg-group = "codex"


### PR DESCRIPTION
nixpkgs no longer builds `claude-code` for `x86_64-darwin` (Intel mac), and this repo is the only one declaring it in `options.systems` - flox must resolve the `claude-code` pkg-group for every declared system, so `migrate-claude.yml`'s bump to `^2.1.238` failed here (and only here): https://github.com/inference-gateway/.github/actions/runs/33076490505/job/98532087789

One-line fix: scope `claude-code` to `aarch64-darwin`, `aarch64-linux`, `x86_64-linux`. The rest of the env keeps Intel-mac support. After merge, re-running `migrate-claude.yml` completes the bump.