### PR TITLE
refactor(auth): drop unused AUTH_OIDC_CLIENT_SECRET setting

### DIFF
--- a/Configurations.md
+++ b/Configurations.md
@@ -54,12 +54,11 @@
 
 ### Authentication
 
-| Environment Variable    | Default Value                                         | Description           |
-| ----------------------- | ----------------------------------------------------- | --------------------- |
-| AUTH_ENABLED            | `false`                                               | Enable authentication |
-| AUTH_OIDC_ISSUER        | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL       |
-| AUTH_OIDC_CLIENT_ID     | `inference-gateway-client`                            | OIDC client ID        |
-| AUTH_OIDC_CLIENT_SECRET | `""`                                                  | OIDC client secret    |
+| Environment Variable | Default Value                                         | Description           |
+| -------------------- | ----------------------------------------------------- | --------------------- |
+| AUTH_ENABLED         | `false`                                               | Enable authentication |
+| AUTH_OIDC_ISSUER     | `http://keycloak:8080/realms/inference-gateway-realm` | OIDC issuer URL       |
+| AUTH_OIDC_CLIENT_ID  | `inference-gateway-client`                            | OIDC client ID        |
 
 ### Guardrails
 

--- a/config/config.go
+++ b/config/config.go
@@ -78,10 +78,9 @@ type MCPConfig struct {
 
 // Authentication configuration
 type AuthConfig struct {
-	Enabled          bool   `env:"ENABLED, default=false" description:"Enable authentication"`
-	OidcIssuer       string `env:"OIDC_ISSUER, default=http://keycloak:8080/realms/inference-gateway-realm" description:"OIDC issuer URL"`
-	OidcClientId     string `env:"OIDC_CLIENT_ID, default=inference-gateway-client" type:"secret" description:"OIDC client ID"`
-	OidcClientSecret string `env:"OIDC_CLIENT_SECRET" type:"secret" description:"OIDC client secret"`
+	Enabled      bool   `env:"ENABLED, default=false" description:"Enable authentication"`
+	OidcIssuer   string `env:"OIDC_ISSUER, default=http://keycloak:8080/realms/inference-gateway-realm" description:"OIDC issuer URL"`
+	OidcClientId string `env:"OIDC_CLIENT_ID, default=inference-gateway-client" type:"secret" description:"OIDC client ID"`
 }
 
 // Guardrails configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -69,10 +69,9 @@ func defaultConfig(mutate func(*config.Config)) config.Config {
 			ExternalTimeout: 5 * time.Second,
 		},
 		Auth: &config.AuthConfig{
-			Enabled:          false,
-			OidcIssuer:       "http://keycloak:8080/realms/inference-gateway-realm",
-			OidcClientId:     "inference-gateway-client",
-			OidcClientSecret: "",
+			Enabled:      false,
+			OidcIssuer:   "http://keycloak:8080/realms/inference-gateway-realm",
+			OidcClientId: "inference-gateway-client",
 		},
 		Server: &config.ServerConfig{
 			Host:               "127.0.0.1",

--- a/examples/docker-compose/authentication/.env.example
+++ b/examples/docker-compose/authentication/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/authentication/README.md
+++ b/examples/docker-compose/authentication/README.md
@@ -25,7 +25,7 @@ The stack runs three services:
 | ------------------------ | ----------------------------------------------------- |
 | Realm                    | `inference-gateway-realm`                             |
 | Client ID                | `inference-gateway-client`                            |
-| Client secret            | `very-secret`                                         |
+| Keycloak client secret   | `very-secret` (used only by `get-token.sh`)           |
 | Test user / password     | `user` / `password`                                   |
 | OIDC issuer (in-network) | `http://keycloak:8080/realms/inference-gateway-realm` |
 | Gateway                  | `http://localhost:8080`                               |
@@ -127,8 +127,9 @@ The shape of an error tells you which layer rejected the request:
 ## How it works
 
 - Authentication is enabled through the gateway service's `environment` block in
-  `docker-compose.yml` (`AUTH_ENABLED`, `AUTH_OIDC_ISSUER`, `AUTH_OIDC_CLIENT_ID`,
-  `AUTH_OIDC_CLIENT_SECRET`), so the generated `.env.example` stays untouched.
+  `docker-compose.yml` (`AUTH_ENABLED`, `AUTH_OIDC_ISSUER`, `AUTH_OIDC_CLIENT_ID`),
+  so the generated `.env.example` stays untouched. The gateway only verifies
+  tokens against the issuer's public keys, so it never needs the client secret.
 - Keycloak starts with `--import-realm` and the realm definition in
   `keycloak/realm-export.json`. That realm adds an **audience mapper** so issued
   tokens include `inference-gateway-client` in their `aud` claim - the gateway

--- a/examples/docker-compose/authentication/docker-compose.yml
+++ b/examples/docker-compose/authentication/docker-compose.yml
@@ -49,7 +49,6 @@ services:
       AUTH_ENABLED: 'true'
       AUTH_OIDC_ISSUER: http://keycloak:8080/realms/inference-gateway-realm
       AUTH_OIDC_CLIENT_ID: inference-gateway-client
-      AUTH_OIDC_CLIENT_SECRET: very-secret
     ports:
       - '8080:8080'
     depends_on:

--- a/examples/docker-compose/basic/.env.example
+++ b/examples/docker-compose/basic/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/guardrails/.env.example
+++ b/examples/docker-compose/guardrails/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/hybrid/.env.example
+++ b/examples/docker-compose/hybrid/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/mcp/.env.example
+++ b/examples/docker-compose/mcp/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/monitoring/.env.example
+++ b/examples/docker-compose/monitoring/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/docker-compose/tools/.env.example
+++ b/examples/docker-compose/tools/.env.example
@@ -43,7 +43,6 @@ MCP_DISABLE_HEALTHCHECK_LOGS=true
 AUTH_ENABLED=false
 AUTH_OIDC_ISSUER=http://keycloak:8080/realms/inference-gateway-realm
 AUTH_OIDC_CLIENT_ID=inference-gateway-client
-AUTH_OIDC_CLIENT_SECRET=
 # Guardrails
 GUARDRAILS_ENABLED=false
 GUARDRAILS_POLICY_DIR=

--- a/examples/kubernetes/authentication/README.md
+++ b/examples/kubernetes/authentication/README.md
@@ -25,8 +25,9 @@ This example demonstrates Keycloak (OIDC) authentication with the Inference Gate
 - **Identity Provider**: Keycloak (with a PostgreSQL backend) handles user authentication. It keeps its own
   TLS (self-signed via cert-manager) and is reached at `https://keycloak.inference-gateway.local:8543`.
 - **Gateway**: An `inference-gateway` `Gateway` custom resource with `spec.auth.oidc` enabled. The operator
-  emits `AUTH_ENABLED`, `AUTH_OIDC_ISSUER`, `AUTH_OIDC_CLIENT_ID`, `AUTH_OIDC_CLIENT_SECRET`, and - via
-  `caCertRef` - mounts Keycloak's CA and sets `SSL_CERT_FILE` so OIDC discovery over HTTPS is trusted.
+  emits `AUTH_ENABLED`, `AUTH_OIDC_ISSUER`, `AUTH_OIDC_CLIENT_ID`, and - via `caCertRef` - mounts Keycloak's
+  CA and sets `SSL_CERT_FILE` so OIDC discovery over HTTPS is trusted. The gateway never needs the client
+  secret; it only verifies tokens against the issuer's public keys.
 - **In-cluster issuer resolution**: A CoreDNS rewrite points `keycloak.inference-gateway.local` at the
   in-cluster Keycloak Service, so the gateway reaches the same issuer hostname Keycloak stamps into tokens.
 - **Routing**: The gateway is exposed over HTTPS via the Kubernetes Gateway API (Envoy Gateway), with the
@@ -83,8 +84,8 @@ This example demonstrates Keycloak (OIDC) authentication with the Inference Gate
 
 - **Keycloak**: edit the YAMLs in `keycloak/` (instance, realm import, DB secret) and the issuer in cert
   settings.
-- **Gateway auth**: configured in `gateway.yaml` under `spec.auth.oidc` (issuer URL, client ID, client
-  secret reference, and the CA certificate reference).
+- **Gateway auth**: configured in `gateway.yaml` under `spec.auth.oidc` (issuer URL, client ID, and the CA
+  certificate reference).
 
 ## Cleanup
 

--- a/examples/kubernetes/authentication/gateway.yaml
+++ b/examples/kubernetes/authentication/gateway.yaml
@@ -31,18 +31,16 @@ spec:
       write: '60s'
       idle: '300s'
   # OIDC authentication against Keycloak. The operator emits AUTH_ENABLED,
-  # AUTH_OIDC_ISSUER, AUTH_OIDC_CLIENT_ID and AUTH_OIDC_CLIENT_SECRET, and - via
-  # caCertRef - mounts Keycloak's self-signed CA and points SSL_CERT_FILE at it so
-  # OIDC discovery over HTTPS is trusted.
+  # AUTH_OIDC_ISSUER and AUTH_OIDC_CLIENT_ID, and - via caCertRef - mounts
+  # Keycloak's self-signed CA and points SSL_CERT_FILE at it so OIDC discovery
+  # over HTTPS is trusted. No client secret is needed: the gateway only verifies
+  # tokens against the issuer's public keys.
   auth:
     enabled: true
     provider: oidc
     oidc:
       issuerUrl: 'https://keycloak.inference-gateway.local:8543/realms/inference-gateway-realm'
       clientId: inference-gateway-client
-      clientSecretRef:
-        name: inference-gateway-auth
-        key: AUTH_OIDC_CLIENT_SECRET
       caCertRef:
         name: keycloak-ca
         key: ca.crt
@@ -81,17 +79,6 @@ spec:
     httpRoute:
       hostnames:
         - api.inference-gateway.local
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: inference-gateway-auth
-  namespace: inference-gateway
-type: Opaque
-stringData:
-  # Must match the client secret of the inference-gateway-client in the realm
-  # (see keycloak/job-import-realm.yaml).
-  AUTH_OIDC_CLIENT_SECRET: very-secret
 ---
 apiVersion: v1
 kind: Secret

--- a/hack/gateway.yaml
+++ b/hack/gateway.yaml
@@ -28,7 +28,6 @@ metadata:
   namespace: inference-gateway
 type: Opaque
 stringData:
-  AUTH_OIDC_CLIENT_SECRET: very-secret
   OPENAI_API_KEY: ''
   ANTHROPIC_API_KEY: ''
 ---

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4161,11 +4161,6 @@ components:
                   default: 'inference-gateway-client'
                   description: 'OIDC client ID'
                   secret: true
-                - name: auth_oidc_client_secret
-                  env: 'AUTH_OIDC_CLIENT_SECRET'
-                  type: string
-                  description: 'OIDC client secret'
-                  secret: true
           - guardrails:
               title: 'Guardrails'
               settings:


### PR DESCRIPTION
## Summary

`AUTH_OIDC_CLIENT_SECRET` (`AuthConfig.OidcClientSecret`) was never read. The auth middleware builds a go-oidc `IDTokenVerifier` from the issuer's discovery document and JWKS; verifying a JWT needs the issuer and the expected audience, not a client secret. A secret would only matter for RFC 7662 introspection or a token exchange, neither of which the gateway performs.

This removes the setting at the source (`openapi.yaml`), regenerates the derived files, and drops it from the hand-written examples. Deployments that still export the variable keep working: go-envconfig ignores unknown variables.

Closes #640

## Changes

- `openapi.yaml`: remove the `auth_oidc_client_secret` setting from the auth `x-config` block
- `task generate`: `config/config.go`, `Configurations.md`, all seven `examples/docker-compose/*/.env.example`
- `config/config_test.go`: drop the `OidcClientSecret` expectation
- `examples/docker-compose/authentication/{docker-compose.yml,README.md}`: no longer set the variable; the Keycloak client secret row stays because `get-token.sh` still authenticates to Keycloak with it
- `examples/kubernetes/authentication/{gateway.yaml,README.md}`: drop `clientSecretRef` (optional in the operator CRD) and the `inference-gateway-auth` Secret
- `hack/gateway.yaml`: drop the key from the Secret

## Verification

- `grep -rn "OIDC_CLIENT_SECRET\|OidcClientSecret" .` returns nothing
- `task generate` leaves a clean tree
- `task test` (race detector) and `task lint` pass

## Follow-up

The operator still emits `AUTH_OIDC_CLIENT_SECRET` from `spec.auth.oidc.clientSecretRef`. That field is optional and harmless, but it should be deprecated in the operator repo so users are not told to provision a value the gateway never uses.
