### PR TITLE
docs(examples): use spec.auth.oidc.audiences in kubernetes auth examples

### DIFF
--- a/examples/kubernetes/auth-cognito/Taskfile.yaml
+++ b/examples/kubernetes/auth-cognito/Taskfile.yaml
@@ -10,8 +10,8 @@ includes:
     taskfile: ../basic/Taskfile.yaml
     dir: ../basic
     vars:
-      # Needs an operator release that wires the OIDC issuer and client ID.
-      OPERATOR_VERSION: v0.24.3
+      # Needs an operator release that supports spec.auth.oidc.audiences.
+      OPERATOR_VERSION: v0.25.0
 
 tasks:
   deploy-infrastructure:

--- a/examples/kubernetes/auth-cognito/gateway.yaml
+++ b/examples/kubernetes/auth-cognito/gateway.yaml
@@ -27,15 +27,15 @@ spec:
       write: '60s'
       idle: '300s'
   # Cognito is a public HTTPS issuer, so no CA bundle or DNS rewrite is needed.
-  # The operator maps clientId to AUTH_OIDC_CLIENT_ID, which the gateway uses
-  # as the expected audience; Cognito machine tokens carry no aud, so the
-  # gateway checks their client_id claim against it.
+  # audiences is rendered to AUTH_OIDC_AUDIENCE; Cognito machine tokens carry
+  # no aud, so the gateway checks their client_id claim against it.
   auth:
     enabled: true
     provider: oidc
     oidc:
       issuerUrl: 'https://cognito-idp.${AWS_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}'
-      clientId: '${COGNITO_CLIENT_ID}'
+      audiences:
+        - '${COGNITO_CLIENT_ID}'
   providers:
     - name: OpenAI
       enabled: true

--- a/examples/kubernetes/auth-entra/Taskfile.yaml
+++ b/examples/kubernetes/auth-entra/Taskfile.yaml
@@ -10,8 +10,8 @@ includes:
     taskfile: ../basic/Taskfile.yaml
     dir: ../basic
     vars:
-      # Needs an operator release that wires the OIDC issuer and client ID.
-      OPERATOR_VERSION: v0.24.3
+      # Needs an operator release that supports spec.auth.oidc.audiences.
+      OPERATOR_VERSION: v0.25.0
 
 tasks:
   deploy-infrastructure:

--- a/examples/kubernetes/auth-entra/gateway.yaml
+++ b/examples/kubernetes/auth-entra/gateway.yaml
@@ -27,15 +27,16 @@ spec:
       write: '60s'
       idle: '300s'
   # Entra ID is a public HTTPS issuer, so unlike the Keycloak example no CA
-  # bundle or DNS rewrite is needed. The operator maps clientId to
-  # AUTH_OIDC_CLIENT_ID, which the gateway uses as the expected token audience:
-  # the API registration's client ID for v2 tokens.
+  # bundle or DNS rewrite is needed. audiences is rendered to
+  # AUTH_OIDC_AUDIENCE; v2 access tokens put the API registration's client ID
+  # in aud.
   auth:
     enabled: true
     provider: oidc
     oidc:
       issuerUrl: 'https://login.microsoftonline.com/${AZURE_TENANT_ID}/v2.0'
-      clientId: '${AZURE_API_APP_ID}'
+      audiences:
+        - '${AZURE_API_APP_ID}'
   providers:
     - name: OpenAI
       enabled: true

--- a/examples/kubernetes/auth-gcp/Taskfile.yaml
+++ b/examples/kubernetes/auth-gcp/Taskfile.yaml
@@ -11,8 +11,8 @@ includes:
     taskfile: ../basic/Taskfile.yaml
     dir: ../basic
     vars:
-      # Needs an operator release that wires the OIDC issuer and client ID.
-      OPERATOR_VERSION: v0.24.3
+      # Needs an operator release that supports spec.auth.oidc.audiences.
+      OPERATOR_VERSION: v0.25.0
 
 tasks:
   deploy-infrastructure:

--- a/examples/kubernetes/auth-gcp/gateway.yaml
+++ b/examples/kubernetes/auth-gcp/gateway.yaml
@@ -19,16 +19,17 @@ spec:
       read: '60s'
       write: '60s'
       idle: '300s'
-  # Google's issuer is shared by every Google account. The operator maps
-  # clientId to AUTH_OIDC_CLIENT_ID, which the gateway uses as the expected
-  # token audience: the URL tokens are minted for. The guardrails policy below
-  # then restricts callers to the allowed service account.
+  # Google's issuer is shared by every Google account. audiences is rendered
+  # to AUTH_OIDC_AUDIENCE: any URL you choose, tokens must be minted for
+  # exactly this audience. The guardrails policy below then restricts callers
+  # to the allowed service account.
   auth:
     enabled: true
     provider: oidc
     oidc:
       issuerUrl: 'https://accounts.google.com'
-      clientId: '${GATEWAY_AUDIENCE}'
+      audiences:
+        - '${GATEWAY_AUDIENCE}'
   guardrails:
     enabled: true
     failMode: closed

--- a/examples/kubernetes/auth-keycloak/README.md
+++ b/examples/kubernetes/auth-keycloak/README.md
@@ -7,8 +7,8 @@ This example demonstrates Keycloak (OIDC) authentication with the Inference Gate
 > in `gateway.yaml`, including `caCertRef` to trust Keycloak's self-signed CA.
 >
 > **Operator version:** This example requires an operator release that wires the OIDC issuer/clientId env
-> vars and supports `spec.auth.oidc.caCertRef` (pinned as `OPERATOR_VERSION` in `Taskfile.yaml`). Earlier
-> releases only set `AUTH_ENABLED`, so OIDC will not function.
+> vars and supports `spec.auth.oidc.caCertRef` and `audiences` (pinned as `OPERATOR_VERSION` in
+> `Taskfile.yaml`). Earlier releases only set `AUTH_ENABLED`, so OIDC will not function.
 
 ## Table of Contents
 
@@ -87,8 +87,9 @@ This example demonstrates Keycloak (OIDC) authentication with the Inference Gate
   settings.
 - **Gateway auth**: configured in `gateway.yaml` under `spec.auth.oidc` (issuer URL, client ID, and the CA
   certificate reference). The gateway checks that the token's `aud` contains the client ID, which the realm's
-  audience mapper adds to access tokens. `AUTH_OIDC_AUDIENCE` accepts a comma-separated list instead (for
-  example an API identifier); the operator does not expose it yet.
+  audience mapper adds to access tokens. For other `aud` values (for example an API identifier) set
+  `spec.auth.oidc.audiences`, which the operator renders to `AUTH_OIDC_AUDIENCE`; see the Entra ID, GCP and
+  Cognito examples next door.
 
 ## Cleanup
 

--- a/examples/kubernetes/auth-keycloak/Taskfile.yaml
+++ b/examples/kubernetes/auth-keycloak/Taskfile.yaml
@@ -8,8 +8,8 @@ vars:
   POSTGRES_VERSION: 16.6.2
   KEYCLOAK_VERSION: 26.2.4
   # Requires an operator release that wires the OIDC issuer/clientId env vars and
-  # supports spec.auth.oidc.caCertRef (see the operator repo).
-  OPERATOR_VERSION: v0.24.3
+  # supports spec.auth.oidc.caCertRef and audiences (see the operator repo).
+  OPERATOR_VERSION: v0.25.0
 
 tasks:
   deploy-infrastructure:


### PR DESCRIPTION
## Why

inference-gateway/operator#217 (released in operator v0.25.0) added `spec.auth.oidc.audiences`, rendered to `AUTH_OIDC_AUDIENCE`. Its cross-repo notes named the Kubernetes auth examples here as follow-up. All four still pinned operator v0.24.3 and passed the audience through `clientId` as a workaround.

## Changes

- `auth-entra`, `auth-gcp`, `auth-cognito` `gateway.yaml`: replace `clientId` with `audiences`, mirroring the docker-compose siblings that already set `AUTH_OIDC_AUDIENCE`. `clientId` is dropped because the gateway ignores `AUTH_OIDC_CLIENT_ID` once an audience is configured (`api/middlewares/auth.go`); Cognito tokens without `aud` are still matched by their `client_id` claim against the same list.
- All four `Taskfile.yaml`: bump `OPERATOR_VERSION` to v0.25.0.
- `auth-keycloak/README.md`: drop the "operator does not expose it yet" note and point at `spec.auth.oidc.audiences`. Its manifest is unchanged since the client ID is the correct `aud` for Keycloak.

## Cross-repo

- `inference-gateway/docs`: already tracked by inference-gateway/docs#665. No new docs ticket: examples-only change.
- `inference-gateway/operator`: nothing further.

## Verification

- Each manifest rendered through `envsubst` parses and yields the expected `audiences` list; the v0.25.0 `crds.yaml` contains the field.
- `prettier --check` and `markdownlint` pass on the changed files.
- Not exercised against a live cluster.
