### PR TITLE
fix(models): resolve community modalities for speech, image, video and dated model ids

### DIFF
--- a/providers/core/community_modalities.json
+++ b/providers/core/community_modalities.json
@@ -295,6 +295,23 @@
       "text"
     ]
   },
+  "cloudflare/@cf/zai-org/glm-5.3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "cloudflare/@cf/zai-org/glm-5.3-flash": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "cohere/c4ai-aya-expanse-32b": {
     "input": [
       "text"
@@ -411,22 +428,6 @@
       "text"
     ]
   },
-  "deepseek/deepseek-chat": {
-    "input": [
-      "text"
-    ],
-    "output": [
-      "text"
-    ]
-  },
-  "deepseek/deepseek-reasoner": {
-    "input": [
-      "text"
-    ],
-    "output": [
-      "text"
-    ]
-  },
   "deepseek/deepseek-v4-flash": {
     "input": [
       "text"
@@ -445,6 +446,23 @@
     ]
   },
   "deepseek/deepseek-v4-pro": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/antigravity-preview-05-2026": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/aqa": {
     "input": [
       "text"
     ],
@@ -474,6 +492,14 @@
     "output": [
       "text",
       "image"
+    ]
+  },
+  "google/deep-research-pro-preview-12-2025": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
     ]
   },
   "google/gemini-2.5-computer-use-preview-10-2025": {
@@ -515,6 +541,39 @@
     ],
     "output": [
       "text"
+    ]
+  },
+  "google/gemini-2.5-flash-native-audio": {
+    "input": [
+      "text",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "google/gemini-2.5-flash-native-audio-preview-09-2025": {
+    "input": [
+      "text",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "google/gemini-2.5-flash-native-audio-preview-12-2025": {
+    "input": [
+      "text",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text",
+      "audio"
     ]
   },
   "google/gemini-2.5-flash-preview-tts": {
@@ -701,6 +760,22 @@
       "text"
     ]
   },
+  "google/gemini-3.5-transcribe": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-3.5-transcribe-live": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "google/gemini-3.6-flash": {
     "input": [
       "text",
@@ -742,6 +817,14 @@
       "text"
     ]
   },
+  "google/gemini-embedding-2-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "google/gemini-flash-latest": {
     "input": [
       "text",
@@ -764,6 +847,17 @@
       "text"
     ]
   },
+  "google/gemini-omni-1.1-flash": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "google/gemini-omni-flash-preview": {
     "input": [
       "text",
@@ -774,12 +868,43 @@
       "video"
     ]
   },
+  "google/gemini-pro": {
+    "input": [
+      "text",
+      "image",
+      "audio",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "google/gemini-robotics-er-1.6-preview": {
     "input": [
       "text",
       "image",
       "video",
       "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-robotics-er-2-preview": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "google/gemini-robotics-er-2-streaming-preview": {
+    "input": [
+      "text",
+      "image",
+      "video"
     ],
     "output": [
       "text"
@@ -821,6 +946,24 @@
     "output": [
       "text",
       "audio"
+    ]
+  },
+  "google/lyria-realtime-exp": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "google/nano-banana-pro-preview": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text",
+      "image"
     ]
   },
   "google/veo-3.1-fast-generate-preview": {
@@ -945,6 +1088,22 @@
     ],
     "output": [
       "text"
+    ]
+  },
+  "groq/playai-tts": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "groq/playai-tts-arabic": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
     ]
   },
   "groq/qwen/qwen3.6-27b": {
@@ -1307,6 +1466,14 @@
       "text"
     ]
   },
+  "mistral/zai-glm-5-2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "moonshot/kimi-k2-0711-preview": {
     "input": [
       "text"
@@ -1397,6 +1564,14 @@
       "text"
     ]
   },
+  "nvidia/01-ai/yi-large": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/abacusai/dracarys-llama-3.1-70b-instruct": {
     "input": [
       "text"
@@ -1405,7 +1580,40 @@
       "text"
     ]
   },
+  "nvidia/adept/fuyu-8b": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/ai21labs/jamba-1.5-large-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/aisingapore/sea-lion-7b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/baai/bge-m3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/bigcode/starcoder2-15b": {
     "input": [
       "text"
     ],
@@ -1455,6 +1663,22 @@
       "text"
     ]
   },
+  "nvidia/databricks/dbrx-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/deepseek-ai/deepseek-coder-6.7b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/deepseek-ai/deepseek-v4-flash": {
     "input": [
       "text"
@@ -1479,7 +1703,56 @@
       "text"
     ]
   },
+  "nvidia/deepseek-ai/deepseek-v4-pro-0813": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/codegemma-1.1-7b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/codegemma-7b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/deplot": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/diffusiongemma-26b-a4b-it": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/google/gemma-2-2b-it": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/gemma-2b": {
     "input": [
       "text"
     ],
@@ -1537,6 +1810,54 @@
     "input": [
       "text",
       "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/google/recurrentgemma-2b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/ibm/granite-3.0-3b-a800m-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/ibm/granite-3.0-8b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/ibm/granite-34b-code-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/ibm/granite-8b-code-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/meta/codellama-70b": {
+    "input": [
+      "text"
     ],
     "output": [
       "text"
@@ -1634,10 +1955,44 @@
       "text"
     ]
   },
+  "nvidia/meta/llama2-70b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/meta/muse-glimmer-30b": {
     "input": [
       "text",
       "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/microsoft/kosmos-2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/microsoft/phi-3-vision-128k-instruct": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/microsoft/phi-3.5-moe-instruct": {
+    "input": [
+      "text"
     ],
     "output": [
       "text"
@@ -1677,6 +2032,14 @@
       "text"
     ]
   },
+  "nvidia/mistralai/codestral-22b-instruct-v0.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/mistralai/magistral-small-2506": {
     "input": [
       "text"
@@ -1695,6 +2058,22 @@
     ]
   },
   "nvidia/mistralai/mistral-7b-instruct-v0.3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-large": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/mistralai/mistral-large-2-instruct": {
     "input": [
       "text"
     ],
@@ -1754,6 +2133,14 @@
       "text"
     ]
   },
+  "nvidia/mistralai/mixtral-8x22b-v0.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/mistralai/mixtral-8x7b-instruct": {
     "input": [
       "text"
@@ -1790,7 +2177,23 @@
       "text"
     ]
   },
+  "nvidia/nv-mistralai/mistral-nemo-12b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/active-speaker-detection": {
+    "input": [
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/ai-synthetic-video-detector": {
     "input": [
       "video"
     ],
@@ -1846,7 +2249,39 @@
       "video"
     ]
   },
+  "nvidia/nvidia/embed-qa-4": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/gliner-pii": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemoguard-8b-content-safety": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemoguard-8b-topic-control": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-51b-instruct": {
     "input": [
       "text"
     ],
@@ -1888,6 +2323,23 @@
     ]
   },
   "nvidia/nvidia/llama-3.1-nemotron-ultra-253b-v1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/llama-3.2-nv-embedqa-1b-v1": {
     "input": [
       "text"
     ],
@@ -1937,6 +2389,14 @@
       "text"
     ]
   },
+  "nvidia/nvidia/llama3-chatqa-1.5-70b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/magpie-tts-zeroshot": {
     "input": [
       "text",
@@ -1946,7 +2406,23 @@
       "audio"
     ]
   },
+  "nvidia/nvidia/mistral-nemo-minitron-8b-8k-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/nemotron-3-content-safety": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-3-embed-1b": {
     "input": [
       "text"
     ],
@@ -1989,7 +2465,31 @@
       "text"
     ]
   },
+  "nvidia/nvidia/nemotron-3.5-content-safety": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/nemotron-3.5-lightning-30b-a3b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-4-340b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-4-340b-reward": {
     "input": [
       "text"
     ],
@@ -2023,10 +2523,35 @@
       "text"
     ]
   },
+  "nvidia/nvidia/nemotron-nano-3-30b-a3b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nemotron-parse": {
+    "input": [
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/nemotron-voicechat": {
     "input": [
       "text",
       "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/neva-22b": {
+    "input": [
+      "text",
+      "image"
     ],
     "output": [
       "text"
@@ -2048,6 +2573,23 @@
       "text"
     ]
   },
+  "nvidia/nvidia/nv-embedqa-mistral-7b-v2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/nvclip": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/nvidia-nemotron-nano-9b-v2": {
     "input": [
       "text"
@@ -2064,7 +2606,23 @@
       "text"
     ]
   },
+  "nvidia/nvidia/riva-translate-4b-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/nvidia/riva-translate-4b-instruct-v1.1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/riva-translate-4b-instruct-v2": {
     "input": [
       "text"
     ],
@@ -2115,6 +2673,16 @@
   "nvidia/nvidia/usdvalidate": {
     "input": [
       "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/nvidia/vila": {
+    "input": [
+      "text",
+      "image",
+      "video"
     ],
     "output": [
       "text"
@@ -2222,6 +2790,14 @@
       "text"
     ]
   },
+  "nvidia/snowflake/arctic-embed-l": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/stepfun-ai/step-3.5-flash": {
     "input": [
       "text"
@@ -2257,7 +2833,47 @@
       "text"
     ]
   },
+  "nvidia/writer/palmyra-creative-122b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/writer/palmyra-fin-70b-32k": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/writer/palmyra-med-70b": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/writer/palmyra-med-70b-32k": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "nvidia/z-ai/glm-5.2": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "nvidia/zyphra/zamba2-7b-instruct": {
     "input": [
       "text"
     ],
@@ -2314,6 +2930,24 @@
       "text"
     ]
   },
+  "ollama_cloud/glm-5.3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/glm-5.3-flash": {
+    "input": [
+      "text",
+      "image",
+      "video"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "ollama_cloud/gpt-oss:120b": {
     "input": [
       "text"
@@ -2352,6 +2986,14 @@
     "input": [
       "text",
       "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "ollama_cloud/kimi-k3": {
+    "input": [
+      "text"
     ],
     "output": [
       "text"
@@ -2425,6 +3067,23 @@
       "text"
     ]
   },
+  "openai/babbage-002": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "openai/chatgpt-image-latest": {
     "input": [
       "text",
@@ -2435,6 +3094,14 @@
       "image"
     ]
   },
+  "openai/davinci-002": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "openai/gpt-3.5-turbo": {
     "input": [
       "text"
@@ -2443,7 +3110,55 @@
       "text"
     ]
   },
+  "openai/gpt-3.5-turbo-0125": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-3.5-turbo-1106": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-3.5-turbo-16k": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-3.5-turbo-instruct": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-3.5-turbo-instruct-0914": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "openai/gpt-4": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4-0613": {
     "input": [
       "text"
     ],
@@ -2532,7 +3247,73 @@
       "text"
     ]
   },
+  "openai/gpt-4o-mini-search-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-mini-transcribe": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-mini-tts": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "openai/gpt-4o-search-preview": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-transcribe": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-4o-transcribe-diarize": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "openai/gpt-5": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5-chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5-codex": {
     "input": [
       "text",
       "image"
@@ -2568,7 +3349,51 @@
       "text"
     ]
   },
+  "openai/gpt-5-search-api": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
   "openai/gpt-5.1": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.1-chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.1-codex": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.1-codex-max": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.1-codex-mini": {
     "input": [
       "text",
       "image"
@@ -2587,6 +3412,15 @@
     ]
   },
   "openai/gpt-5.2-chat-latest": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-5.2-codex": {
     "input": [
       "text",
       "image"
@@ -2721,6 +3555,36 @@
       "text"
     ]
   },
+  "openai/gpt-audio": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-audio-1.5": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-audio-mini": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
   "openai/gpt-image-1": {
     "input": [
       "text",
@@ -2759,6 +3623,44 @@
       "image"
     ]
   },
+  "openai/gpt-live-transcribe": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-realtime": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-realtime-1.5": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-realtime-2": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
   "openai/gpt-realtime-2.1": {
     "input": [
       "text",
@@ -2768,6 +3670,52 @@
     "output": [
       "text",
       "audio"
+    ]
+  },
+  "openai/gpt-realtime-2.1-mini": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-realtime-mini": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-realtime-translate": {
+    "input": [
+      "text",
+      "audio"
+    ],
+    "output": [
+      "text",
+      "audio"
+    ]
+  },
+  "openai/gpt-realtime-whisper": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/gpt-transcribe": {
+    "input": [
+      "audio"
+    ],
+    "output": [
+      "text"
     ]
   },
   "openai/o1": {
@@ -2823,6 +3771,33 @@
       "text"
     ]
   },
+  "openai/omni-moderation": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/sora-2": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "video"
+    ]
+  },
+  "openai/sora-2-pro": {
+    "input": [
+      "text",
+      "image"
+    ],
+    "output": [
+      "video"
+    ]
+  },
   "openai/text-embedding-3-large": {
     "input": [
       "text"
@@ -2842,6 +3817,46 @@
   "openai/text-embedding-ada-002": {
     "input": [
       "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "openai/tts-1": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "openai/tts-1-1106": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "openai/tts-1-hd": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "openai/tts-1-hd-1106": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "audio"
+    ]
+  },
+  "openai/whisper-1": {
+    "input": [
+      "audio"
     ],
     "output": [
       "text"
@@ -2950,6 +3965,24 @@
   "zai/glm-5.2": {
     "input": [
       "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5.3": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "zai/glm-5.3-flash": {
+    "input": [
+      "text",
+      "image",
+      "video"
     ],
     "output": [
       "text"

--- a/providers/core/community_modalities.overrides.json
+++ b/providers/core/community_modalities.overrides.json
@@ -1,1 +1,306 @@
-{}
+{
+  "google/antigravity-preview-05-2026": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "google/aqa": { "input": ["text"], "output": ["text"] },
+  "google/deep-research-pro-preview-12-2025": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "google/gemini-2.5-flash-native-audio": {
+    "input": ["text", "audio", "video"],
+    "output": ["text", "audio"]
+  },
+  "google/gemini-2.5-flash-native-audio-preview-09-2025": {
+    "input": ["text", "audio", "video"],
+    "output": ["text", "audio"]
+  },
+  "google/gemini-2.5-flash-native-audio-preview-12-2025": {
+    "input": ["text", "audio", "video"],
+    "output": ["text", "audio"]
+  },
+  "google/gemini-3.5-transcribe": { "input": ["audio"], "output": ["text"] },
+  "google/gemini-3.5-transcribe-live": {
+    "input": ["audio"],
+    "output": ["text"]
+  },
+  "google/gemini-embedding-2-preview": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "google/gemini-omni-1.1-flash": {
+    "input": ["text", "image", "audio", "video"],
+    "output": ["text"]
+  },
+  "google/gemini-pro": {
+    "input": ["text", "image", "audio", "video"],
+    "output": ["text"]
+  },
+  "google/gemini-robotics-er-2-preview": {
+    "input": ["text", "image", "video"],
+    "output": ["text"]
+  },
+  "google/gemini-robotics-er-2-streaming-preview": {
+    "input": ["text", "image", "video"],
+    "output": ["text"]
+  },
+  "google/lyria-realtime-exp": { "input": ["text"], "output": ["audio"] },
+  "google/nano-banana-pro-preview": {
+    "input": ["text", "image"],
+    "output": ["text", "image"]
+  },
+  "groq/playai-tts": { "input": ["text"], "output": ["audio"] },
+  "groq/playai-tts-arabic": { "input": ["text"], "output": ["audio"] },
+  "nvidia/01-ai/yi-large": { "input": ["text"], "output": ["text"] },
+  "nvidia/adept/fuyu-8b": { "input": ["text", "image"], "output": ["text"] },
+  "nvidia/ai21labs/jamba-1.5-large-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/aisingapore/sea-lion-7b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/bigcode/starcoder2-15b": { "input": ["text"], "output": ["text"] },
+  "nvidia/databricks/dbrx-instruct": { "input": ["text"], "output": ["text"] },
+  "nvidia/deepseek-ai/deepseek-coder-6.7b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/google/codegemma-1.1-7b": { "input": ["text"], "output": ["text"] },
+  "nvidia/google/codegemma-7b": { "input": ["text"], "output": ["text"] },
+  "nvidia/google/deplot": { "input": ["text", "image"], "output": ["text"] },
+  "nvidia/google/diffusiongemma-26b-a4b-it": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/google/gemma-2b": { "input": ["text"], "output": ["text"] },
+  "nvidia/google/recurrentgemma-2b": { "input": ["text"], "output": ["text"] },
+  "nvidia/ibm/granite-3.0-3b-a800m-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/ibm/granite-3.0-8b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/ibm/granite-34b-code-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/ibm/granite-8b-code-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/meta/codellama-70b": { "input": ["text"], "output": ["text"] },
+  "nvidia/meta/llama2-70b": { "input": ["text"], "output": ["text"] },
+  "nvidia/microsoft/kosmos-2": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "nvidia/microsoft/phi-3-vision-128k-instruct": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "nvidia/microsoft/phi-3.5-moe-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/mistralai/codestral-22b-instruct-v0.1": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/mistralai/mistral-large": { "input": ["text"], "output": ["text"] },
+  "nvidia/mistralai/mistral-large-2-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/mistralai/mixtral-8x22b-v0.1": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nv-mistralai/mistral-nemo-12b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/ai-synthetic-video-detector": {
+    "input": ["video"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/embed-qa-4": { "input": ["text"], "output": ["text"] },
+  "nvidia/nvidia/llama-3.1-nemoguard-8b-content-safety": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/llama-3.1-nemoguard-8b-topic-control": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/llama-3.1-nemotron-51b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/llama-3.2-nemoretriever-1b-vlm-embed-v1": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/llama-3.2-nv-embedqa-1b-v1": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/llama3-chatqa-1.5-70b": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/mistral-nemo-minitron-8b-8k-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-3-embed-1b": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-3.5-content-safety": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-4-340b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-4-340b-reward": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-nano-3-30b-a3b": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nemotron-parse": { "input": ["image"], "output": ["text"] },
+  "nvidia/nvidia/neva-22b": { "input": ["text", "image"], "output": ["text"] },
+  "nvidia/nvidia/nv-embedqa-mistral-7b-v2": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/nvclip": { "input": ["text", "image"], "output": ["text"] },
+  "nvidia/nvidia/riva-translate-4b-instruct": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/riva-translate-4b-instruct-v2": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/nvidia/vila": {
+    "input": ["text", "image", "video"],
+    "output": ["text"]
+  },
+  "nvidia/snowflake/arctic-embed-l": { "input": ["text"], "output": ["text"] },
+  "nvidia/writer/palmyra-creative-122b": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/writer/palmyra-fin-70b-32k": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/writer/palmyra-med-70b": { "input": ["text"], "output": ["text"] },
+  "nvidia/writer/palmyra-med-70b-32k": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "nvidia/zyphra/zamba2-7b-instruct": { "input": ["text"], "output": ["text"] },
+  "ollama_cloud/kimi-k3": { "input": ["text"], "output": ["text"] },
+  "openai/babbage-002": { "input": ["text"], "output": ["text"] },
+  "openai/chat-latest": { "input": ["text", "image"], "output": ["text"] },
+  "openai/davinci-002": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-3.5-turbo-0125": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-3.5-turbo-1106": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-3.5-turbo-16k": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-3.5-turbo-instruct": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-3.5-turbo-instruct-0914": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "openai/gpt-4-0613": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-4o-mini-search-preview": {
+    "input": ["text"],
+    "output": ["text"]
+  },
+  "openai/gpt-4o-mini-transcribe": { "input": ["audio"], "output": ["text"] },
+  "openai/gpt-4o-mini-tts": { "input": ["text"], "output": ["audio"] },
+  "openai/gpt-4o-search-preview": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-4o-transcribe": { "input": ["audio"], "output": ["text"] },
+  "openai/gpt-4o-transcribe-diarize": {
+    "input": ["audio"],
+    "output": ["text"]
+  },
+  "openai/gpt-5-chat-latest": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "openai/gpt-5-codex": { "input": ["text", "image"], "output": ["text"] },
+  "openai/gpt-5-search-api": { "input": ["text"], "output": ["text"] },
+  "openai/gpt-5.1-chat-latest": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "openai/gpt-5.1-codex": { "input": ["text", "image"], "output": ["text"] },
+  "openai/gpt-5.1-codex-max": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "openai/gpt-5.1-codex-mini": {
+    "input": ["text", "image"],
+    "output": ["text"]
+  },
+  "openai/gpt-5.2-codex": { "input": ["text", "image"], "output": ["text"] },
+  "openai/gpt-audio": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-audio-1.5": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-audio-mini": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-live-transcribe": { "input": ["audio"], "output": ["text"] },
+  "openai/gpt-realtime": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-1.5": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-2": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-2.1-mini": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-mini": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-translate": {
+    "input": ["text", "audio"],
+    "output": ["text", "audio"]
+  },
+  "openai/gpt-realtime-whisper": { "input": ["audio"], "output": ["text"] },
+  "openai/gpt-transcribe": { "input": ["audio"], "output": ["text"] },
+  "openai/omni-moderation": { "input": ["text", "image"], "output": ["text"] },
+  "openai/sora-2": { "input": ["text", "image"], "output": ["video"] },
+  "openai/sora-2-pro": { "input": ["text", "image"], "output": ["video"] },
+  "openai/tts-1": { "input": ["text"], "output": ["audio"] },
+  "openai/tts-1-1106": { "input": ["text"], "output": ["audio"] },
+  "openai/tts-1-hd": { "input": ["text"], "output": ["audio"] },
+  "openai/tts-1-hd-1106": { "input": ["text"], "output": ["audio"] },
+  "openai/whisper-1": { "input": ["audio"], "output": ["text"] }
+}

--- a/providers/core/community_modalities_test.go
+++ b/providers/core/community_modalities_test.go
@@ -63,6 +63,31 @@ func TestCommunityModalitiesTableDistinguishesImageGen(t *testing.T) {
 	}
 }
 
+// TestCommunityModalitiesOverridesCoverSpeechModels verifies the hand-curated
+// overlay survives a re-sync into the embedded table: speech models absent
+// from models.dev must resolve with the correct audio side.
+func TestCommunityModalitiesOverridesCoverSpeechModels(t *testing.T) {
+	models := []types.Model{
+		{ID: "openai/tts-1"},
+		{ID: "openai/whisper-1"},
+		{ID: "groq/playai-tts"},
+	}
+
+	applyCommunityModalities(models)
+
+	tts := models[0].Modalities
+	if tts == nil || !slices.Contains(tts.Output, types.ModalityAudio) || slices.Contains(tts.Output, types.ModalityText) {
+		t.Errorf("tts-1 must be audio-out without text-out, got %+v", tts)
+	}
+	stt := models[1].Modalities
+	if stt == nil || !slices.Contains(stt.Input, types.ModalityAudio) {
+		t.Errorf("whisper-1 must be audio-in, got %+v", stt)
+	}
+	if models[2].Modalities == nil {
+		t.Error("playai-tts missing from community table")
+	}
+}
+
 // TestModelAcceptsImages verifies the per-model vision gate: table-confirmed
 // vision models pass (including date-pinned IDs), table-confirmed text-only
 // models fail, and unknown models pass so requests are never silently stripped.
@@ -75,7 +100,7 @@ func TestModelAcceptsImages(t *testing.T) {
 	}{
 		{"vision model with date pin", "anthropic", "claude-haiku-4-5-20251001", true},
 		{"vision model", "anthropic", "claude-haiku-4-5", true},
-		{"text-only model", "deepseek", "deepseek-chat", false},
+		{"text-only model", "deepseek", "deepseek-v4-flash", false},
 		{"unknown model is permissive", "openai", "gpt-nonexistent", true},
 	}
 	for _, tt := range tests {

--- a/providers/core/community_pricing.go
+++ b/providers/core/community_pricing.go
@@ -45,8 +45,9 @@ func applyCommunityPricing(models []types.Model) {
 }
 
 // communityLookupKeys returns candidate table keys for a gateway model ID in
-// preference order: exact, without Google's "models/" path prefix, without a
-// "-latest" alias suffix, and without a trailing "-YYYYMMDD" date pin, so
+// preference order: exact, without Ollama's ":tag" suffix, without Google's
+// "models/" path prefix, without a "-latest" alias suffix, and without a
+// trailing "-YYYYMMDD" (Anthropic) or "-YYYY-MM-DD" (OpenAI) date pin, so
 // upstream listing IDs still match the dataset's canonical names. Each
 // candidate containing dots also gets an underscored variant, because
 // models.dev file names replace dots in model ids (e.g. NIM's
@@ -56,6 +57,10 @@ func communityLookupKeys(id string) []string {
 	provider, model, ok := strings.Cut(id, "/")
 	if !ok {
 		return keys
+	}
+	if rest, _, found := strings.Cut(model, ":"); found {
+		model = rest
+		keys = append(keys, provider+"/"+model)
 	}
 	if rest, found := strings.CutPrefix(model, "models/"); found {
 		model = rest
@@ -67,12 +72,21 @@ func communityLookupKeys(id string) []string {
 	if len(model) > 9 && model[len(model)-9] == '-' && isDigits(model[len(model)-8:]) {
 		keys = append(keys, provider+"/"+model[:len(model)-9])
 	}
+	if len(model) > 11 && isDashedDate(model[len(model)-11:]) {
+		keys = append(keys, provider+"/"+model[:len(model)-11])
+	}
 	for _, key := range keys {
 		if strings.Contains(key, ".") {
 			keys = append(keys, strings.ReplaceAll(key, ".", "_"))
 		}
 	}
 	return keys
+}
+
+// isDashedDate reports whether s is a "-YYYY-MM-DD" date-pin suffix.
+func isDashedDate(s string) bool {
+	return len(s) == 11 && s[0] == '-' && s[5] == '-' && s[8] == '-' &&
+		isDigits(s[1:5]) && isDigits(s[6:8]) && isDigits(s[9:11])
 }
 
 func isDigits(s string) bool {

--- a/providers/core/community_pricing_test.go
+++ b/providers/core/community_pricing_test.go
@@ -19,6 +19,8 @@ func TestCommunityLookupKeys(t *testing.T) {
 		{"google models prefix", "google/models/gemini-2.0-flash", []string{"google/models/gemini-2.0-flash", "google/gemini-2.0-flash", "google/models/gemini-2_0-flash", "google/gemini-2_0-flash"}},
 		{"latest alias", "anthropic/claude-3-5-sonnet-latest", []string{"anthropic/claude-3-5-sonnet-latest", "anthropic/claude-3-5-sonnet"}},
 		{"date pin", "anthropic/claude-sonnet-4-5-20250929", []string{"anthropic/claude-sonnet-4-5-20250929", "anthropic/claude-sonnet-4-5"}},
+		{"dashed date pin", "openai/gpt-5-2025-08-07", []string{"openai/gpt-5-2025-08-07", "openai/gpt-5"}},
+		{"ollama tag", "ollama_cloud/deepseek-v4-pro:0813", []string{"ollama_cloud/deepseek-v4-pro:0813", "ollama_cloud/deepseek-v4-pro"}},
 		{"not a date suffix", "groq/llama-3.3-70b", []string{"groq/llama-3.3-70b", "groq/llama-3_3-70b"}},
 		{"no provider prefix", "gpt-4o", []string{"gpt-4o"}},
 		{"dotted nim id", "nvidia/upstage/solar-10.7b-instruct", []string{"nvidia/upstage/solar-10.7b-instruct", "nvidia/upstage/solar-10_7b-instruct"}},

--- a/tests/api_modalities_test.go
+++ b/tests/api_modalities_test.go
@@ -1,0 +1,80 @@
+package tests
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+
+	constants "github.com/inference-gateway/inference-gateway/providers/constants"
+)
+
+func TestListModelsHandler_ModalitiesResolution(t *testing.T) {
+	mux := http.NewServeMux()
+	writeJSON := func(w http.ResponseWriter, payload string) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}
+
+	mux.HandleFunc("/proxy/openai/models", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"object":"list","data":[{"id":"tts-1","object":"model","created":1750000000,"owned_by":"openai"},{"id":"whisper-1","object":"model","created":1750000000,"owned_by":"openai"},{"id":"gpt-5-2025-08-07","object":"model","created":1750000000,"owned_by":"openai"},{"id":"gpt-nonexistent","object":"model","created":1750000000,"owned_by":"openai"}]}`)
+	})
+
+	mux.HandleFunc("/proxy/ollama_cloud/models", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, `{"object":"list","data":[{"id":"deepseek-v4-pro:0813","object":"model","created":1750000000,"owned_by":"ollama"}]}`)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	providerCfg := contextWindowProviderConfig(server.URL, constants.OpenaiID, constants.OllamaCloudID)
+	r := newContextWindowRouter(t, server, providerCfg)
+
+	t.Run("include resolves overlay, normalized, and null modalities", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/models?include=modalities", nil)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		models := modelsByID(t, w.Body.Bytes())
+		require.Len(t, models, 5)
+
+		tts, ok := models["openai/tts-1"]["modalities"].(map[string]any)
+		require.True(t, ok, "overlay-covered speech models must resolve modalities")
+		assert.Equal(t, []any{"text"}, tts["input"])
+		assert.Equal(t, []any{"audio"}, tts["output"], "text-to-speech models must be audio-out")
+
+		stt, ok := models["openai/whisper-1"]["modalities"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, []any{"audio"}, stt["input"], "speech-to-text models must be audio-in")
+		assert.Equal(t, []any{"text"}, stt["output"])
+
+		dated, ok := models["openai/gpt-5-2025-08-07"]["modalities"].(map[string]any)
+		require.True(t, ok, "dashed date-pinned IDs must resolve to their base table entry")
+		assert.Contains(t, dated["input"], "text")
+
+		tagged, ok := models["ollama_cloud/deepseek-v4-pro:0813"]["modalities"].(map[string]any)
+		require.True(t, ok, "ollama tag-suffixed IDs must resolve to their base table entry")
+		assert.Contains(t, tagged["input"], "text")
+
+		unknown, exists := models["openai/gpt-nonexistent"]["modalities"]
+		require.True(t, exists, "requested modalities must be present as an explicit key")
+		assert.Nil(t, unknown, "models absent from the community table must carry null modalities")
+	})
+
+	t.Run("without include no modalities key appears", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/v1/models", nil)
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+
+		for id, model := range modelsByID(t, w.Body.Bytes()) {
+			_, exists := model["modalities"]
+			assert.False(t, exists, "model %q should not carry modalities without include", id)
+		}
+	})
+}


### PR DESCRIPTION
Closes #570

## What

`GET /v1/models?include=modalities` returned `"modalities": null` for 152 of 293 models on a live gateway. Two root causes, two fixes:

1. **Lookup normalization gaps** in `communityLookupKeys` (shared by the pricing, context-window and modalities tables):
   - OpenAI-style dashed date pins (`gpt-5-2025-08-07`) never matched their base entry — only Anthropic-style `-YYYYMMDD` was stripped
   - Ollama-style `:tag` suffixes (`deepseek-v4-pro:0813`) never matched
2. **Data gaps**: models.dev simply does not carry `tts-1`, `whisper-1`, `omni-moderation-*`, `sora-2`, `playai-tts`, most of the NVIDIA NIM catalog, and Google's preview/speech models. These are now hand-curated in `community_modalities.overrides.json`, which the generator merges over every re-sync (overrides win and survive `task modalities:sync`).

Also re-syncs `community_modalities.json` from the current models.dev dataset.

## Result

Verified against a live gateway with real provider keys: **null modalities drop from 152/293 to 1/293** (`nvidia/nvidia/ising-calibration-1.5-31b`, genuinely unclassifiable). `null` now means unknown, as the issue asked.

The issue's option 2 (a first-class `type` field) was considered and dropped as redundant — clients derive capability from the modalities pair (schemas PR inference-gateway/schemas#189 closed unmerged).

## Tests

- `communityLookupKeys` cases for dashed date pins and `:tag` suffixes
- overlay coverage test (`tts-1` audio-out, `whisper-1` audio-in, `playai-tts`)
- new handler-level `?include=modalities` test (`tests/api_modalities_test.go`) covering overlay, normalized-ID and explicit-null rendering — a previously untested path
- `go test -race ./...`, `task lint`, `task generate` all clean

## Cross-repo impact

Contained to this repo. `inference-gateway/cli` can drop its model-picker blocklist (inference-gateway/cli#1132) once this ships — capability filtering on modalities now works across the catalog.