### PR TITLE
fix(proxy): relay upstream status and body on streaming /proxy requests

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -131,9 +131,13 @@ func (router *RouterImpl) ProxyHandler(c *gin.Context) {
 	handleProxyRequest(c, provider, router)
 }
 
+// handleStreamingRequest serves the /proxy streaming path (selected by an
+// Accept: text/event-stream request) by relaying the upstream response line by
+// line. Only a real event stream gets the SSE headers: anything else the
+// upstream answers, an error envelope or a JSON reply from an endpoint that
+// never streams, is relayed verbatim with its own status code and
+// Content-Type, mirroring the Messages and Responses handlers.
 func handleStreamingRequest(c *gin.Context, provider core.IProvider, router *RouterImpl) {
-	middlewares.SetSSEHeaders(c)
-
 	fullURL, err := constructProviderURL(provider, c.Param("path"), c.Request.URL.RawQuery)
 	if err != nil {
 		router.logger.Error("failed to construct provider url", err, "provider", provider.GetName())
@@ -171,12 +175,54 @@ func handleStreamingRequest(c *gin.Context, provider core.IProvider, router *Rou
 	}
 	defer resp.Body.Close()
 
+	contentType := resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "text/event-stream") {
+		c.DataFromReader(resp.StatusCode, resp.ContentLength, contentType, resp.Body, nil)
+		return
+	}
+
+	middlewares.SetSSEHeaders(c)
+	c.Status(resp.StatusCode)
+
 	reader := bufio.NewReaderSize(resp.Body, 4096)
 
 	c.Stream(func(w io.Writer) bool {
 		middlewares.ResetWriteDeadline(c, router.cfg.Server.WriteTimeout)
 
+		// A final line without a trailing newline arrives together with
+		// io.EOF, so it must be written before the error is inspected.
 		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			if router.cfg.Environment == "development" {
+				shouldLog := len(line) > 512 ||
+					(c.Param("provider") != "" && (len(line)%10 == 0))
+
+				if shouldLog {
+					router.logger.Debug("stream chunk",
+						"provider", c.Param("provider"),
+						"bytes", len(line),
+						"data_preview", func() string {
+							preview := string(bytes.TrimSpace(line))
+							if len(preview) > 200 {
+								return preview[:200] + "... (truncated)"
+							}
+							return preview
+						}(),
+					)
+				}
+			}
+
+			if _, werr := w.Write(line); werr != nil {
+				router.logger.Error("failed to write response", werr,
+					"bytes", len(line))
+				return false
+			}
+
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
+
 		if err != nil {
 			if err != io.EOF {
 				router.logger.Error("failed to read stream", err,
@@ -184,39 +230,6 @@ func handleStreamingRequest(c *gin.Context, provider core.IProvider, router *Rou
 					"method", c.Request.Method)
 			}
 			return false
-		}
-
-		if len(line) == 0 {
-			return true
-		}
-
-		if router.cfg.Environment == "development" {
-			shouldLog := len(line) > 512 ||
-				(c.Param("provider") != "" && len(line) > 0 && (len(line)%10 == 0))
-
-			if shouldLog {
-				router.logger.Debug("stream chunk",
-					"provider", c.Param("provider"),
-					"bytes", len(line),
-					"data_preview", func() string {
-						preview := string(bytes.TrimSpace(line))
-						if len(preview) > 200 {
-							return preview[:200] + "... (truncated)"
-						}
-						return preview
-					}(),
-				)
-			}
-		}
-
-		if _, err := w.Write(line); err != nil {
-			router.logger.Error("failed to write response", err,
-				"bytes", len(line))
-			return false
-		}
-
-		if flusher, ok := w.(http.Flusher); ok {
-			flusher.Flush()
 		}
 
 		return true

--- a/tests/api_proxy_test.go
+++ b/tests/api_proxy_test.go
@@ -1,0 +1,182 @@
+package tests
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gin "github.com/gin-gonic/gin"
+	assert "github.com/stretchr/testify/assert"
+	require "github.com/stretchr/testify/require"
+	gomock "go.uber.org/mock/gomock"
+
+	api "github.com/inference-gateway/inference-gateway/api"
+	config "github.com/inference-gateway/inference-gateway/config"
+	logger "github.com/inference-gateway/inference-gateway/logger"
+	constants "github.com/inference-gateway/inference-gateway/providers/constants"
+	registry "github.com/inference-gateway/inference-gateway/providers/registry"
+	types "github.com/inference-gateway/inference-gateway/providers/types"
+	providersmocks "github.com/inference-gateway/inference-gateway/tests/mocks/providers"
+)
+
+const (
+	sseContentType  = "text/event-stream"
+	jsonContentType = "application/json"
+)
+
+// newProxyGateway mounts ProxyHandler in front of upstreamURL and returns the
+// gateway test server. The provider client is a passthrough so the streaming
+// path performs a real HTTP round trip against the upstream.
+func newProxyGateway(t *testing.T, upstreamURL string, serverCfg *config.ServerConfig) *httptest.Server {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockClient := providersmocks.NewMockClient(ctrl)
+	mockClient.EXPECT().
+		Do(gomock.Any()).
+		DoAndReturn(func(req *http.Request) (*http.Response, error) {
+			return http.DefaultClient.Do(req)
+		}).
+		AnyTimes()
+
+	log, err := logger.NewLogger("test")
+	require.NoError(t, err)
+
+	providerCfg := map[types.Provider]*registry.ProviderConfig{
+		constants.OpenaiID: {
+			ID:       constants.OpenaiID,
+			Name:     constants.OpenaiDisplayName,
+			URL:      upstreamURL,
+			Token:    "test-key",
+			AuthType: constants.AuthTypeBearer,
+		},
+	}
+	cfg := config.Config{
+		Server:    serverCfg,
+		Providers: providerCfg,
+	}
+	router := api.NewRouter(cfg, log, registry.NewProviderRegistry(providerCfg, log), mockClient, nil, nil, nil)
+
+	r := gin.New()
+	r.Any("/proxy/:provider/*path", router.ProxyHandler)
+
+	gateway := httptest.NewServer(r)
+	t.Cleanup(gateway.Close)
+	return gateway
+}
+
+// The hand-rolled streaming path of /proxy (selected by Accept:
+// text/event-stream) must relay whatever the upstream answered: an error
+// envelope keeps its status code and JSON content type instead of being
+// wrapped in a 200 event stream, and a real event stream is passed through.
+func TestProxyHandler_StreamingRelaysUpstreamResponse(t *testing.T) {
+	tests := []struct {
+		name                string
+		upstreamStatus      int
+		upstreamContentType string
+		upstreamBody        string
+	}{
+		{
+			name:                "upstream error envelope keeps its status and JSON content type",
+			upstreamStatus:      http.StatusUnauthorized,
+			upstreamContentType: jsonContentType,
+			upstreamBody:        `{"error":{"message":"invalid api key"}}`,
+		},
+		{
+			name:                "upstream rate limit keeps its status and JSON content type",
+			upstreamStatus:      http.StatusTooManyRequests,
+			upstreamContentType: jsonContentType,
+			upstreamBody:        `{"error":{"message":"rate limit exceeded"}}`,
+		},
+		{
+			name:                "upstream non-streaming success is relayed as JSON",
+			upstreamStatus:      http.StatusOK,
+			upstreamContentType: jsonContentType,
+			upstreamBody:        `{"object":"list","data":[]}`,
+		},
+		{
+			name:                "upstream event stream is streamed through",
+			upstreamStatus:      http.StatusOK,
+			upstreamContentType: sseContentType,
+			upstreamBody:        "data: {\"id\":\"chunk-1\"}\n\ndata: [DONE]\n\n",
+		},
+		{
+			name:                "final stream line without trailing newline is not dropped",
+			upstreamStatus:      http.StatusOK,
+			upstreamContentType: sseContentType,
+			upstreamBody:        "data: {\"id\":\"chunk-1\"}\n\ndata: [DONE]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "Bearer test-key", r.Header.Get("Authorization"))
+				w.Header().Set("Content-Type", tt.upstreamContentType)
+				w.WriteHeader(tt.upstreamStatus)
+				_, _ = w.Write([]byte(tt.upstreamBody))
+			}))
+			defer upstream.Close()
+
+			gateway := newProxyGateway(t, upstream.URL, &config.ServerConfig{
+				ReadTimeout:  5 * time.Second,
+				WriteTimeout: 5 * time.Second,
+			})
+
+			req, err := http.NewRequest(http.MethodPost, gateway.URL+"/proxy/openai/chat/completions", strings.NewReader(`{"model":"gpt-4o","stream":true}`))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", jsonContentType)
+			req.Header.Set("Accept", sseContentType)
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.upstreamStatus, resp.StatusCode)
+			assert.Contains(t, resp.Header.Get("Content-Type"), tt.upstreamContentType)
+			assert.Equal(t, tt.upstreamBody, string(body))
+		})
+	}
+}
+
+// Errors the gateway raises before contacting the upstream (here: an
+// oversized body) must be plain JSON errors, not responses carrying the SSE
+// headers of a stream that never started.
+func TestProxyHandler_StreamingRejectsOversizedBodyAsJSON(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	const maxBodySize = 16
+	gateway := newProxyGateway(t, upstream.URL, &config.ServerConfig{
+		ReadTimeout:        5 * time.Second,
+		WriteTimeout:       5 * time.Second,
+		MaxRequestBodySize: maxBodySize,
+	})
+
+	req, err := http.NewRequest(http.MethodPost, gateway.URL+"/proxy/openai/chat/completions", strings.NewReader(strings.Repeat("x", maxBodySize+1)))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", jsonContentType)
+	req.Header.Set("Accept", sseContentType)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), jsonContentType)
+	assert.Empty(t, resp.Header.Get("Cache-Control"), "SSE headers must not leak onto a JSON error")
+	assert.Equal(t, int32(0), upstreamCalls.Load(), "upstream must not be contacted")
+}


### PR DESCRIPTION
## Summary

`ANY /proxy/:provider/*path` has a hand-rolled streaming path that is selected when the caller sends `Accept: text/event-stream`. It set the SSE headers and started a `200` event stream before looking at what the upstream actually answered, so an upstream error (401, 429, 5xx, ...) came back to the client as `200 OK` with `Content-Type: text/event-stream`. On top of that, the stream loop returned on `io.EOF` before writing the line it had just read, so a JSON error body without a trailing newline was dropped entirely: the client saw an empty `200` event stream and had no way to tell the request had failed.

The gateway's own self-proxy hop for `/v1/chat/completions` is not affected (it sends `Accept: text/event-stream, application/json` and goes through the `httputil.ReverseProxy` path), so this only changes what external callers of `/proxy` with `Accept: text/event-stream` see.

## Changes

- `handleStreamingRequest` now relays anything that is not an event stream (an error envelope, or JSON from an endpoint that never streams) verbatim with the upstream status code and `Content-Type`, and only sets the SSE headers once a real `text/event-stream` response is in hand. This mirrors what `MessagesHandler` and `ResponsesHandler` already do.
- The upstream status code is propagated for the SSE path as well (`c.Status(resp.StatusCode)`).
- A final line that arrives together with `io.EOF` is written before the error is inspected, same as the sibling handlers, so the last `data: [DONE]` of a stream without a trailing newline is no longer lost.
- Gateway-side errors raised before the upstream is contacted (for example `413 Request body too large`) are plain JSON responses again instead of carrying `Cache-Control: no-cache` and a `text/event-stream` content type.

## Tests

`tests/api_proxy_test.go` mounts `ProxyHandler` in front of a real `httptest` upstream and covers: 401 and 429 JSON envelopes keeping their status, content type and body; a non-streaming 200 JSON reply relayed as JSON; an event stream passed through unchanged; a stream whose final line has no trailing newline; and an oversized body rejected as a JSON 413 without SSE headers and without contacting the upstream.

`go test -race ./...`, `go vet ./...` and `golangci-lint run` are clean.
