### PR TITLE
fix(guardrails): pass decoded input to OPA so policies see input fields

### DIFF
--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -148,9 +148,6 @@ func (e *Evaluator) Eval(ctx context.Context, input *Input) (Decision, error) {
 	if err != nil {
 		return Decision{}, fmt.Errorf("guardrails: marshal input: %w", err)
 	}
-	// OPA round-trips unknown Go types through JSON, so raw bytes would reach
-	// the policy as one base64 string and leave every input.* reference
-	// undefined. Hand it the decoded document instead.
 	var inputValue any
 	if err := json.Unmarshal(inputBytes, &inputValue); err != nil {
 		return Decision{}, fmt.Errorf("guardrails: decode input: %w", err)

--- a/internal/guardrails/guardrails.go
+++ b/internal/guardrails/guardrails.go
@@ -148,8 +148,15 @@ func (e *Evaluator) Eval(ctx context.Context, input *Input) (Decision, error) {
 	if err != nil {
 		return Decision{}, fmt.Errorf("guardrails: marshal input: %w", err)
 	}
+	// OPA round-trips unknown Go types through JSON, so raw bytes would reach
+	// the policy as one base64 string and leave every input.* reference
+	// undefined. Hand it the decoded document instead.
+	var inputValue any
+	if err := json.Unmarshal(inputBytes, &inputValue); err != nil {
+		return Decision{}, fmt.Errorf("guardrails: decode input: %w", err)
+	}
 
-	results, err := e.query.Eval(ctx, rego.EvalInput(inputBytes))
+	results, err := e.query.Eval(ctx, rego.EvalInput(inputValue))
 	if err != nil {
 		return Decision{}, fmt.Errorf("guardrails: eval: %w", err)
 	}

--- a/tests/middlewares/guardrails_test.go
+++ b/tests/middlewares/guardrails_test.go
@@ -333,3 +333,34 @@ func TestGuardrailsMiddleware_NonStreamingPostCall(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Hello! How can I help you?", content)
 }
+
+// The shipped authz.rego restricts openai/gpt-4o to the ml-eng group. It only
+// works if OPA sees the decoded input document, so this pins that path.
+func TestGuardrailsMiddleware_ExamplePolicyBlocks(t *testing.T) {
+	evaluator, err := guardrails.NewEvaluator(context.Background(), "../../examples/docker-compose/guardrails/policies")
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		identity map[string]any
+		want     string
+	}{
+		{name: "Member of ml-eng", identity: map[string]any{"groups": []any{"ml-eng"}}, want: guardrails.ActionAllow},
+		{name: "Authenticated outside ml-eng", identity: map[string]any{"groups": []any{"sales"}}, want: guardrails.ActionBlock},
+		{name: "Unauthenticated", identity: nil, want: guardrails.ActionAllow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dec, err := evaluator.Eval(context.Background(), &guardrails.Input{
+				Method:   "POST",
+				Path:     "/v1/chat/completions",
+				Phase:    guardrails.PhasePreCall,
+				Request:  &guardrails.Req{Body: `{"model":"openai/gpt-4o","messages":[]}`, Model: "openai/gpt-4o"},
+				Identity: tt.identity,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, dec.Action)
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #645. Found while writing a policy for the cloud identity-provider examples that follow in #646.

## Bug

`Evaluator.Eval` in `internal/guardrails/guardrails.go` marshals the input to JSON and passes the `[]byte` to `rego.EvalInput`. OPA converts unfamiliar Go types by round-tripping them through JSON, and Go marshals `[]byte` as a base64 string. Every policy therefore received `input` as one opaque string: `input.request`, `input.identity` and `input.phase` were always undefined, so each rule fell through to its default.

In practice, file-based Rego policies never blocked anything. The shipped `examples/docker-compose/guardrails/policies/authz.rego`, which restricts `openai/gpt-4o` to the `ml-eng` group, allowed every caller. The existing compile test only asserted the allow path, so this went unnoticed. The regex detectors and the external guardrail client are unaffected.

Reproduction with OPA directly:

```go
raw, _ := json.Marshal(map[string]any{"identity": map[string]any{"email": "bad@example.com"}})
q.Eval(ctx, rego.EvalInput(raw))     // allow
q.Eval(ctx, rego.EvalInput(decoded)) // block
```

## Fix

Unmarshal the marshalled document into an `any` and pass that. Three lines plus a comment.

## Test

`TestGuardrailsMiddleware_ExamplePolicyBlocks` runs the shipped example policies against a member of `ml-eng` (allow), an authenticated caller outside it (block) and an unauthenticated request (allow). The block case fails without the fix.
