### PR TITLE
docs: fix dead CONTRIBUTING links and complete README provider and example lists

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,7 @@ The Flox environment provides all necessary development tools with pinned versio
 - kubectl, Helm (for Kubernetes examples)
 - And many more utilities
 
-For detailed development information, see [DEVELOPMENT.md](./DEVELOPMENT.md).
+For detailed development information, see [AGENTS.md](./AGENTS.md).
 
 **Git Hooks:** The installed hook from `.githooks/` runs automatically on
 `git commit`:
@@ -117,7 +117,7 @@ task generate                  # Generate code from OpenAPI spec
 task pre-commit:install        # Install git hooks (recommended)
 ```
 
-For detailed development information, see [DEVELOPMENT.md](./DEVELOPMENT.md) and [CLAUDE.md](./CLAUDE.md).
+For detailed development information, see [AGENTS.md](./AGENTS.md).
 
 ### Code Style
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use of Mixture of Experts.
 
 | Feature                          | Description                                                                                                                                                                                               |
 | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🔀 **Unified API**               | One OpenAI-compatible endpoint for OpenAI, Anthropic, Groq, Cohere, Ollama, Ollama Cloud, Cloudflare, DeepSeek, Google, Mistral, Moonshot, and Nvidia                                                     |
+| 🔀 **Unified API**               | One OpenAI-compatible endpoint for OpenAI, Anthropic, Groq, Cohere, Ollama, Ollama Cloud, llama.cpp, Cloudflare, DeepSeek, Google, Mistral, MiniMax, Moonshot, Nvidia, and Z.ai                           |
 | 🔧 **Tool-use Support**          | Function calling capabilities across supported providers with a unified API                                                                                                                               |
 | 🌐 **MCP Support**               | Full Model Context Protocol integration - tools from MCP servers are discovered and exposed to LLMs automatically                                                                                         |
 | 🌊 **Streaming**                 | Real-time token streaming from all supported providers                                                                                                                                                    |
@@ -483,6 +483,7 @@ The included Grafana dashboard provides:
 - [OpenAI](https://platform.openai.com/)
 - [Ollama](https://ollama.com/)
 - [Ollama Cloud](https://ollama.com/cloud) (Preview)
+- [llama.cpp](https://github.com/ggml-org/llama.cpp)
 - [Groq](https://console.groq.com/)
 - [Cloudflare](https://www.cloudflare.com/)
 - [Cohere](https://docs.cohere.com/docs/the-cohere-platform)
@@ -490,8 +491,10 @@ The included Grafana dashboard provides:
 - [DeepSeek](https://api-docs.deepseek.com/)
 - [Google](https://aistudio.google.com/)
 - [Mistral](https://mistral.ai/)
+- [MiniMax](https://platform.minimax.io/docs)
 - [Moonshot](https://platform.moonshot.ai/)
 - [Nvidia](https://build.nvidia.com/)
+- [Z.ai](https://docs.z.ai/)
 
 ## Configuration
 
@@ -532,6 +535,10 @@ model supports vision.
   - [Authentication & Authorization](examples/docker-compose/authentication/) - OIDC
     authentication and guardrails authorization setup
   - [Tools](examples/docker-compose/tools/) - Tool integration examples
+  - [Guardrails](examples/docker-compose/guardrails/) - OPA/Rego request
+    guardrails
+  - [Monitoring](examples/docker-compose/monitoring/) - Prometheus and
+    Grafana metrics stack
 - Using [Kubernetes](examples/kubernetes/)
   - [Basic setup](examples/kubernetes/basic/) - Simple Kubernetes deployment
   - [MCP Integration](examples/kubernetes/mcp/) - Model Context Protocol in
@@ -541,6 +548,8 @@ model supports vision.
     Kubernetes
   - [Authentication](examples/kubernetes/authentication/) - OIDC authentication
     in Kubernetes
+  - [Guardrails](examples/kubernetes/guardrails/) - OPA/Rego guardrails via
+    the operator
   - [Monitoring](examples/kubernetes/monitoring/) - Observability and monitoring
     setup
   - [TLS setup](examples/kubernetes/tls/) - TLS/SSL configuration


### PR DESCRIPTION
## Summary

Small docs-only fix, no code changes.

- `CONTRIBUTING.md` linked to `./DEVELOPMENT.md` in two places, but that file has never existed in the repository (`git log --all -- DEVELOPMENT.md` is empty). Both links now point at `AGENTS.md`, which is where the development guidance lives (`CLAUDE.md` is a symlink to it).
- `README.md` listed 12 providers while the `Provider` enum in `openapi.yaml` has 15. Added the missing **llama.cpp**, **MiniMax** and **Z.ai** to the feature table and to the "Supported API's" list.
- The README "Examples" section did not mention the `examples/docker-compose/guardrails`, `examples/docker-compose/monitoring` and `examples/kubernetes/guardrails` directories, although they exist and have their own READMEs. Added one line each.

## Checks

- A scan of every relative link in all `*.md` files finds no remaining broken targets.
- `prettier --write` and `markdownlint` (same invocation as CI) are clean on both files.
